### PR TITLE
UNOMI-229: Added Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,37 @@
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+FROM openjdk:8-jre
+
+# Unomi environment variables
+ENV KARAF_INSTALL_PATH /opt
+ENV KARAF_HOME $KARAF_INSTALL_PATH/apache-unomi
+ENV PATH $PATH:$KARAF_HOME/bin
+ENV KARAF_OPTS "-Dunomi.autoStart=true"
+WORKDIR $KARAF_HOME
+
+RUN wget http://apache.mirrors.pair.com/incubator/unomi/1.3.0-incubating/unomi-1.3.0-incubating-bin.tar.gz
+RUN tar -xzf unomi-1.3.0-incubating-bin.tar.gz
+RUN mv unomi-1.3.0-incubating/* .
+RUN rm unomi-1.3.0-incubating-bin.tar.gz
+RUN rm -r unomi-1.3.0-incubating
+COPY ./entrypoint.sh ./entrypoint.sh
+
+EXPOSE 9443
+EXPOSE 8181
+
+CMD ["/bin/bash", "./entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,14 +1,13 @@
 # Unomi Docker Image
 
-![Docker Pulls](https://img.shields.io/docker/pulls/mikeghen/unomi.svg)
- [![](https://images.microbadger.com/badges/version/mikeghen/unomi:1.3.svg)](https://microbadger.com/images/mikeghen/unomi:1.3 "Get your own version badge on microbadger.com")
-# Running Unomi
+## Running Unomi
 Unomi requires ElasticSearch so it is recommended to run Unomi and ElasticSearch using docker-compose:
 ```
 docker-compose up
 ```
+You will need to wait while Docker builds the containers and they boot up (ES will take a minute or two). Once they are up you can check that the Unomi services are available by visiting http://localhost:8181/cxs in a web browser.
 
-# Environment variables
+## Environment variables
 
 When you start the `unomi` image, you can adjust the configuration of the Unomi instance by passing one or more environment variables on the `docker run` command line.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,16 @@
+# Unomi Docker Image
+
+![Docker Pulls](https://img.shields.io/docker/pulls/mikeghen/unomi.svg)
+ [![](https://images.microbadger.com/badges/version/mikeghen/unomi:1.3.svg)](https://microbadger.com/images/mikeghen/unomi:1.3 "Get your own version badge on microbadger.com")
+# Running Unomi
+Unomi requires ElasticSearch so it is recommended to run Unomi and ElasticSearch using docker-compose:
+```
+docker-compose up
+```
+
+# Environment variables
+
+When you start the `unomi` image, you can adjust the configuration of the Unomi instance by passing one or more environment variables on the `docker run` command line.
+
+- **`ELASTICSEARCH_HOST`** - The IP address of hostname for ElasticSearch
+- **`ELASTICSEARCH_PORT`** - The port for ElasticSearch

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,8 +15,7 @@ services:
       - "9200:9200"
 
   unomi:
-    # TODO: Replace with official image
-    image: mikeghen/unomi:1.3
+    build: .
     container_name: unomi
     environment:
       - ELASTICSEARCH_HOST=elasticsearch

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '2.2'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.3
+    volumes: # Persist ES data in seperate "esdata" volume
+      - esdata1:/usr/share/elasticsearch/data
+    environment:
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - cluster.name=contextElasticSearch
+    ports: # Expose Elasticsearch ports
+      - "9300:9300"
+      - "9200:9200"
+
+  unomi:
+    # TODO: Replace with official image
+    image: mikeghen/unomi:1.3
+    container_name: unomi
+    environment:
+      - ELASTICSEARCH_HOST=elasticsearch
+      - ELASTICSEARCH_PORT=9300
+    ports:
+      - 8181:8181
+      - 9443:9443
+    links:
+      - elasticsearch
+    depends_on:
+      - elasticsearch
+
+
+volumes: # Define seperate volume for Elasticsearch data
+  esdata1:
+    driver: local

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Wait for heathy ElasticSearch
+# next wait for ES status to turn to Green
+health_check="$(curl -fsSL "$ELASTICSEARCH_HOST:9200/_cat/health?h=status")"
+
+until ([ "$health_check" = 'yellow' ] || [ "$health_check" = 'green' ]); do
+    health_check="$(curl -fsSL "$ELASTICSEARCH_HOST:9200/_cat/health?h=status")"
+    >&2 echo "Elastic Search is unavailable - waiting"
+    sleep 1
+done
+
+sed -i "s/elasticSearchAddresses=localhost:9300/elasticSearchAddresses=${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/g" /opt/apache-unomi/etc/org.apache.unomi.persistence.elasticsearch.cfg
+$KARAF_HOME/bin/start
+$KARAF_HOME/bin/status # Call to status delays while Karaf creates karaf.log
+tail -f $KARAF_HOME/data/log/karaf.log


### PR DESCRIPTION
This pull request simplifies the Unomi evaluation process by adding a few Docker artifacts to make running Unomi locally on Docker quick and easy.

Future work should look at exposing more of the Unomi configuration to Docker. I only setup and tested changing the ES host and port. 
