### PR TITLE
[UNOMI-236] Add a profile for OWASP maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -589,6 +589,45 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>owasp</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                                <inherited>false</inherited>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <name>OWASP Dependency Check</name>
+                        </configuration>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <report>aggregate</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
     </profiles>
 
     <dependencyManagement>
@@ -1050,6 +1089,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-scm-publish-plugin</artifactId>
                     <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>5.0.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
This PR add a profile to run the **owasp** `dependency-check-maven` plugin.

Usage:

- `mvn verify -Powasp` : report generated under `target/dependency-check-report.html`
- `mvn site -Powasp` : report generated under  ̀target/site/dependency-check-report.html`

