### PR TITLE
Return Complete Rules via Rule REST Endpoint /cxs/rules

### DIFF
--- a/api/src/main/java/org/apache/unomi/api/services/RulesService.java
+++ b/api/src/main/java/org/apache/unomi/api/services/RulesService.java
@@ -27,11 +27,19 @@ import org.apache.unomi.api.rules.RuleStatistics;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.List;
 
 /**
  * A service to access and operate on {@link Rule}s.
  */
 public interface RulesService {
+
+    /**
+     * Retrieves all known action types.
+     *
+     * @return all known action types
+     */
+    List<Rule> getAllRules();
 
     /**
      * Retrieves the metadata for all known rules.

--- a/pom.xml
+++ b/pom.xml
@@ -937,6 +937,13 @@
                 <version>2.3.1.Final</version>
             </dependency>
 
+            <!-- added by JK -->
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.1</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -937,13 +937,6 @@
                 <version>2.3.1.Final</version>
             </dependency>
 
-            <!-- added by JK -->
-            <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>2.3.1</version>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 

--- a/rest/src/main/java/org/apache/unomi/rest/RulesServiceEndPoint.java
+++ b/rest/src/main/java/org/apache/unomi/rest/RulesServiceEndPoint.java
@@ -33,6 +33,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.util.Map;
 import java.util.Set;
+import java.util.List;
 
 /**
  * A JAX-RS endpoint to manage {@link Rule}s.
@@ -66,8 +67,8 @@ public class RulesServiceEndPoint {
      */
     @GET
     @Path("/")
-    public Set<Metadata> getRuleMetadatas() {
-        return rulesService.getRuleMetadatas();
+    public List<Rule> getRuleMetadatas() {
+        return rulesService.getAllRules();
     }
 
     /**

--- a/services/src/main/java/org/apache/unomi/services/services/RulesServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/services/RulesServiceImpl.java
@@ -249,7 +249,7 @@ public class RulesServiceImpl implements RulesService, EventListenerService, Syn
         allRuleStatistics.put(ruleStatistics.getItemId(), ruleStatistics);
     }
 
-    private List<Rule> getAllRules() {
+    public List<Rule> getAllRules() {
         List<Rule> allItems = persistenceService.getAllItems(Rule.class, 0, -1, "priority").getList();
         for (Rule rule : allItems) {
             ParserHelper.resolveConditionType(definitionsService, rule.getCondition());


### PR DESCRIPTION
Previously, when listing all Rules as `GET /cxs/rules`, the returned Rule objects were incomplete, modified definitions of a complete Rule object with different (and fewer) keys. Besides not being particularly RESTful, this also made it difficult to inspect specifics around Rules without querying each individually, or building a detailed query using the `matchAllCondition` condition.

This update makes an existing `getAllRules()` method public and part of the `RuleServiceImplementation`, and returns the entire Rule definition as is expected and equivalent to the result of returning a single Rule definition.

(First PR here, please feel free to correct, modify, or let me know of any PR requirements!)