### PR TITLE
Fix for Jira UNOMI-238

### DIFF
--- a/services/src/main/java/org/apache/unomi/services/services/ProfileServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/services/ProfileServiceImpl.java
@@ -997,6 +997,9 @@ public class ProfileServiceImpl implements ProfileService, SynchronousBundleList
     private boolean merge(Map<String, Object> target, Map<String, Object> object) {
         boolean changed = false;
         for (Map.Entry<String, Object> newEntry : object.entrySet()) {
+
+            String packageName = newEntry.getValue().getClass().getPackage().getName();
+
             if (newEntry.getValue() != null) {
                 if (newEntry.getValue() instanceof Collection) {
                     target.put(newEntry.getKey(), newEntry.getValue());
@@ -1009,7 +1012,8 @@ public class ProfileServiceImpl implements ProfileService, SynchronousBundleList
                     } else {
                         changed |= merge(currentMap, (Map) newEntry.getValue());
                     }
-                } else if (newEntry.getValue().getClass().getPackage().getName().equals("java.lang")) {
+                } else if (StringUtils.equals(packageName, "java.lang")
+                        || StringUtils.equals(packageName, "org.apache.unomi.api")) {
                     if (newEntry.getValue() != null && !newEntry.getValue().equals(target.get(newEntry.getKey()))) {
                         target.put(newEntry.getKey(), newEntry.getValue());
                         changed = true;

--- a/services/src/main/java/org/apache/unomi/services/services/ProfileServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/services/ProfileServiceImpl.java
@@ -997,10 +997,8 @@ public class ProfileServiceImpl implements ProfileService, SynchronousBundleList
     private boolean merge(Map<String, Object> target, Map<String, Object> object) {
         boolean changed = false;
         for (Map.Entry<String, Object> newEntry : object.entrySet()) {
-
-            String packageName = newEntry.getValue().getClass().getPackage().getName();
-
             if (newEntry.getValue() != null) {
+                String packageName = newEntry.getValue().getClass().getPackage().getName();
                 if (newEntry.getValue() instanceof Collection) {
                     target.put(newEntry.getKey(), newEntry.getValue());
                     changed = true;


### PR DESCRIPTION
Hi,
I've added a small fix for the Jira UNOMI-238.
I declared a new variable on line 1001 because I wasn't able to use `StringUtils. equalsAny` which was introduced with `StringUtils` version 3.5 ([source](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/StringUtils.html#equalsAny-java.lang.CharSequence-java.lang.CharSequence...-)).

Best regards
Michele