### PR TITLE
UNOMI-250 Refactoring services into seperate Java packages

### DIFF
--- a/services/src/main/java/org/apache/unomi/services/impl/AbstractServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/AbstractServiceImpl.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl;
 
 import org.apache.unomi.api.Metadata;
 import org.apache.unomi.api.MetadataItem;
@@ -32,9 +32,9 @@ import java.util.List;
  */
 public abstract class AbstractServiceImpl {
 
-    PersistenceService persistenceService;
+    protected PersistenceService persistenceService;
 
-    DefinitionsService definitionsService;
+    protected DefinitionsService definitionsService;
 
     public void setPersistenceService(PersistenceService persistenceService) {
         this.persistenceService = persistenceService;
@@ -44,7 +44,7 @@ public abstract class AbstractServiceImpl {
         this.definitionsService = definitionsService;
     }
 
-    <T extends MetadataItem> PartialList<Metadata> getMetadatas(int offset, int size, String sortBy, Class<T> clazz) {
+    protected <T extends MetadataItem> PartialList<Metadata> getMetadatas(int offset, int size, String sortBy, Class<T> clazz) {
         PartialList<T> items = persistenceService.getAllItems(clazz, offset, size, sortBy);
         List<Metadata> details = new LinkedList<>();
         for (T definition : items.getList()) {
@@ -53,7 +53,7 @@ public abstract class AbstractServiceImpl {
         return new PartialList<>(details, items.getOffset(), items.getPageSize(), items.getTotalSize());
     }
 
-    <T extends MetadataItem> PartialList<Metadata> getMetadatas(Query query, Class<T> clazz) {
+    protected <T extends MetadataItem> PartialList<Metadata> getMetadatas(Query query, Class<T> clazz) {
         if (query.isForceRefresh()) {
             persistenceService.refresh();
         }

--- a/services/src/main/java/org/apache/unomi/services/impl/ParserHelper.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/ParserHelper.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl;
 
 import org.apache.unomi.api.PropertyType;
 import org.apache.unomi.api.ValueType;
@@ -31,6 +31,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * Helper class to resolve condition, action and values types when loading definitions from JSON files
+ */
 public class ParserHelper {
 
     private static final Logger logger = LoggerFactory.getLogger(ParserHelper.class);

--- a/services/src/main/java/org/apache/unomi/services/impl/cluster/ClusterServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/cluster/ClusterServiceImpl.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.cluster;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.karaf.cellar.config.ClusterConfigurationEvent;

--- a/services/src/main/java/org/apache/unomi/services/impl/cluster/ClusterSystemStatisticsEvent.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/cluster/ClusterSystemStatisticsEvent.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.cluster;
 
 import org.apache.karaf.cellar.core.event.Event;
 

--- a/services/src/main/java/org/apache/unomi/services/impl/cluster/ClusterSystemStatisticsEventHandler.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/cluster/ClusterSystemStatisticsEventHandler.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.cluster;
 
 import org.apache.karaf.cellar.config.Constants;
 import org.apache.karaf.cellar.core.CellarSupport;

--- a/services/src/main/java/org/apache/unomi/services/impl/configsharing/ConfigSharingServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/configsharing/ConfigSharingServiceImpl.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.configsharing;
 
 import org.apache.unomi.api.services.ConfigSharingService;
 import org.osgi.framework.*;

--- a/services/src/main/java/org/apache/unomi/services/impl/definitions/DefinitionsServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/definitions/DefinitionsServiceImpl.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.definitions;
 
 import org.apache.unomi.api.PluginType;
 import org.apache.unomi.api.PropertyMergeStrategyType;
@@ -27,6 +27,7 @@ import org.apache.unomi.api.services.DefinitionsService;
 import org.apache.unomi.api.services.SchedulerService;
 import org.apache.unomi.persistence.spi.CustomObjectMapper;
 import org.apache.unomi.persistence.spi.PersistenceService;
+import org.apache.unomi.services.impl.ParserHelper;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;

--- a/services/src/main/java/org/apache/unomi/services/impl/events/EventServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/events/EventServiceImpl.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.events;
 
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
@@ -31,6 +31,7 @@ import org.apache.unomi.api.services.EventListenerService;
 import org.apache.unomi.api.services.EventService;
 import org.apache.unomi.persistence.spi.PersistenceService;
 import org.apache.unomi.persistence.spi.aggregate.TermsAggregate;
+import org.apache.unomi.services.impl.ParserHelper;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;

--- a/services/src/main/java/org/apache/unomi/services/impl/events/ThirdPartyServer.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/events/ThirdPartyServer.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.events;
 
 import inet.ipaddr.IPAddress;
 

--- a/services/src/main/java/org/apache/unomi/services/impl/goals/GoalsServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/goals/GoalsServiceImpl.java
@@ -15,9 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.goals;
 
-import org.apache.unomi.api.*;
+import org.apache.unomi.api.Metadata;
+import org.apache.unomi.api.PartialList;
+import org.apache.unomi.api.Profile;
+import org.apache.unomi.api.Session;
 import org.apache.unomi.api.actions.Action;
 import org.apache.unomi.api.campaigns.Campaign;
 import org.apache.unomi.api.campaigns.CampaignDetail;
@@ -34,6 +37,7 @@ import org.apache.unomi.api.services.RulesService;
 import org.apache.unomi.persistence.spi.CustomObjectMapper;
 import org.apache.unomi.persistence.spi.PersistenceService;
 import org.apache.unomi.persistence.spi.aggregate.*;
+import org.apache.unomi.services.impl.ParserHelper;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;

--- a/services/src/main/java/org/apache/unomi/services/impl/lists/UserListServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/lists/UserListServiceImpl.java
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.lists;
 
 import org.apache.unomi.api.Metadata;
 import org.apache.unomi.api.PartialList;
 import org.apache.unomi.api.lists.UserList;
 import org.apache.unomi.api.services.UserListService;
+import org.apache.unomi.services.impl.AbstractServiceImpl;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
 import org.osgi.framework.SynchronousBundleListener;

--- a/services/src/main/java/org/apache/unomi/services/impl/patches/PatchServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/patches/PatchServiceImpl.java
@@ -14,12 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.patches;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jsonpatch.JsonPatch;
 import com.github.fge.jsonpatch.JsonPatchException;
-import org.apache.unomi.api.*;
+import org.apache.unomi.api.Item;
+import org.apache.unomi.api.Patch;
 import org.apache.unomi.api.services.PatchService;
 import org.apache.unomi.persistence.spi.CustomObjectMapper;
 import org.apache.unomi.persistence.spi.PersistenceService;

--- a/services/src/main/java/org/apache/unomi/services/impl/personalization/PersonalizationServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/personalization/PersonalizationServiceImpl.java
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.personalization;
 
+import org.apache.unomi.api.PersonalizationStrategy;
 import org.apache.unomi.api.Profile;
 import org.apache.unomi.api.Session;
-import org.apache.unomi.api.PersonalizationStrategy;
 import org.apache.unomi.api.conditions.Condition;
 import org.apache.unomi.api.services.PersonalizationService;
 import org.apache.unomi.api.services.ProfileService;

--- a/services/src/main/java/org/apache/unomi/services/impl/profiles/ProfileServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/profiles/ProfileServiceImpl.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.profiles;
 
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.PropertyUtils;
@@ -32,6 +32,7 @@ import org.apache.unomi.api.services.SegmentService;
 import org.apache.unomi.persistence.spi.CustomObjectMapper;
 import org.apache.unomi.persistence.spi.PersistenceService;
 import org.apache.unomi.persistence.spi.PropertyHelper;
+import org.apache.unomi.services.impl.ParserHelper;
 import org.osgi.framework.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/services/src/main/java/org/apache/unomi/services/impl/queries/QueryServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/queries/QueryServiceImpl.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.queries;
 
 import org.apache.unomi.api.conditions.Condition;
 import org.apache.unomi.api.query.AggregateQuery;
@@ -23,6 +23,7 @@ import org.apache.unomi.api.services.DefinitionsService;
 import org.apache.unomi.api.services.QueryService;
 import org.apache.unomi.persistence.spi.PersistenceService;
 import org.apache.unomi.persistence.spi.aggregate.*;
+import org.apache.unomi.services.impl.ParserHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/services/src/main/java/org/apache/unomi/services/impl/rules/RulesServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/rules/RulesServiceImpl.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.rules;
 
 import org.apache.unomi.api.Event;
 import org.apache.unomi.api.Item;
@@ -31,6 +31,7 @@ import org.apache.unomi.api.services.*;
 import org.apache.unomi.persistence.spi.CustomObjectMapper;
 import org.apache.unomi.persistence.spi.PersistenceService;
 import org.apache.unomi.services.actions.ActionExecutorDispatcher;
+import org.apache.unomi.services.impl.ParserHelper;
 import org.osgi.framework.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/services/src/main/java/org/apache/unomi/services/impl/scheduler/SchedulerServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/scheduler/SchedulerServiceImpl.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.scheduler;
 
 import org.apache.unomi.api.services.SchedulerService;
 import org.slf4j.Logger;

--- a/services/src/main/java/org/apache/unomi/services/impl/segments/SegmentServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/segments/SegmentServiceImpl.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.unomi.services.services;
+package org.apache.unomi.services.impl.segments;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.unomi.api.Event;
@@ -34,6 +34,8 @@ import org.apache.unomi.api.services.SchedulerService;
 import org.apache.unomi.api.services.SegmentService;
 import org.apache.unomi.persistence.spi.CustomObjectMapper;
 import org.apache.unomi.persistence.spi.aggregate.TermsAggregate;
+import org.apache.unomi.services.impl.AbstractServiceImpl;
+import org.apache.unomi.services.impl.ParserHelper;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;

--- a/services/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/services/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -68,7 +68,7 @@
 
     <!-- Service definitions -->
 
-    <bean id="schedulerServiceImpl" class="org.apache.unomi.services.services.SchedulerServiceImpl"
+    <bean id="schedulerServiceImpl" class="org.apache.unomi.services.impl.scheduler.SchedulerServiceImpl"
           init-method="postConstruct" destroy-method="preDestroy"/>
     <service id="schedulerService" ref="schedulerServiceImpl">
         <interfaces>
@@ -76,7 +76,7 @@
         </interfaces>
     </service>
 
-    <bean id="definitionsServiceImpl" class="org.apache.unomi.services.services.DefinitionsServiceImpl"
+    <bean id="definitionsServiceImpl" class="org.apache.unomi.services.impl.definitions.DefinitionsServiceImpl"
           init-method="postConstruct" destroy-method="preDestroy">
         <property name="persistenceService" ref="persistenceService"/>
         <property name="bundleContext" ref="blueprintBundleContext"/>
@@ -90,7 +90,7 @@
         </interfaces>
     </service>
 
-    <bean id="eventServiceImpl" class="org.apache.unomi.services.services.EventServiceImpl"
+    <bean id="eventServiceImpl" class="org.apache.unomi.services.impl.events.EventServiceImpl"
         init-method="init" destroy-method="destroy">
         <property name="persistenceService" ref="persistenceService"/>
         <property name="definitionsService" ref="definitionsServiceImpl"/>
@@ -119,7 +119,7 @@
     </bean>
     <service id="eventService" ref="eventServiceImpl" interface="org.apache.unomi.api.services.EventService"/>
 
-    <bean id="goalsServiceImpl" class="org.apache.unomi.services.services.GoalsServiceImpl"
+    <bean id="goalsServiceImpl" class="org.apache.unomi.services.impl.goals.GoalsServiceImpl"
           init-method="postConstruct" destroy-method="preDestroy">
         <property name="persistenceService" ref="persistenceService"/>
         <property name="definitionsService" ref="definitionsServiceImpl"/>
@@ -138,7 +138,7 @@
         <property name="metricsService" ref="metricsService" />
     </bean>
 
-    <bean id="rulesServiceImpl" class="org.apache.unomi.services.services.RulesServiceImpl"
+    <bean id="rulesServiceImpl" class="org.apache.unomi.services.impl.rules.RulesServiceImpl"
           init-method="postConstruct" destroy-method="preDestroy">
         <property name="persistenceService" ref="persistenceService"/>
         <property name="definitionsService" ref="definitionsServiceImpl"/>
@@ -157,7 +157,7 @@
         </interfaces>
     </service>
 
-    <bean id="segmentServiceImpl" class="org.apache.unomi.services.services.SegmentServiceImpl"
+    <bean id="segmentServiceImpl" class="org.apache.unomi.services.impl.segments.SegmentServiceImpl"
           init-method="postConstruct" destroy-method="preDestroy">
         <property name="persistenceService" ref="persistenceService"/>
         <property name="definitionsService" ref="definitionsServiceImpl"/>
@@ -177,7 +177,7 @@
         </interfaces>
     </service>
 
-    <bean id="userListServiceImpl" class="org.apache.unomi.services.services.UserListServiceImpl"
+    <bean id="userListServiceImpl" class="org.apache.unomi.services.impl.lists.UserListServiceImpl"
           init-method="postConstruct" destroy-method="preDestroy">
         <property name="persistenceService" ref="persistenceService"/>
         <property name="definitionsService" ref="definitionsServiceImpl"/>
@@ -190,7 +190,7 @@
         </interfaces>
     </service>
 
-    <bean id="profileServiceImpl" class="org.apache.unomi.services.services.ProfileServiceImpl"
+    <bean id="profileServiceImpl" class="org.apache.unomi.services.impl.profiles.ProfileServiceImpl"
           init-method="postConstruct" destroy-method="preDestroy">
         <property name="persistenceService" ref="persistenceService"/>
         <property name="definitionsService" ref="definitionsServiceImpl"/>
@@ -211,14 +211,14 @@
         </interfaces>
     </service>
 
-    <bean id="queryServiceImpl" class="org.apache.unomi.services.services.QueryServiceImpl"
+    <bean id="queryServiceImpl" class="org.apache.unomi.services.impl.queries.QueryServiceImpl"
           init-method="postConstruct" destroy-method="preDestroy">
         <property name="persistenceService" ref="persistenceService"/>
         <property name="definitionsService" ref="definitionsServiceImpl"/>
     </bean>
     <service id="queryService" ref="queryServiceImpl" interface="org.apache.unomi.api.services.QueryService"/>
 
-    <bean id="clusterServiceImpl" class="org.apache.unomi.services.services.ClusterServiceImpl"
+    <bean id="clusterServiceImpl" class="org.apache.unomi.services.impl.cluster.ClusterServiceImpl"
           init-method="init" destroy-method="destroy">
         <property name="publicAddress" value="${cluster.contextserver.publicAddress}"/>
         <property name="internalAddress" value="${cluster.contextserver.internalAddress}"/>
@@ -234,13 +234,13 @@
     <service id="clusterService" ref="clusterServiceImpl" interface="org.apache.unomi.api.services.ClusterService"/>
 
 
-    <bean id="personalizationServiceImpl" class="org.apache.unomi.services.services.PersonalizationServiceImpl">
+    <bean id="personalizationServiceImpl" class="org.apache.unomi.services.impl.personalization.PersonalizationServiceImpl">
         <property name="profileService" ref="profileServiceImpl"/>
         <property name="bundleContext" ref="blueprintBundleContext"/>
     </bean>
     <service id="personalizationService" ref="personalizationServiceImpl" interface="org.apache.unomi.api.services.PersonalizationService" />
 
-    <bean id="patchServiceImpl" class="org.apache.unomi.services.services.PatchServiceImpl"
+    <bean id="patchServiceImpl" class="org.apache.unomi.services.impl.patches.PatchServiceImpl"
           init-method="postConstruct" destroy-method="preDestroy">
         <property name="persistenceService" ref="persistenceService"/>
         <property name="bundleContext" ref="blueprintBundleContext"/>
@@ -352,7 +352,7 @@
     </service>
 
 
-    <bean id="configSharingServiceImpl" class="org.apache.unomi.services.services.ConfigSharingServiceImpl" destroy-method="preDestroy">
+    <bean id="configSharingServiceImpl" class="org.apache.unomi.services.impl.configsharing.ConfigSharingServiceImpl" destroy-method="preDestroy">
         <property name="configProperties">
             <map>
                 <entry key="internalServerAddress" value="${cluster.contextserver.internalAddress}" />
@@ -369,7 +369,7 @@
     </service>
 
     <!-- Cluster System Statistics Event Handler -->
-    <bean id="clusterSystemStatisticsEventHandler" class="org.apache.unomi.services.services.ClusterSystemStatisticsEventHandler"
+    <bean id="clusterSystemStatisticsEventHandler" class="org.apache.unomi.services.impl.cluster.ClusterSystemStatisticsEventHandler"
           init-method="init" destroy-method="destroy">
         <property name="configurationAdmin" ref="osgiConfigurationAdmin"/>
         <property name="clusterManager" ref="karafCellarClusterManager"/>


### PR DESCRIPTION
Right now we have a bit of a mess in our services implementation sub-project. All the service implementations are in the package:
org.apache.unomi.services.services
I propose that we rename this package to:
org.apache.unomi.services.impl
and that each service gets its own sub-package, for example the RulesServiceImpl would be in:
org.apache.unomi.services.impl.rules
This would make it much easier to activate/deactivate logging per service implementation, because currently it is tricky to get logging activated properly unless using configuration by class. Having it by package would be a lot better.
Utility classes such as ThirdPartyService or the clustering event classes would also be moved with the service sub-package they belong to.
In terms of impact this should minimal, only people activating logs should be notified that the class location has changed.

Signed-off-by: Serge Huber <shuber@apache.org>