### PR TITLE
UNOMI-254 Add Groovy scripting support for actions

### DIFF
--- a/api/src/main/java/org/apache/unomi/api/actions/ActionDispatcher.java
+++ b/api/src/main/java/org/apache/unomi/api/actions/ActionDispatcher.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.api.actions;
+
+import org.apache.unomi.api.Event;
+import org.apache.unomi.api.services.EventService;
+
+/**
+ * This class is the base interface for action dispatcher, which provide a pluggeable way to implement classes that
+ * will dispatcher to execute actions. This may include dispatcher for scripting technologies such as Groovy or others.
+ * The ActionExecutor class is not related to this, it is only used for Java implementations of Actions, whereas
+ * ActionDispatchers may be used for other languages.
+ */
+public interface ActionDispatcher {
+
+    /**
+     * Retrieves the prefix that this dispatcher recognizes and that is used in the actionTypeId. For example to dispatch
+     * to a GroovyActionDispatcher, the prefix could be : "groovy". Then when you want to refer to a Groovy action type
+     * you could do something like this: "groovy:myGroovyAction".
+     * Prefixes MUST be globally unique. Not sanity check is done on this so please be careful!
+     * @return a string containing the unique
+     */
+    String getPrefix();
+
+    /**
+     * This method is responsible of executing the action logic, so it will probably dispatch to an underlying engine
+     * such as a scripting engine or any other type. This makes it possible for example to implement actions in Groovy
+     * or even Javascript.
+     * @param action the {@link Action} to execute
+     * @param event  the {@link Event} that triggered the action
+     * @param actionName the name of the action to execute that is after the prefix in the action type
+     * @return an integer status corresponding to what happened as defined by public constants of {@link EventService}
+     */
+    Integer execute(Action action, Event event, String actionName);
+
+}

--- a/extensions/groovy-actions/karaf-kar/pom.xml
+++ b/extensions/groovy-actions/karaf-kar/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.unomi</groupId>
+        <artifactId>unomi-groovy-actions-root</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>unomi-groovy-actions</artifactId>
+    <name>Apache Unomi :: Extensions :: Groovy Actions :: Apache Karaf Feature and KAR archive</name>
+    <description>Apache Karaf Feature and KAR archive for the Apache Unomi Context Server extension that provides the possibility to use Groovy for actions</description>
+    <packaging>kar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.unomi</groupId>
+            <artifactId>unomi-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>3.0.0-rc-1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-xml</artifactId>
+            <version>3.0.0-rc-1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.unomi</groupId>
+            <artifactId>unomi-groovy-actions-services</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.karaf.tooling</groupId>
+                    <artifactId>karaf-maven-plugin</artifactId>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <includeTransitiveDependency>false</includeTransitiveDependency>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+                <configuration>
+                    <startLevel>85</startLevel>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/groovy-actions/karaf-kar/pom.xml
+++ b/extensions/groovy-actions/karaf-kar/pom.xml
@@ -51,6 +51,16 @@
             <artifactId>unomi-groovy-actions-services</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.http-builder-ng</groupId>
+            <artifactId>http-builder-ng-core</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.12.1</version>
+        </dependency>
 
     </dependencies>
 

--- a/extensions/groovy-actions/pom.xml
+++ b/extensions/groovy-actions/pom.xml
@@ -13,33 +13,25 @@
   ~ distributed under the License is distributed on an "AS IS" BASIS,
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
-  ~ limitations under the License
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.unomi</groupId>
-        <artifactId>unomi-root</artifactId>
+        <artifactId>unomi-extensions</artifactId>
         <version>1.5.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>unomi-extensions</artifactId>
-    <name>Apache Unomi :: Extensions</name>
-    <description>Apache Unomi Context Server extensions</description>
+    <artifactId>unomi-groovy-actions-root</artifactId>
+    <name>Apache Unomi :: Extensions :: Groovy Actions</name>
+    <description>Apache Unomi Context Server extension that provides support for Groovy Actions</description>
     <packaging>pom</packaging>
 
     <modules>
-        <module>lists-extension</module>
-        <module>privacy-extension</module>
-        <module>geonames</module>
-        <module>router</module>
-        <module>salesforce-connector</module>
-        <module>unomi-mailchimp</module>
-        <module>weather-update</module>
-        <module>web-tracker</module>
-        <module>groovy-actions</module>
+        <module>services</module>
+        <module>karaf-kar</module>
     </modules>
 
 </project>

--- a/extensions/groovy-actions/services/pom.xml
+++ b/extensions/groovy-actions/services/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.unomi</groupId>
+        <artifactId>unomi-groovy-actions-root</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>unomi-groovy-actions-services</artifactId>
+    <name>Apache Unomi :: Extensions :: Groovy Actions :: Service</name>
+    <description>Service implementation for the Apache Unomi Context Server extension that provides the possibility to implement actions in Groovy</description>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.unomi</groupId>
+            <artifactId>unomi-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.unomi</groupId>
+            <artifactId>unomi-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>3.0.0-rc-1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
+                        <Import-Package>
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/groovy-actions/services/src/main/java/org/apache/unomi/services/actions/groovy/GroovyAction.java
+++ b/extensions/groovy-actions/services/src/main/java/org/apache/unomi/services/actions/groovy/GroovyAction.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.services.actions.groovy;
+
+import org.osgi.framework.BundleContext;
+
+import java.net.URL;
+
+/**
+ * This class represents a Groovy action, containing all the contextual variables needed to execute such an action.
+ * It is not designed to be used outside of the Groovy Action dispatcher.
+ */
+public class GroovyAction {
+
+    private String name;
+    private String path;
+    private URL url;
+    private BundleContext bundleContext;
+
+    public GroovyAction(URL url, BundleContext bundleContext) {
+        this.url = url;
+        this.bundleContext = bundleContext;
+        this.path = url.getPath();
+        this.name = url.getPath().substring(url.getPath().lastIndexOf('/')+1);
+        if (this.name.endsWith(".groovy")) {
+            this.name = this.name.substring(0, this.name.length() - ".groovy".length());
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    public BundleContext getBundleContext() {
+        return bundleContext;
+    }
+}

--- a/extensions/groovy-actions/services/src/main/java/org/apache/unomi/services/actions/groovy/GroovyActionDispatcher.java
+++ b/extensions/groovy-actions/services/src/main/java/org/apache/unomi/services/actions/groovy/GroovyActionDispatcher.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.services.actions.groovy;
+
+import groovy.lang.Binding;
+import groovy.util.GroovyScriptEngine;
+import org.apache.unomi.api.Event;
+import org.apache.unomi.api.actions.Action;
+import org.apache.unomi.api.actions.ActionDispatcher;
+import org.apache.unomi.metrics.MetricAdapter;
+import org.apache.unomi.metrics.MetricsService;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.SynchronousBundleListener;
+import org.osgi.framework.wiring.BundleWiring;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * An implementation of an ActionDispatcher for the Groovy language. It will use actionName and match them against
+ * groovy script file names deployed in the same directory as the action descriptors (META-INF/cxs/actions)
+ */
+public class GroovyActionDispatcher implements ActionDispatcher, SynchronousBundleListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(GroovyActionDispatcher.class.getName());
+
+    private Map<String, GroovyAction> groovyActionsByName = new ConcurrentHashMap<>();
+    private Map<BundleContext, List<GroovyAction>> groovyActionsByBundle = new ConcurrentHashMap<>();
+    private MetricsService metricsService;
+    private BundleContext bundleContext;
+
+    public void setMetricsService(MetricsService metricsService) {
+        this.metricsService = metricsService;
+    }
+
+    public void setBundleContext(BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+    }
+
+    public String getPrefix() {
+        return "groovy";
+    }
+
+    public Integer execute(Action action, Event event, String actionName) {
+        GroovyAction groovyAction = groovyActionsByName.get(actionName);
+        if (groovyAction == null) {
+            logger.warn("Couldn't find a Groovy action with name {}, action will not execute !", actionName);
+        } else {
+            try {
+                return new MetricAdapter<Integer>(metricsService, this.getClass().getName() + ".action.groovy." + actionName) {
+                    @Override
+                    public Integer execute(Object... args) throws Exception {
+                        Binding binding = new Binding();
+                        binding.setVariable("groovyAction", groovyAction);
+                        binding.setVariable("action", action);
+                        binding.setVariable("event", event);
+                        GroovyBundleResourceConnector bundleResourceConnector = new GroovyBundleResourceConnector(groovyAction.getBundleContext());
+                        GroovyScriptEngine engine = new GroovyScriptEngine(bundleResourceConnector, groovyAction.getBundleContext().getBundle().adapt(BundleWiring.class).getClassLoader());
+                        return (Integer) engine.run(groovyAction.getPath(), binding);
+                    }
+                }.runWithTimer();
+            } catch (Exception e) {
+                logger.error("Error executing Groovy action with key=" + actionName, e);
+            }
+        }
+
+        return null;
+    }
+
+    public void postConstruct() {
+        logger.debug("postConstruct {" + bundleContext.getBundle() + "}");
+
+        for (Bundle bundle : bundleContext.getBundles()) {
+            if (bundle.getBundleContext() != null && bundle.getBundleId() != bundleContext.getBundle().getBundleId()) {
+                loadGroovyActions(bundleContext);
+            }
+        }
+
+        bundleContext.addBundleListener(this);
+
+        logger.info("Groovy Action Dispatcher initialized.");
+    }
+
+    public void preDestroy() {
+        bundleContext.removeBundleListener(this);
+        logger.info("Groovy Action Dispatcher shutdown.");
+    }
+
+    private void processBundleStartup(BundleContext bundleContext) {
+        if (bundleContext == null) {
+            return;
+        }
+        loadGroovyActions(bundleContext);
+    }
+
+    private void processBundleStop(BundleContext bundleContext) {
+        if (bundleContext == null) {
+            return;
+        }
+        unloadGroovyActions(bundleContext);
+    }
+
+    public void bundleChanged(BundleEvent event) {
+        switch (event.getType()) {
+            case BundleEvent.STARTED:
+                processBundleStartup(event.getBundle().getBundleContext());
+                break;
+            case BundleEvent.STOPPING:
+                processBundleStop(event.getBundle().getBundleContext());
+                break;
+        }
+    }
+
+
+    private void addGroovyAction(BundleContext bundleContext, URL groovyActionURL) {
+        GroovyAction groovyAction = new GroovyAction(groovyActionURL, bundleContext);
+        if (groovyActionsByName.containsKey(groovyAction.getName())) {
+            logger.warn("Found an existing Groovy action with name {}. Will overwrite it!", groovyAction.getName());
+        }
+        groovyActionsByName.put(groovyAction.getName(), groovyAction);
+        List<GroovyAction> bundleGroovyActions = groovyActionsByBundle.get(bundleContext);
+        if (bundleGroovyActions == null) {
+            bundleGroovyActions = new ArrayList<>();
+        }
+        bundleGroovyActions.add(groovyAction);
+        groovyActionsByBundle.put(bundleContext, bundleGroovyActions);
+    }
+
+    private void removeGroovyActions(BundleContext bundleContext) {
+        List<GroovyAction> bundleGroovyActions = groovyActionsByBundle.get(bundleContext);
+        if (bundleGroovyActions == null) {
+            return;
+        }
+        for (GroovyAction groovyAction : bundleGroovyActions) {
+            groovyActionsByName.remove(groovyAction.getName());
+        }
+        groovyActionsByBundle.remove(bundleContext);
+    }
+
+    private void loadGroovyActions(BundleContext bundleContext) {
+        Enumeration<URL> bundleGroovyActions = bundleContext.getBundle().findEntries("META-INF/cxs/actions", "*.groovy", true);
+        if (bundleGroovyActions == null) {
+            return;
+        }
+
+        while (bundleGroovyActions.hasMoreElements()) {
+            URL groovyActionURL = bundleGroovyActions.nextElement();
+            logger.debug("Found Groovy action at " + groovyActionURL + ", loading... ");
+            addGroovyAction(bundleContext, groovyActionURL);
+        }
+    }
+
+    private void unloadGroovyActions(BundleContext bundleContext) {
+        removeGroovyActions(bundleContext);
+    }
+
+}

--- a/extensions/groovy-actions/services/src/main/java/org/apache/unomi/services/actions/groovy/GroovyBundleResourceConnector.java
+++ b/extensions/groovy-actions/services/src/main/java/org/apache/unomi/services/actions/groovy/GroovyBundleResourceConnector.java
@@ -52,7 +52,7 @@ public class GroovyBundleResourceConnector implements ResourceConnector {
         if (headers.get("Unomi-Source-Folders") != null) {
             File moduleSourceFolder = new File(headers.get("Unomi-Source-Folders"));
             if (moduleSourceFolder.exists()) {
-                File resourcesSourceFolder = new File(moduleSourceFolder, "src/main/resources/META-INF/cxs/actions");
+                File resourcesSourceFolder = new File(moduleSourceFolder, "src/main/resources");
                 if (resourcesSourceFolder.exists()) {
                     File resourceFile = new File(resourcesSourceFolder, resourcePath);
                     if (resourceFile.exists()) {

--- a/extensions/groovy-actions/services/src/main/java/org/apache/unomi/services/actions/groovy/GroovyBundleResourceConnector.java
+++ b/extensions/groovy-actions/services/src/main/java/org/apache/unomi/services/actions/groovy/GroovyBundleResourceConnector.java
@@ -19,6 +19,8 @@ package org.apache.unomi.services.actions.groovy;
 import groovy.util.ResourceConnector;
 import groovy.util.ResourceException;
 import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,6 +34,8 @@ import java.util.Dictionary;
  * code folder if the corresponding header has been set in the bundle.
  */
 public class GroovyBundleResourceConnector implements ResourceConnector {
+
+    private static final Logger logger = LoggerFactory.getLogger(GroovyBundleResourceConnector.class.getName());
 
     private BundleContext bundleContext;
 
@@ -53,10 +57,10 @@ public class GroovyBundleResourceConnector implements ResourceConnector {
                     File resourceFile = new File(resourcesSourceFolder, resourcePath);
                     if (resourceFile.exists()) {
                         try {
-                            System.out.println("Loading file " + resourcePath + " from module source !");
+                            logger.info("Loading file {} from module source !", resourcePath);
                             resourceURL = resourceFile.toURI().toURL();
                         } catch (MalformedURLException e) {
-                            e.printStackTrace();
+                            logger.warn("Error loading file "+resourcePath+" from module source code", e);
                         }
                     }
                 }

--- a/extensions/groovy-actions/services/src/main/java/org/apache/unomi/services/actions/groovy/GroovyBundleResourceConnector.java
+++ b/extensions/groovy-actions/services/src/main/java/org/apache/unomi/services/actions/groovy/GroovyBundleResourceConnector.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.services.actions.groovy;
+
+import groovy.util.ResourceConnector;
+import groovy.util.ResourceException;
+import org.osgi.framework.BundleContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Dictionary;
+
+/**
+ * This implementation of a Groovy ResourceConnector will load resources either from an OSGi bundle or from a source
+ * code folder if the corresponding header has been set in the bundle.
+ */
+public class GroovyBundleResourceConnector implements ResourceConnector {
+
+    private BundleContext bundleContext;
+
+    public GroovyBundleResourceConnector(BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+    }
+
+    @Override
+    public URLConnection getResourceConnection(String resourcePath) throws ResourceException {
+        // This piece of code should be made more generic but basically allows to work on the template from the source
+        // code without having to redeploy the bundle.
+        URL resourceURL = null;
+        Dictionary<String,String> headers = bundleContext.getBundle().getHeaders();
+        if (headers.get("Unomi-Source-Folders") != null) {
+            File moduleSourceFolder = new File(headers.get("Unomi-Source-Folders"));
+            if (moduleSourceFolder.exists()) {
+                File resourcesSourceFolder = new File(moduleSourceFolder, "src/main/resources/META-INF/cxs/actions");
+                if (resourcesSourceFolder.exists()) {
+                    File resourceFile = new File(resourcesSourceFolder, resourcePath);
+                    if (resourceFile.exists()) {
+                        try {
+                            System.out.println("Loading file " + resourcePath + " from module source !");
+                            resourceURL = resourceFile.toURI().toURL();
+                        } catch (MalformedURLException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                }
+            }
+        }
+        if (resourceURL == null) {
+            resourceURL = bundleContext.getBundle().getEntry(resourcePath);
+            if (resourceURL == null) {
+                throw new ResourceException("Could find Groovy resource " + resourcePath);
+            }
+        }
+        try {
+            return resourceURL.openConnection();
+        } catch (IOException e) {
+            throw new ResourceException(e);
+        }
+    }
+}

--- a/extensions/groovy-actions/services/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/extensions/groovy-actions/services/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <reference id="metricsService" interface="org.apache.unomi.metrics.MetricsService" />
+
+    <bean id="groovyActionDispatcherImpl" class="org.apache.unomi.services.actions.groovy.GroovyActionDispatcher"
+          init-method="postConstruct" destroy-method="preDestroy">
+        <property name="metricsService" ref="metricsService" />
+        <property name="bundleContext" ref="blueprintBundleContext"/>
+    </bean>
+    <service id="groovyActionDispatcher" ref="groovyActionDispatcherImpl">
+        <interfaces>
+            <value>org.apache.unomi.api.actions.ActionDispatcher</value>
+            <value>org.osgi.framework.SynchronousBundleListener</value>
+        </interfaces>
+    </service>
+</blueprint>

--- a/samples/groovy-actions/pom.xml
+++ b/samples/groovy-actions/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>samples</artifactId>
+        <groupId>org.apache.unomi</groupId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>test-groovy-action-sample</artifactId>
+    <name>Apache Unomi :: Samples :: Test Groovy Action</name>
+    <packaging>bundle</packaging>
+    <description>This is a simple Apache Unomi plugin that demonstrate how to define and use a Groovy Action</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.unomi</groupId>
+            <artifactId>unomi-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.http-builder-ng</groupId>
+            <artifactId>http-builder-ng-core</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.12.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>3.0.0-rc-1</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            com.opencsv;resolution:=optional,
+                            groovy.json;resolution:=optional,
+                            org.cyberneko.html.parsers;resolution:=optional,
+                            org.codehaus.groovy.runtime.callsite,
+                            org.codehaus.groovy.reflection,
+                            groovy.lang,
+                            groovy.util.slurpersupport,
+                            org.codehaus.groovy.runtime.typehandling,
+                            org.apache.unomi.api.services,
+                            *
+                        </Import-Package>
+                        <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/samples/groovy-actions/pom.xml
+++ b/samples/groovy-actions/pom.xml
@@ -40,11 +40,13 @@
             <groupId>io.github.http-builder-ng</groupId>
             <artifactId>http-builder-ng-core</artifactId>
             <version>1.0.4</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.12.1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
@@ -63,18 +65,8 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Import-Package>
-                            com.opencsv;resolution:=optional,
-                            groovy.json;resolution:=optional,
-                            org.cyberneko.html.parsers;resolution:=optional,
-                            org.codehaus.groovy.runtime.callsite,
-                            org.codehaus.groovy.reflection,
-                            groovy.lang,
-                            groovy.util.slurpersupport,
-                            org.codehaus.groovy.runtime.typehandling,
-                            org.apache.unomi.api.services,
-                            *
-                        </Import-Package>
+                        <Unomi-Source-Folders>${project.basedir}</Unomi-Source-Folders>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                         <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
                     </instructions>
                 </configuration>

--- a/samples/groovy-actions/src/main/resources/META-INF/cxs/actions/testGroovyAction.groovy
+++ b/samples/groovy-actions/src/main/resources/META-INF/cxs/actions/testGroovyAction.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.unomi.api.services.EventService
+import org.jsoup.nodes.Document
+
+import static groovyx.net.http.HttpBuilder.configure
+
+Document page = configure {
+    request.uri = 'https://mvnrepository.com/artifact/org.codehaus.groovy/groovy-all'
+}.get()
+
+String license = page.select('span.b.lic').collect { it.text() }.join(', ')
+
+println "Groovy is licensed under: ${license}"
+
+EventService.NO_CHANGE

--- a/samples/groovy-actions/src/main/resources/META-INF/cxs/actions/testGroovyAction.groovy
+++ b/samples/groovy-actions/src/main/resources/META-INF/cxs/actions/testGroovyAction.groovy
@@ -26,6 +26,11 @@ Document page = configure {
 
 String license = page.select('span.b.lic').collect { it.text() }.join(', ')
 
+println "Event type:${event.getEventType()}"
+println "Profile ID=${event.getProfile().getItemId()}"
+println "Action name=${action.actionType.metadata.name}"
+println "Action parameters=${action.parameterValues}"
+
 println "Groovy is licensed under: ${license}"
 
 EventService.NO_CHANGE

--- a/samples/groovy-actions/src/main/resources/META-INF/cxs/actions/testGroovyAction.json
+++ b/samples/groovy-actions/src/main/resources/META-INF/cxs/actions/testGroovyAction.json
@@ -1,0 +1,15 @@
+{
+  "metadata": {
+    "id": "testGroovyAction",
+    "name": "testGroovyAction",
+    "description": "A sample test Groovy Action",
+    "systemTags": [
+      "profileTags",
+      "demographic"
+    ],
+    "readOnly": true
+  },
+  "actionExecutor": "groovy:testGroovyAction",
+  "parameters": [
+  ]
+}

--- a/samples/groovy-actions/src/main/resources/META-INF/cxs/rules/testGroovyActionRule.json
+++ b/samples/groovy-actions/src/main/resources/META-INF/cxs/rules/testGroovyActionRule.json
@@ -1,0 +1,22 @@
+{
+  "metadata": {
+    "id": "testGroovyActionRule",
+    "name": "Test Groovy Action Rule",
+    "description": "A sample rule to test Groovy actions"
+  },
+  "condition": {
+      "type": "eventTypeCondition",
+      "parameterValues": {
+        "eventTypeId": "view"
+      }
+  },
+  "actions": [
+    {
+      "parameterValues": {
+        "parameter1": "eventProperty::target.properties(email)",
+        "parameter2": "parameter2value"
+      },
+      "type": "testGroovyAction"
+    }
+  ]
+}

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -29,6 +29,7 @@
     <modules>
         <module>tweet-button-plugin</module>
         <module>login-integration</module>
+        <module>groovy-actions</module>
     </modules>
 
 </project>

--- a/services/src/main/java/org/apache/unomi/services/impl/rules/RulesServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/rules/RulesServiceImpl.java
@@ -22,7 +22,6 @@ import org.apache.unomi.api.Item;
 import org.apache.unomi.api.Metadata;
 import org.apache.unomi.api.PartialList;
 import org.apache.unomi.api.actions.Action;
-import org.apache.unomi.api.actions.ActionExecutor;
 import org.apache.unomi.api.conditions.Condition;
 import org.apache.unomi.api.query.Query;
 import org.apache.unomi.api.rules.Rule;
@@ -94,18 +93,6 @@ public class RulesServiceImpl implements RulesService, EventListenerService, Syn
 
     public void setRulesStatisticsRefreshInterval(Integer rulesStatisticsRefreshInterval) {
         this.rulesStatisticsRefreshInterval = rulesStatisticsRefreshInterval;
-    }
-
-    public void bindExecutor(ServiceReference<ActionExecutor> actionExecutorServiceReference) {
-        ActionExecutor actionExecutor = bundleContext.getService(actionExecutorServiceReference);
-        actionExecutorDispatcher.addExecutor(actionExecutorServiceReference.getProperty("actionExecutorId").toString(), actionExecutor);
-    }
-
-    public void unbindExecutor(ServiceReference<ActionExecutor> actionExecutorServiceReference) {
-        if (actionExecutorServiceReference == null) {
-            return;
-        }
-        actionExecutorDispatcher.removeExecutor(actionExecutorServiceReference.getProperty("actionExecutorId").toString());
     }
 
     public void postConstruct() {

--- a/services/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/services/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -136,6 +136,7 @@
     <bean id="actionExecutorDispatcherImpl"
           class="org.apache.unomi.services.actions.ActionExecutorDispatcher">
         <property name="metricsService" ref="metricsService" />
+        <property name="bundleContext" ref="blueprintBundleContext"/>
     </bean>
 
     <bean id="rulesServiceImpl" class="org.apache.unomi.services.impl.rules.RulesServiceImpl"
@@ -272,7 +273,14 @@
                     interface="org.apache.unomi.api.actions.ActionExecutor"
                     availability="optional">
         <reference-listener
-                bind-method="bindExecutor" unbind-method="unbindExecutor" ref="rulesServiceImpl"/>
+                bind-method="bindExecutor" unbind-method="unbindExecutor" ref="actionExecutorDispatcherImpl"/>
+    </reference-list>
+
+    <reference-list id="actionDispatchers"
+                    interface="org.apache.unomi.api.actions.ActionDispatcher"
+                    availability="optional">
+        <reference-listener
+                bind-method="bindDispatcher" unbind-method="unbindDispatcher" ref="actionExecutorDispatcherImpl"/>
     </reference-list>
 
     <reference-list id="personalizationStrategies"


### PR DESCRIPTION
These changes include:
- Make the ActionExecutorDispatcher pluggeable, so that it may delegate to multiple implementations
- Provide an implementation for Groovy
- Provide an sample bundle that uses a Groovy action

Signed-off-by: Serge Huber <shuber@apache.org>