### PR TITLE
[UNOMI-256] Add device brand and device name to user agent detector

### DIFF
--- a/plugins/request/src/main/java/org/apache/unomi/plugins/request/actions/SetRemoteHostInfoAction.java
+++ b/plugins/request/src/main/java/org/apache/unomi/plugins/request/actions/SetRemoteHostInfoAction.java
@@ -166,6 +166,8 @@ public class SetRemoteHostInfoAction implements ActionExecutor {
         session.setProperty("userAgentVersion", agent.getUserAgentVersion());
         session.setProperty("userAgentNameAndVersion", agent.getUserAgentNameAndVersion());
         session.setProperty("deviceCategory", agent.getDeviceCategory());
+        session.setProperty("deviceName", agent.getDeviceName());
+        session.setProperty("deviceBrand", agent.getDeviceBrand());
 
         return EventService.SESSION_UPDATED;
     }

--- a/plugins/request/src/main/java/org/apache/unomi/plugins/request/useragent/UserAgent.java
+++ b/plugins/request/src/main/java/org/apache/unomi/plugins/request/useragent/UserAgent.java
@@ -27,6 +27,8 @@ public class UserAgent {
     private String userAgentName;
     private String userAgentVersion;
     private String deviceCategory;
+    private String deviceBrand;
+    private String deviceName;
 
     public String getOperatingSystemFamily() {
         return operatingSystemFamily;
@@ -68,6 +70,22 @@ public class UserAgent {
         this.deviceCategory = deviceCategory;
     }
 
+    public String getDeviceBrand() {
+        return deviceBrand;
+    }
+
+    public void setDeviceBrand(String deviceBrand) {
+        this.deviceBrand = deviceBrand;
+    }
+
+    public String getDeviceName() {
+        return deviceName;
+    }
+
+    public void setDeviceName(String deviceName) {
+        this.deviceCategory = deviceName;
+    }
+
     public String getUserAgentNameAndVersion() {
         return this.userAgentName + "@@" + this.userAgentVersion;
     }
@@ -81,6 +99,8 @@ public class UserAgent {
         sb.append("operatingsystem.family: " + this.getOperatingSystemFamily() + ",\n");
         sb.append("operatingsystem.name: " + this.getOperatingSystemName() + ",\n");
         sb.append("device.category: " + this.getDeviceCategory() + " \n}");
+        sb.append("device.brand: " + this.getDeviceBrand() + " \n}");
+        sb.append("device.name: " + this.getDeviceName() + " \n}");
         return super.toString();
     }
 }

--- a/plugins/request/src/main/java/org/apache/unomi/plugins/request/useragent/UserAgentDetectorServiceImpl.java
+++ b/plugins/request/src/main/java/org/apache/unomi/plugins/request/useragent/UserAgentDetectorServiceImpl.java
@@ -43,6 +43,8 @@ public class UserAgentDetectorServiceImpl {
                     .withField(nl.basjes.parse.useragent.UserAgent.AGENT_NAME)
                     .withField(nl.basjes.parse.useragent.UserAgent.AGENT_VERSION)
                     .withField(nl.basjes.parse.useragent.UserAgent.DEVICE_CLASS)
+                    .withField(nl.basjes.parse.useragent.UserAgent.DEVICE_NAME)
+                    .withField(nl.basjes.parse.useragent.UserAgent.DEVICE_BRAND)
                     .build();
             this.userAgentAnalyzer.immediateInitialization();
             this.userAgentAnalyzer.initializeMatchers();
@@ -62,6 +64,8 @@ public class UserAgentDetectorServiceImpl {
 
         UserAgent userAgent = new UserAgent();
         userAgent.setDeviceCategory(yauaaAgent.getValue(nl.basjes.parse.useragent.UserAgent.DEVICE_CLASS));
+        userAgent.setDeviceName(yauaaAgent.getValue(nl.basjes.parse.useragent.UserAgent.DEVICE_NAME));
+        userAgent.setDeviceBrand(yauaaAgent.getValue(nl.basjes.parse.useragent.UserAgent.DEVICE_BRAND));
         userAgent.setOperatingSystemFamily(yauaaAgent.getValue(nl.basjes.parse.useragent.UserAgent.OPERATING_SYSTEM_CLASS));
         userAgent.setOperatingSystemName(yauaaAgent.getValue(nl.basjes.parse.useragent.UserAgent.OPERATING_SYSTEM_NAME));
         userAgent.setUserAgentName(yauaaAgent.getValue(nl.basjes.parse.useragent.UserAgent.AGENT_NAME));


### PR DESCRIPTION
The useragent service does a great job of grabbing more information than is currently persisted, and this adds the device name (`iPhone 7`) and device brand (`Apple`) to the session information - useful for measurement and specific targeting needs.