### PR TITLE
UNOMI-225 ElasticSearch 7 fix for changes in the total hits

### DIFF
--- a/api/src/main/java/org/apache/unomi/api/PartialList.java
+++ b/api/src/main/java/org/apache/unomi/api/PartialList.java
@@ -35,8 +35,19 @@ public class PartialList<T> implements Serializable {
     private long offset;
     private long pageSize;
     private long totalSize;
+    private Relation totalSizeRelation;
     private String scrollIdentifier = null;
     private String scrollTimeValidity = null;
+
+    /**
+     * This enum exists to replicate Lucene's total hits relation in a back-end agnostic way. Basically Lucene will
+     * by default not report accurate total hit counts above a certain threshold for performance reasons. Using the
+     * relation we can understand if we are in the case of an accurate hit or not.
+     */
+    public enum Relation {
+        EQUAL,
+        GREATER_THAN_OR_EQUAL_TO
+    }
 
     /**
      * Instantiates a new PartialList.
@@ -46,6 +57,7 @@ public class PartialList<T> implements Serializable {
         offset = 0;
         pageSize = 0;
         totalSize = 0;
+        totalSizeRelation = Relation.EQUAL;
     }
 
     /**
@@ -56,11 +68,12 @@ public class PartialList<T> implements Serializable {
      * @param pageSize  the number of elements this PartialList contains
      * @param totalSize the total size of elements in the original List
      */
-    public PartialList(List<T> list, long offset, long pageSize, long totalSize) {
+    public PartialList(List<T> list, long offset, long pageSize, long totalSize, Relation totalSizeRelation) {
         this.list = list;
         this.offset = offset;
         this.pageSize = pageSize;
         this.totalSize = totalSize;
+        this.totalSizeRelation = totalSizeRelation;
     }
 
     /**
@@ -163,5 +176,18 @@ public class PartialList<T> implements Serializable {
 
     public void setScrollTimeValidity(String scrollTimeValidity) {
         this.scrollTimeValidity = scrollTimeValidity;
+    }
+
+    /**
+     * Retrieve the relation to the total site, wether it is equal to or greater than the value stored in the
+     * totalSize property.
+     * @return a Relation enum value that describes the type of total size we have in this object.
+     */
+    public Relation getTotalSizeRelation() {
+        return totalSizeRelation;
+    }
+
+    public void setTotalSizeRelation(Relation totalSizeRelation) {
+        this.totalSizeRelation = totalSizeRelation;
     }
 }

--- a/extensions/lists-extension/services/src/main/java/org/apache/unomi/services/UserListServiceImpl.java
+++ b/extensions/lists-extension/services/src/main/java/org/apache/unomi/services/UserListServiceImpl.java
@@ -51,7 +51,7 @@ public class UserListServiceImpl implements UserListService {
         for (UserList definition : userLists.getList()) {
             metadata.add(definition.getMetadata());
         }
-        return new PartialList<>(metadata, userLists.getOffset(), userLists.getPageSize(), userLists.getTotalSize());
+        return new PartialList<>(metadata, userLists.getOffset(), userLists.getPageSize(), userLists.getTotalSize(), userLists.getTotalSizeRelation());
     }
 
     public PartialList<Metadata> getListMetadatas(Query query) {
@@ -64,7 +64,7 @@ public class UserListServiceImpl implements UserListService {
         for (UserList definition : userLists.getList()) {
             metadata.add(definition.getMetadata());
         }
-        return new PartialList<>(metadata, userLists.getOffset(), userLists.getPageSize(), userLists.getTotalSize());
+        return new PartialList<>(metadata, userLists.getOffset(), userLists.getPageSize(), userLists.getTotalSize(), userLists.getTotalSizeRelation());
     }
 
     @Override

--- a/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
+++ b/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
@@ -25,7 +25,6 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.lucene.search.TotalHits;
 import org.apache.unomi.api.Item;
 import org.apache.unomi.api.PartialList;
@@ -1356,15 +1355,6 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
                 countRequest.source(searchSourceBuilder);
                 CountResponse response = client.count(countRequest, RequestOptions.DEFAULT);
                 return response.getCount();
-                /*
-                SearchRequest searchRequest = new SearchRequest(getIndexNameForQuery(itemType));
-                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-                searchSourceBuilder.query(filter);
-                searchSourceBuilder.size(0);
-                searchRequest.source(searchSourceBuilder);
-                SearchResponse response = client.search(searchRequest, RequestOptions.DEFAULT);
-                return response.getHits().getTotalHits().value;
-                 */
             }
         }.catchingExecuteInClassLoader(true);
     }

--- a/services/src/main/java/org/apache/unomi/services/impl/AbstractServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/AbstractServiceImpl.java
@@ -50,7 +50,7 @@ public abstract class AbstractServiceImpl {
         for (T definition : items.getList()) {
             details.add(definition.getMetadata());
         }
-        return new PartialList<>(details, items.getOffset(), items.getPageSize(), items.getTotalSize());
+        return new PartialList<>(details, items.getOffset(), items.getPageSize(), items.getTotalSize(), items.getTotalSizeRelation());
     }
 
     protected <T extends MetadataItem> PartialList<Metadata> getMetadatas(Query query, Class<T> clazz) {
@@ -63,6 +63,6 @@ public abstract class AbstractServiceImpl {
         for (T definition : items.getList()) {
             details.add(definition.getMetadata());
         }
-        return new PartialList<>(details, items.getOffset(), items.getPageSize(), items.getTotalSize());
+        return new PartialList<>(details, items.getOffset(), items.getPageSize(), items.getTotalSize(), items.getTotalSizeRelation());
     }
 }

--- a/services/src/main/java/org/apache/unomi/services/impl/goals/GoalsServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/goals/GoalsServiceImpl.java
@@ -360,7 +360,7 @@ public class GoalsServiceImpl implements GoalsService, SynchronousBundleListener
                 details.add(campaignDetail);
             }
         }
-        return new PartialList<>(details, campaigns.getOffset(), campaigns.getPageSize(), campaigns.getTotalSize());
+        return new PartialList<>(details, campaigns.getOffset(), campaigns.getPageSize(), campaigns.getTotalSize(), campaigns.getTotalSizeRelation());
     }
 
     public CampaignDetail getCampaignDetail(String id) {

--- a/services/src/main/java/org/apache/unomi/services/impl/rules/RulesServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/rules/RulesServiceImpl.java
@@ -314,7 +314,7 @@ public class RulesServiceImpl implements RulesService, EventListenerService, Syn
         for (Rule definition : rules.getList()) {
             descriptions.add(definition.getMetadata());
         }
-        return new PartialList<>(descriptions, rules.getOffset(), rules.getPageSize(), rules.getTotalSize());
+        return new PartialList<>(descriptions, rules.getOffset(), rules.getPageSize(), rules.getTotalSize(), rules.getTotalSizeRelation());
     }
 
     public PartialList<Rule> getRuleDetails(Query query) {
@@ -325,7 +325,7 @@ public class RulesServiceImpl implements RulesService, EventListenerService, Syn
         PartialList<Rule> rules = persistenceService.query(query.getCondition(), query.getSortby(), Rule.class, query.getOffset(), query.getLimit());
         List<Rule> details = new LinkedList<>();
         details.addAll(rules.getList());
-        return new PartialList<>(details, rules.getOffset(), rules.getPageSize(), rules.getTotalSize());
+        return new PartialList<>(details, rules.getOffset(), rules.getPageSize(), rules.getTotalSize(), rules.getTotalSizeRelation());
     }
 
     public Rule getRule(String ruleId) {

--- a/services/src/main/java/org/apache/unomi/services/impl/segments/SegmentServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/segments/SegmentServiceImpl.java
@@ -198,7 +198,7 @@ public class SegmentServiceImpl extends AbstractServiceImpl implements SegmentSe
         for (Segment definition : segments.getList()) {
             details.add(definition.getMetadata());
         }
-        return new PartialList<>(details, segments.getOffset(), segments.getPageSize(), segments.getTotalSize());
+        return new PartialList<>(details, segments.getOffset(), segments.getPageSize(), segments.getTotalSize(), segments.getTotalSizeRelation());
     }
 
     public PartialList<Metadata> getSegmentMetadatas(Query query) {


### PR DESCRIPTION
- Replaced total hits with count API requests when possible
- For aggregations replaced with a manual sum of all buckets
- Added in the PartialList the relation for the total hits so that users of the API can know if the total size is EQUAL or GREATER_THAN_OR_EQUAL_TO

Signed-off-by: Serge Huber <shuber@apache.org>