### PR TITLE
UNOMI-225 ElasticSearch 7 fix issues with mappings when migrating

### DIFF
--- a/manual/src/main/asciidoc/new-data-model.adoc
+++ b/manual/src/main/asciidoc/new-data-model.adoc
@@ -86,3 +86,6 @@ Once in the console launch the migration using the following command:
 Follow the instructions and answer the prompts. If you used the above configuration as an example you can simply use the
 default values. Note that it is also possible to change the index prefix to be different from the default `context` value
 so that you could host multiple Apache Unomi instances on the same ElasticSearch cluster.
+
+Important note: only the data that Apache Unomi manages will be migrate. If you have any other data (for example Kibana
+or ElasticSearch monitoring indices) they will not be migrated by this migration tool.

--- a/persistence-elasticsearch/core/src/main/resources/META-INF/cxs/mappings/event.json
+++ b/persistence-elasticsearch/core/src/main/resources/META-INF/cxs/mappings/event.json
@@ -20,6 +20,41 @@
   "properties": {
     "timeStamp": {
       "type": "date"
+    },
+    "target" : {
+      "properties" : {
+        "lastEventDate" : {
+          "type" : "date"
+        },
+        "profile" : {
+          "properties" : {
+            "properties" : {
+              "properties" : {
+                "birthDate" : {
+                  "type" : "date"
+                },
+                "firstVisit" : {
+                  "type" : "date"
+                },
+                "lastVisit" : {
+                  "type" : "date"
+                },
+                "notificationRefreshDate" : {
+                  "type" : "date"
+                },
+                "previousVisit" : {
+                  "type" : "date"
+                }
+              }
+            },
+            "systemProperties" : {
+              "properties" : {
+
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/persistence-elasticsearch/core/src/main/resources/META-INF/cxs/mappings/profile.json
+++ b/persistence-elasticsearch/core/src/main/resources/META-INF/cxs/mappings/profile.json
@@ -20,6 +20,9 @@
   "properties": {
     "properties": {
       "properties": {
+        "age" : {
+          "type" : "long"
+        },
         "firstVisit": {
           "type": "date"
         },

--- a/persistence-elasticsearch/core/src/main/resources/META-INF/cxs/mappings/propertyType.json
+++ b/persistence-elasticsearch/core/src/main/resources/META-INF/cxs/mappings/propertyType.json
@@ -1,4 +1,4 @@
-  {
+{
   "dynamic_templates": [
     {
       "all": {

--- a/persistence-elasticsearch/core/src/main/resources/META-INF/cxs/mappings/propertyType.json
+++ b/persistence-elasticsearch/core/src/main/resources/META-INF/cxs/mappings/propertyType.json
@@ -1,4 +1,4 @@
-{
+  {
   "dynamic_templates": [
     {
       "all": {

--- a/persistence-elasticsearch/core/src/main/resources/META-INF/cxs/mappings/session.json
+++ b/persistence-elasticsearch/core/src/main/resources/META-INF/cxs/mappings/session.json
@@ -24,6 +24,32 @@
     "lastEventDate": {
       "type": "date"
     },
+    "profile" : {
+      "properties" : {
+        "properties" : {
+          "properties" : {
+            "age" : {
+              "type" : "long"
+            },
+            "birthDate" : {
+              "type" : "date"
+            },
+            "firstDate" : {
+              "type" : "date"
+            },
+            "lastVisit" : {
+              "type" : "date"
+            },
+            "previousVisit" : {
+              "type" : "date"
+            },
+            "notificationsRefreshDate" : {
+              "type" : "date"
+            }
+          }
+        }
+      }
+    },
     "properties": {
       "properties": {
         "location": {

--- a/tools/shell-commands/src/main/java/org/apache/unomi/shell/migration/impl/MigrationTo150.java
+++ b/tools/shell-commands/src/main/java/org/apache/unomi/shell/migration/impl/MigrationTo150.java
@@ -276,8 +276,13 @@ public class MigrationTo150 implements Migration {
                 result.put(oldPropertyName, oldProperties.get(oldPropertyName));
                 continue;
             }
-            if (oldProperties.get(oldPropertyName) instanceof JSONObject && newProperties.get(oldPropertyName) instanceof JSONObject) {
-                result.put(oldPropertyName, getMergedPropertyMappings(oldProperties.getJSONObject(oldPropertyName), newProperties.getJSONObject(oldPropertyName)));
+            JSONObject oldProperty = oldProperties.getJSONObject(oldPropertyName);
+            JSONObject newProperty = newProperties.getJSONObject(oldPropertyName);
+            if (oldProperty.has("properties") && newProperty.has("properties")) {
+                // we are in the case of an object, we merge merge deeper
+                JSONObject newObjectMapping = new JSONObject(newProperty.toString());
+                newObjectMapping.put("properties", getMergedPropertyMappings(oldProperty.getJSONObject("properties"), newProperty.getJSONObject("properties")));
+                result.put(oldPropertyName, newObjectMapping);
             } else {
                 // in all other cases we copy the new value.
                 result.put(oldPropertyName, newProperties.get(oldPropertyName));

--- a/tools/shell-commands/src/main/java/org/apache/unomi/shell/migration/utils/HttpUtils.java
+++ b/tools/shell-commands/src/main/java/org/apache/unomi/shell/migration/utils/HttpUtils.java
@@ -110,6 +110,13 @@ public class HttpUtils {
         return getResponse(httpClient, url, headers, httpGet);
     }
 
+    public static String executeHeadRequest(CloseableHttpClient httpClient, String url, Map<String, String> headers) throws IOException {
+        HttpHead httpHead = new HttpHead(url);
+        httpHead.addHeader("accept", "application/json");
+
+        return getResponse(httpClient, url, headers, httpHead);
+    }
+
     public static String executeDeleteRequest(CloseableHttpClient httpClient, String url, Map<String, String> headers) throws IOException {
         HttpDelete httpDelete = new HttpDelete(url);
         httpDelete.addHeader("accept", "application/json");
@@ -153,19 +160,23 @@ public class HttpUtils {
 
         CloseableHttpResponse response = httpClient.execute(httpRequestBase);
         final int statusCode = response.getStatusLine().getStatusCode();
+        HttpEntity entity = response.getEntity();
         if (statusCode >= 400) {
-            throw new HttpRequestException("Couldn't execute " + httpRequestBase + " response: " + EntityUtils.toString(response.getEntity()), statusCode);
+            throw new HttpRequestException("Couldn't execute " + httpRequestBase + " response: " + ((entity != null) ? EntityUtils.toString(entity) : "n/a"), statusCode);
         }
 
-        HttpEntity entity = response.getEntity();
         if (logger.isDebugEnabled()) {
             if (entity !=null) {
                 entity = new BufferedHttpEntity(response.getEntity());
             }
-            logger.debug("POST request " + httpRequestBase + " executed with code: " + statusCode + " and message: " + (entity!=null?EntityUtils.toString(entity):null));
+            logger.debug("Request " + httpRequestBase + " executed with code: " + statusCode + " and message: " + (entity!=null?EntityUtils.toString(entity):null));
 
             long totalRequestTime = System.currentTimeMillis() - requestStartTime;
             logger.debug("Request to Apache Unomi url: " + url + " executed in " + totalRequestTime + "ms");
+        }
+
+        if (entity == null) {
+            return null;
         }
 
         String stringResponse = EntityUtils.toString(entity);


### PR DESCRIPTION
These corrections are based on tests with real customer datasets.

Basically the mappings are now first read from the old ElasticSearch 5
indices and then merged with the new mapping definitions included in
Apache Unomi. The result is then used to create the indices properly.
Also, the total mapping fields value is also copied from the ES 5
indices if it exists.

Finally we added an important note in the documentation to mention the
fact that the migration tool only migrates Apache Unomi data. If there is
other data (such as monitoring for example) data in the ElasticSearch 5
cluster it will not be migrated by the tool.

The tool has also been improved to make it possible to stop and continue where it left off in the case of errors, to avoid restarting a migration from scratch. Note that this is not battle-tested and should be used cautiously which is why it is not documented (yet). The way it works is that if there is an error while reindexing, it will destroy the target index and it checks for the existence of indices in the destination before reindexing, making it possible to continue an migration that was stopped previously.

Signed-off-by: Serge Huber <shuber@apache.org>