### PR TITLE
fix(elasticsearch-7): remove type from ids query, type is deprecated

### DIFF
--- a/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
+++ b/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
@@ -647,7 +647,7 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
                         return new MetricAdapter<T>(metricsService, ".loadItemWithQuery") {
                             @Override
                             public T execute(Object... args) throws Exception {
-                                PartialList<T> r = query(QueryBuilders.idsQuery(itemType).addIds(itemId), null, clazz, 0, 1, null, null);
+                                PartialList<T> r = query(QueryBuilders.idsQuery().addIds(itemId), null, clazz, 0, 1, null, null);
                                 if (r.size() > 0) {
                                     return r.get(0);
                                 }
@@ -1263,7 +1263,7 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
             String itemType = Item.getItemType(clazz);
 
             QueryBuilder builder = QueryBuilders.boolQuery()
-                    .must(QueryBuilders.idsQuery(itemType).addIds(item.getItemId()))
+                    .must(QueryBuilders.idsQuery().addIds(item.getItemId()))
                     .must(conditionESQueryBuilderDispatcher.buildFilter(query));
             return queryCount(builder, itemType) > 0;
         } finally {

--- a/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/PastEventConditionESQueryBuilder.java
+++ b/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/PastEventConditionESQueryBuilder.java
@@ -114,7 +114,7 @@ public class PastEventConditionESQueryBuilder implements ConditionESQueryBuilder
                 }
             }
 
-            return QueryBuilders.idsQuery(Profile.ITEM_TYPE).addIds(ids.toArray(new String[0]));
+            return QueryBuilders.idsQuery().addIds(ids.toArray(new String[0]));
         }
     }
 


### PR DESCRIPTION
Index type is deprecated, also now all types are _doc, this causes past event condition to not function.