### PR TITLE
fix(docker): add missing env variable

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     environment:
       - ELASTICSEARCH_HOST=elasticsearch
       - ELASTICSEARCH_PORT=9300
+      - UNOMI_ELASTICSEARCH_ADDRESSES=elasticsearch:9300
     ports:
       - 8181:8181
       - 9443:9443


### PR DESCRIPTION
UNOMI_ELASTICSEARCH_ADDRESSES was missing in unomi env variables