### PR TITLE
feat(pom.xml): bump karaf version to 4.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.jackson.core>2.9.10</version.jackson.core>
         <version.jackson.databind>2.9.10.1</version.jackson.databind>
         <version.jackson.jaxb>2.9.10</version.jackson.jaxb>
-        <version.karaf>4.2.7</version.karaf>
+        <version.karaf>4.2.8</version.karaf>
         <version.karaf.cellar>4.1.3</version.karaf.cellar>
         <version.pax.exam>4.13.1</version.pax.exam>
         <elasticsearch.version>7.4.2</elasticsearch.version>


### PR DESCRIPTION
Hey, 
Karaf references Maven Central via HTTP which stopped working today as per https://support.sonatype.com/hc/en-us/articles/360041287334-Central-501-HTTPS-Required
This is fixed in version 4.2.8
issue is attached here:
https://issues.apache.org/jira/browse/KARAF-6599

