### PR TITLE
UNOMI-281 Add lastUpdated system property to Profiles

### DIFF
--- a/api/src/main/java/org/apache/unomi/api/Profile.java
+++ b/api/src/main/java/org/apache/unomi/api/Profile.java
@@ -132,6 +132,20 @@ public class Profile extends Item {
     }
 
     /**
+     * Sets a system property, overwriting an existing one if it existed. This call will also created the system
+     * properties hash map if it didn't exist.
+     * @param key the key for the system property hash map
+     * @param value the value for the system property hash map
+     * @return the previous value object if it existing.
+     */
+    public Object setSystemProperty(String key, Object value) {
+        if (this.systemProperties == null) {
+            this.systemProperties = new LinkedHashMap<>();
+        }
+        return this.systemProperties.put(key, value);
+    }
+
+    /**
      * {@inheritDoc}
      *
      * Note that Profiles are always in the shared system scope ({@link Metadata#SYSTEM_SCOPE}).

--- a/extensions/lists-extension/services/src/main/java/org/apache/unomi/services/UserListServiceImpl.java
+++ b/extensions/lists-extension/services/src/main/java/org/apache/unomi/services/UserListServiceImpl.java
@@ -25,6 +25,7 @@ import org.apache.unomi.api.services.DefinitionsService;
 import org.apache.unomi.lists.UserList;
 import org.apache.unomi.persistence.spi.PersistenceService;
 
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -85,14 +86,15 @@ public class UserListServiceImpl implements UserListService {
         query.setParameter("propertyValue", listId);
 
         List<Profile> profiles = persistenceService.query(query, null, Profile.class);
-        Map<String, Object> profileProps;
+        Map<String, Object> profileSystemProperties;
         for (Profile p : profiles) {
-            profileProps = p.getSystemProperties();
-            if(profileProps != null && profileProps.get("lists") != null) {
-                int index = ((List) profileProps.get("lists")).indexOf(listId);
+            profileSystemProperties = p.getSystemProperties();
+            if(profileSystemProperties != null && profileSystemProperties.get("lists") != null) {
+                int index = ((List) profileSystemProperties.get("lists")).indexOf(listId);
                 if(index != -1){
-                    ((List) profileProps.get("lists")).remove(index);
-                    persistenceService.update(p.getItemId(), null, Profile.class, "systemProperties", profileProps);
+                    ((List) profileSystemProperties.get("lists")).remove(index);
+                    profileSystemProperties.put("lastUpdated", new Date());
+                    persistenceService.update(p.getItemId(), null, Profile.class, "systemProperties", profileSystemProperties);
                 }
             }
         }

--- a/extensions/privacy-extension/services/src/main/java/org/apache/unomi/privacy/internal/PrivacyServiceImpl.java
+++ b/extensions/privacy-extension/services/src/main/java/org/apache/unomi/privacy/internal/PrivacyServiceImpl.java
@@ -88,6 +88,9 @@ public class PrivacyServiceImpl implements PrivacyService {
         if (profile == null) {
             return false;
         }
+        Event profileDeletedEvent = new Event("profileDeleted", null, profile, null, null, profile, new Date());
+        profileDeletedEvent.setPersistent(true);
+        eventService.send(profileDeletedEvent);
         // we simply overwrite the existing profile with an empty one.
         Profile emptyProfile = new Profile(profileId);
         profileService.save(emptyProfile);

--- a/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
+++ b/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
@@ -785,16 +785,16 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
                                 logger.error("Failure : cause={} , message={}", failure.getCause(), failure.getMessage());
                             }
                         } else {
-                            logger.info("Update By Query has processed {} in {}.", response.getUpdated(), response.getTook().toString());
+                            logger.info("Update with query and script processed {} entries in {}.", response.getUpdated(), response.getTook().toString());
                         }
                         if (response.isTimedOut()) {
-                            logger.error("Update By Query ended with timeout!");
+                            logger.error("Update with query and script ended with timeout!");
                         }
                         if (response.getVersionConflicts() > 0) {
-                            logger.warn("Update By Query ended with {} Version Conflicts!", response.getVersionConflicts());
+                            logger.warn("Update with query and script ended with {} version conflicts!", response.getVersionConflicts());
                         }
                         if (response.getNoops() > 0) {
-                            logger.warn("Update By Query ended with {} noops!", response.getNoops());
+                            logger.warn("Update Bwith query and script ended with {} noops!", response.getNoops());
                         }
                     }
                     return true;
@@ -803,8 +803,6 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
                 } catch (ScriptException e) {
                     logger.error("Error in the update script : {}\n{}\n{}", e.getScript(), e.getDetailedMessage(), e.getScriptStack());
                     throw new Exception("Error in the update script");
-                } finally {
-                    return false;
                 }
             }
         }.catchingExecuteInClassLoader(true);
@@ -1901,9 +1899,9 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
         public T catchingExecuteInClassLoader(boolean logError, Object... args) {
             try {
                 return executeInClassLoader(timerName, args);
-            } catch (Exception e) {
+            } catch (Throwable t) {
                 if (logError) {
-                    logger.error("Error while executing in class loader", e);
+                    logger.error("Error while executing in class loader", t);
                 }
             }
             return null;

--- a/persistence-spi/src/main/java/org/apache/unomi/persistence/spi/PersistenceService.java
+++ b/persistence-spi/src/main/java/org/apache/unomi/persistence/spi/PersistenceService.java
@@ -116,7 +116,8 @@ public interface PersistenceService {
     boolean updateWithScript(String itemId, Date dateHint, Class<?> clazz, String script, Map<String, Object> scriptParams);
 
     /**
-     * Updates the items of the specified class by a query with a new property value for the specified property name based on a provided script.
+     * Updates the items of the specified class by a query with a new property value for the specified property name
+     * based on provided scripts and script parameters
      *
      * @param dateHint      a Date helping in identifying where the item is located
      * @param clazz         the Item subclass of the item to update

--- a/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/actions/MergeProfilesOnPropertyAction.java
+++ b/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/actions/MergeProfilesOnPropertyAction.java
@@ -34,9 +34,7 @@ import org.slf4j.LoggerFactory;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 public class MergeProfilesOnPropertyAction implements ActionExecutor {
     private static final Logger logger = LoggerFactory.getLogger(MergeProfilesOnPropertyAction.class.getName());
@@ -183,7 +181,11 @@ public class MergeProfilesOnPropertyAction implements ActionExecutor {
                                     // we must mark all the profiles that we merged into the master as merged with the master, and they will
                                     // be deleted upon next load
                                     profile.setMergedWith(masterProfileId);
-                                    persistenceService.update(profile.getItemId(), null, Profile.class, "mergedWith", masterProfileId);
+                                    Map<String,Object> sourceMap = new HashMap<>();
+                                    sourceMap.put("mergedWith", masterProfile);
+                                    profile.setSystemProperty("lastUpdated", new Date());
+                                    sourceMap.put("systemProperties", profile.getSystemProperties());
+                                    persistenceService.update(profile.getItemId(), null, Profile.class, sourceMap);
                                 }
                             }
                         } catch (Exception e) {

--- a/plugins/mail/src/main/java/org/apache/unomi/plugins/mail/actions/SendMailAction.java
+++ b/plugins/mail/src/main/java/org/apache/unomi/plugins/mail/actions/SendMailAction.java
@@ -33,6 +33,7 @@ import org.stringtemplate.v4.ST;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -112,7 +113,9 @@ public class SendMailAction implements ActionExecutor {
             }
         }
 
-        event.getProfile().getSystemProperties().put("notificationAck", profileNotif);
+        event.getProfile().setSystemProperty("notificationAck", profileNotif);
+        event.getProfile().setSystemProperty("lastUpdated", new Date());
+
         persistenceService.update(event.getProfile().getItemId(), null, Profile.class, "systemProperties", event.getProfile().getSystemProperties());
 
         ST stringTemplate = new ST(template, '$', '$');

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -38,6 +38,7 @@
         <module>hover-event</module>
         <module>past-event</module>
         <module>tracked-event</module>
+        <module>kafka-injector</module>
     </modules>
 
     <dependencies>

--- a/services/src/main/java/org/apache/unomi/services/impl/profiles/ProfileServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/profiles/ProfileServiceImpl.java
@@ -521,6 +521,7 @@ public class ProfileServiceImpl implements ProfileService, SynchronousBundleList
         if (profile.getItemId() == null) {
             return null;
         }
+        profile.setSystemProperty("lastUpdated", new Date());
         if (persistenceService.save(profile)) {
             if (forceRefresh) {
                 // triggering a load will force an in-place refresh, that may be expensive in performance but will make data immediately available.
@@ -534,6 +535,7 @@ public class ProfileServiceImpl implements ProfileService, SynchronousBundleList
 
     public Profile saveOrMerge(Profile profile) {
         Profile previousProfile = persistenceService.load(profile.getItemId(), Profile.class);
+        profile.setSystemProperty("lastUpdated", new Date());
         if (previousProfile == null) {
             if (persistenceService.save(profile)) {
                 return profile;
@@ -551,6 +553,7 @@ public class ProfileServiceImpl implements ProfileService, SynchronousBundleList
     }
 
     public Persona savePersona(Persona profile) {
+        profile.setSystemProperty("lastUpdated", new Date());
         if (persistenceService.load(profile.getItemId(), Persona.class) == null) {
             Session session = new PersonaSession(UUID.randomUUID().toString(), profile, new Date());
             persistenceService.save(profile);

--- a/tools/shell-dev-commands/src/main/java/org/apache/unomi/shell/commands/ProfileList.java
+++ b/tools/shell-dev-commands/src/main/java/org/apache/unomi/shell/commands/ProfileList.java
@@ -51,14 +51,15 @@ public class ProfileList extends ListCommandSupport {
                 "Scope",
                 "Segments",
                 "Consents",
-                "Last modification",
+                "Last visit",
+                "Last update"
         };
     }
 
     @java.lang.Override
     protected DataTable buildDataTable() {
         Query query = new Query();
-        query.setSortby("properties.lastVisit:desc");
+        query.setSortby("systemProperties.lastUpdated:desc,properties.lastVisit:desc");
         query.setLimit(maxEntries);
         Condition matchAllCondition = new Condition(definitionsService.getConditionType("matchAllCondition"));
         query.setCondition(matchAllCondition);
@@ -71,6 +72,11 @@ public class ProfileList extends ListCommandSupport {
             rowData.add(StringUtils.join(profile.getSegments(), ","));
             rowData.add(StringUtils.join(profile.getConsents().keySet(), ","));
             rowData.add((String) profile.getProperty("lastVisit"));
+            if (profile.getSystemProperties() != null && profile.getSystemProperties().get("lastUpdated") != null) {
+                rowData.add((String) profile.getSystemProperties().get("lastUpdated"));
+            } else {
+                rowData.add("");
+            }
             dataTable.addRow(rowData.toArray(new Comparable[rowData.size()]));
         }
         return dataTable;


### PR DESCRIPTION
- This patch adds the lastUpdated system property to profiles
- Added as a system property to avoid any issues with migration. If it doesn't exist in existing installations it will simply be added the next time a profile is updated.
- Any profile modification (including changing consents, adding new segments or scoring plans) will update the last update date on profiles
- This patch also includes some various minor improvements to logging, that were used while developing this feature