### PR TITLE
Unomi 307 enable profile's sessions and events deletion

### DIFF
--- a/api/src/main/java/org/apache/unomi/api/services/EventService.java
+++ b/api/src/main/java/org/apache/unomi/api/services/EventService.java
@@ -122,4 +122,11 @@ public interface EventService {
      * @return {@code true} if the event has already been raised, {@code false} otherwise
      */
     boolean hasEventAlreadyBeenRaised(Event event, boolean session);
+
+    /**
+     * Removes all events of the specified profile
+     *
+     * @param profileId identifier of the profile that we want to remove it's events
+     */
+    void removeProfileEvents(String profileId);
 }

--- a/api/src/main/java/org/apache/unomi/api/services/PrivacyService.java
+++ b/api/src/main/java/org/apache/unomi/api/services/PrivacyService.java
@@ -66,9 +66,10 @@ public interface PrivacyService {
      * This method will perform two operations, first it will call the anonymizeBrowsingData method on the
      * specified profile, and then it will delete the profile from the persistence service.
      * @param profileId the identifier of the profile
+     * @param purgeData flag that indicates whether to purge the profile's data
      * @return true if the operation was successful, false otherwise
      */
-    Boolean deleteProfileData(String profileId);
+    Boolean deleteProfileData(String profileId,boolean purgeData);
 
     /**
      * Controls the activation/deactivation of anonymous browsing. This method will simply set a system

--- a/api/src/main/java/org/apache/unomi/api/services/ProfileService.java
+++ b/api/src/main/java/org/apache/unomi/api/services/ProfileService.java
@@ -167,6 +167,13 @@ public interface ProfileService {
     PartialList<Session> findProfileSessions(String profileId);
 
     /**
+     * Removes all sessions of the specified profile
+     *
+     * @param profileId identifier of the profile that we want to remove it's sessions
+     */
+    void removeProfileSessions(String profileId);
+
+    /**
      * Checks whether the specified profile and/or session satisfy the specified condition.
      *
      * @param condition the condition we're testing against which might or might not have profile- or session-specific sub-conditions

--- a/extensions/privacy-extension/rest/src/main/java/org/apache/unomi/privacy/rest/PrivacyServiceEndPoint.java
+++ b/extensions/privacy-extension/rest/src/main/java/org/apache/unomi/privacy/rest/PrivacyServiceEndPoint.java
@@ -55,9 +55,12 @@ public class PrivacyServiceEndPoint {
 
     @DELETE
     @Path("/profiles/{profileId}")
-    public Response deleteProfileData(@PathParam("profileId") String profileId, @QueryParam("withData") @DefaultValue("false") boolean withData) {
-        if (withData) {
-            privacyService.deleteProfileData(profileId);
+    public Response deleteProfileData(@PathParam("profileId") String profileId, @QueryParam("withData") @DefaultValue("false") boolean withData,
+                                      @QueryParam("purgeAll") @DefaultValue("false") boolean purgeAll) {
+        if (purgeAll) {
+            privacyService.deleteProfileData(profileId,true);
+        } else if (withData) {
+            privacyService.deleteProfileData(profileId,false);
         } else {
             privacyService.deleteProfile(profileId);
         }

--- a/extensions/privacy-extension/services/src/main/java/org/apache/unomi/privacy/internal/PrivacyServiceImpl.java
+++ b/extensions/privacy-extension/services/src/main/java/org/apache/unomi/privacy/internal/PrivacyServiceImpl.java
@@ -145,8 +145,13 @@ public class PrivacyServiceImpl implements PrivacyService {
     }
 
     @Override
-    public Boolean deleteProfileData(String profileId) {
-        anonymizeBrowsingData(profileId);
+    public Boolean deleteProfileData(String profileId,boolean purgeData) {
+        if (purgeData) {
+            eventService.removeProfileEvents(profileId);
+            profileService.removeProfileSessions(profileId);
+        } else {
+            anonymizeBrowsingData(profileId);
+        }
         profileService.delete(profileId, false);
         return true;
     }

--- a/services/src/main/java/org/apache/unomi/services/impl/events/EventServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/events/EventServiceImpl.java
@@ -301,4 +301,14 @@ public class EventServiceImpl implements EventService {
             eventListeners.remove(eventListenerService);
         }
     }
+
+    public void removeProfileEvents(String profileId){
+        Condition profileCondition = new Condition();
+        profileCondition.setConditionType(definitionsService.getConditionType("eventPropertyCondition"));
+        profileCondition.setParameter("propertyName", "profileId");
+        profileCondition.setParameter("comparisonOperator", "equals");
+        profileCondition.setParameter("propertyValue", profileId);
+
+        persistenceService.removeByQuery(profileCondition,Event.class);
+    }
 }

--- a/services/src/main/java/org/apache/unomi/services/impl/profiles/ProfileServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/profiles/ProfileServiceImpl.java
@@ -749,6 +749,16 @@ public class ProfileServiceImpl implements ProfileService, SynchronousBundleList
         return persistenceService.query("profileId", profileId, "timeStamp:desc", Session.class, 0, 50);
     }
 
+    public void removeProfileSessions(String profileId) {
+        Condition profileCondition = new Condition();
+        profileCondition.setConditionType(definitionsService.getConditionType("sessionPropertyCondition"));
+        profileCondition.setParameter("propertyName", "profileId");
+        profileCondition.setParameter("comparisonOperator", "equals");
+        profileCondition.setParameter("propertyValue", profileId);
+
+        persistenceService.removeByQuery(profileCondition,Session.class);
+    }
+
     @Override
     public boolean matchCondition(Condition condition, Profile profile, Session session) {
         ParserHelper.resolveConditionType(definitionsService, condition);


### PR DESCRIPTION
Added an option to the deleteProfile API (PrivacyService) - when deleting a profile you can now delete also all the profile's sessions and events. I added a new parameter to the deleteProfile API - 
called "purgeAll", when it is set to true the profile's sessions and events are deleted also. The parameter is not required and it's default value is false.

