### PR TITLE
UNOMI-327 Various quality issues

### DIFF
--- a/package/src/main/resources/bin/setenv
+++ b/package/src/main/resources/bin/setenv
@@ -58,3 +58,5 @@ MY_KARAF_HOME=`cd "$MY_DIRNAME/.."; pwd`
 # export YOURKIT_AGENTPATH="/home/jahia/install/yourkit/YourKit-JavaProfiler-2017.02/bin/linux-x86-64/libyjpagent.so"
 # Also activate this line to activate the agent on the JVM command line:
 # export KARAF_OPTS="-agentpath:$YOURKIT_AGENTPATH=disablestacktelemetry,exceptions=disable,delay=10000,probe_disable=*"
+
+export JAVA_MAX_MEM=2G

--- a/package/src/main/resources/bin/setenv.bat
+++ b/package/src/main/resources/bin/setenv.bat
@@ -43,7 +43,7 @@ rem SET JAVA_HOME
 rem Minimum memory for the JVM
 rem SET JAVA_MIN_MEM
 rem Maximum memory for the JVM
-SET JAVA_MAX_MEM=3G
+SET JAVA_MAX_MEM=2G
 rem Minimum perm memory for the JVM
 rem SET JAVA_PERM_MEM
 rem Maximum perm memory for the JVM

--- a/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
+++ b/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
@@ -38,6 +38,7 @@ import org.apache.unomi.metrics.MetricsService;
 import org.apache.unomi.persistence.elasticsearch.conditions.*;
 import org.apache.unomi.persistence.spi.PersistenceService;
 import org.apache.unomi.persistence.spi.aggregate.*;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
@@ -72,6 +73,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.ScriptType;
@@ -688,6 +690,12 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
                             return null;
                         }
                     }
+                } catch (ElasticsearchStatusException ese) {
+                    if (ese.status().equals(RestStatus.NOT_FOUND)) {
+                        // this can happen if we are just testing the existence of the item, it is not always an error.
+                        return null;
+                    }
+                    throw new Exception("Error loading itemType=" + clazz.getName() + " itemId=" + itemId, ese);
                 } catch (IndexNotFoundException e) {
                     // this can happen if we are just testing the existence of the item, it is not always an error.
                     return null;
@@ -1475,6 +1483,12 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
                         scrollIdentifier = response.getScrollId();
                         totalHits = searchHits.getTotalHits().value;
                         totalHitsRelation = getTotalHitsRelation(searchHits.getTotalHits());
+                        if (scrollIdentifier != null && totalHits == 0) {
+                            // we have no results, we must clear the scroll request immediately.
+                            ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
+                            clearScrollRequest.addScrollId(response.getScrollId());
+                            client.clearScroll(clearScrollRequest, RequestOptions.DEFAULT);
+                        }
                         for (SearchHit searchHit : searchHits) {
                             String sourceAsString = searchHit.getSourceAsString();
                             final T value = ESCustomObjectMapper.getObjectMapper().readValue(sourceAsString, clazz);


### PR DESCRIPTION
- Change heap size from 512MB (default) to 2GB
- Catch ElasticsearchStatusException and in the case of an index not found we simply return null, in all other cases we raise the exception
- Fix scroll identifier leak when query returns no results.