### PR TITLE
UNOMI-332 Improvements to event-list command

### DIFF
--- a/manual/src/main/asciidoc/shell-commands.adoc
+++ b/manual/src/main/asciidoc/shell-commands.adoc
@@ -120,9 +120,9 @@ created, EXECUTE means the rule's actions are being executed.
 |event-id
 |Dumps a single event in JSON. The `event-id` can be retrieved from the event-tail command output.
 |event-list
-|[max-entries] [--csv]
+|[max-entries] [event-type] [--csv]
 |List the last events processed by Apache Unomi. The `max-entries` parameter can be used to control how many events are
-displayed (default is 100). The `--csv` argument is used to output the list as a CSV list instead of an ASCII table.
+displayed (default is 100). The `event-type` makes it possible to filter the list by event type. The `--csv` argument is used to output the list as a CSV list instead of an ASCII table.
 |event-search
 |profile-id [event-type] [max-entries]
 |This command makes it possible to search for the last events by `profile-id` and by `event-type`. A `max-entries`


### PR DESCRIPTION
- List is now sorted in reverse chronological order
- A new argument makes it possible to filter the list by event type.