### PR TITLE
UNOMI-334 Docker Maven integration

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,19 +24,16 @@ ENV PATH $PATH:$UNOMI_HOME/bin
 ENV KARAF_OPTS "-Dunomi.autoStart=true"
 
 ENV ELASTICSEARCH_HOST localhost
-ENV ELASTICSEARCH_PORT 9300
+ENV ELASTICSEARCH_PORT 9200
 
-ENV UNOMI_VERSION "1.4.0"
+ENV UNOMI_VERSION "${project.version}"
 
 WORKDIR $UNOMI_HOME
 
-RUN wget http://apache.mirrors.pair.com/unomi/${UNOMI_VERSION}/unomi-${UNOMI_VERSION}-bin.tar.gz
+ADD target/dependency/unomi-${UNOMI_VERSION}.tar.gz ./
 
-RUN tar -xzf unomi-${UNOMI_VERSION}-bin.tar.gz \
-	&& mv unomi-*/* . \
+RUN mv unomi-*/* . \
 	&& rm -rf unomi-*
-
-RUN cp ${UNOMI_HOME}/etc/custom.properties ${UNOMI_HOME}/etc/custom.properties.template
 
 COPY ./entrypoint.sh ./entrypoint.sh
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,21 +19,15 @@
 You can build the docker image provided in this directory by using the following command:
 
 ```
-docker build -t unomi .
+mvn clean install
 ```
 
 # Unomi Docker Image
 
 ## Running Unomi
+
 Unomi requires ElasticSearch so it is recommended to run Unomi and ElasticSearch using docker-compose:
 ```
-docker-compose up
+mvn docker:start
 ```
-You will need to wait while Docker builds the containers and they boot up (ES will take a minute or two). Once they are up you can check that the Unomi services are available by visiting http://localhost:8181/cxs in a web browser.
-
-## Environment variables
-
-When you start the `unomi` image, you can adjust the configuration of the Unomi instance by passing one or more environment variables on the `docker run` command line.
-
-- **`ELASTICSEARCH_HOST`** - The IP address of hostname for ElasticSearch
-- **`ELASTICSEARCH_PORT`** - The port for ElasticSearch
+You will need to wait while Docker builds the containers and they boot up (ES will take a minute or two). Once they are up you can check that the Unomi services are available by visiting http://localhost:8181 in a web browser.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,12 +17,12 @@
 version: '2.2'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.4.2
     volumes: # Persist ES data in seperate "esdata" volume
       - esdata1:/usr/share/elasticsearch/data
     environment:
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "ES_JAVA_OPTS=-Xms1G -Xmx1G"
       - discovery.type=single-node
       - xpack.security.enabled=false
       - cluster.name=contextElasticSearch
@@ -34,8 +34,8 @@ services:
     container_name: unomi
     environment:
       - ELASTICSEARCH_HOST=elasticsearch
-      - ELASTICSEARCH_PORT=9300
-      - UNOMI_ELASTICSEARCH_ADDRESSES=elasticsearch:9300
+      - ELASTICSEARCH_PORT=9200
+      - UNOMI_ELASTICSEARCH_ADDRESSES=elasticsearch:9200
     ports:
       - 8181:8181
       - 9443:9443

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,16 +18,13 @@
 ################################################################################
 # Wait for heathy ElasticSearch
 # next wait for ES status to turn to Green
-health_check="$(curl -fsSL "$ELASTICSEARCH_HOST:9200/_cat/health?h=status")"
+health_check="$(curl -fsSL "$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT/_cat/health?h=status")"
 
 until ([ "$health_check" = 'yellow' ] || [ "$health_check" = 'green' ]); do
-    health_check="$(curl -fsSL "$ELASTICSEARCH_HOST:9200/_cat/health?h=status")"
-    >&2 echo "Elastic Search is unavailable - waiting"
+    health_check="$(curl -fsSL "$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT/_cat/health?h=status")"
+    >&2 echo "Elastic Search is not yet available - waiting (health check=$health_check)..."
     sleep 1
 done
-
-cp -f $UNOMI_HOME/etc/custom.properties.template $UNOMI_HOME/etc/custom.properties
-echo org.apache.unomi.elasticsearch.addresses=$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT >> $UNOMI_HOME/etc/custom.properties
 
 $UNOMI_HOME/bin/start
 $UNOMI_HOME/bin/status # Call to status delays while Karaf creates karaf.log

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -73,8 +73,7 @@
                     <images>
                         <image>
                             <alias>unomi</alias>
-                            <name>apache/unomi:latest</name>
-
+                            <name>apache/unomi:${project.version}</name>
                             <external>
                                 <type>compose</type>
                                 <basedir>${basedir}</basedir>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.unomi</groupId>
+        <artifactId>unomi-root</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>unomi-docker</artifactId>
+    <name>Apache Unomi :: Docker Image</name>
+    <description>Maven project to generate Docker image</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.unomi</groupId>
+            <artifactId>unomi</artifactId>
+            <version>${project.version}</version>
+            <type>tar.gz</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.unomi</groupId>
+                                    <artifactId>unomi</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>tar.gz</type>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.33.0</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <alias>unomi</alias>
+                            <name>apache/unomi:latest</name>
+
+                            <external>
+                                <type>compose</type>
+                                <basedir>${basedir}</basedir>
+                                <composeFile>docker-compose.yml</composeFile>
+                            </external>
+
+                        </image>
+                    </images>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>docker-build</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/extensions/web-tracker/javascript/src/analytics.js-integration-apache-unomi.js
+++ b/extensions/web-tracker/javascript/src/analytics.js-integration-apache-unomi.js
@@ -25,7 +25,7 @@ var Unomi = (module.exports = integration('Apache Unomi')
     .readyOnLoad()
     .option('scope', 'systemscope')
     .option('url', 'http://localhost:8181')
-    .option('timeoutInMilliseconds', 1500)
+    .option('timeoutInMilliseconds', 3000)
     .option('sessionCookieName', 'unomiSessionId')
     .option('sessionId'));
 

--- a/pom.xml
+++ b/pom.xml
@@ -666,6 +666,12 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>docker</id>
+            <modules>
+                <module>docker</module>
+            </modules>
+        </profile>
     </profiles>
 
     <dependencyManagement>


### PR DESCRIPTION
This PR contains a Maven - Docker integration which brings the following benefits:
- Version is automatically managed by Maven
- Docker-compose is integrated with Maven, making it very easy to build and start a full Unomi environment by just using: `mvn clean install` and then `mvn docker:start` in the Docker sub-project
- Docker push is also possible directly using `mvn docker:push` (it will use the project version as a tag, which should make it also easy to handle releases).

