### PR TITLE
UNOMI-341 - Refactor ServiceManager

### DIFF
--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/CreateOrUpdatePersonaCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/CreateOrUpdatePersonaCommand.java
@@ -48,7 +48,7 @@ public class CreateOrUpdatePersonaCommand extends BaseCommand<CDPPersona> {
 
     @Override
     public CDPPersona execute() {
-        final ProfileService profileService = serviceManager.getProfileService();
+        final ProfileService profileService = serviceManager.getService(ProfileService.class);
 
         final Map<String, Object> personaAsMap = environment.getArgument(PERSONA_ARGUMENT_NAME);
 

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/CreateOrUpdateProfilePropertiesCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/CreateOrUpdateProfilePropertiesCommand.java
@@ -18,6 +18,7 @@ package org.apache.unomi.graphql.commands;
 
 import org.apache.unomi.api.PropertyType;
 import org.apache.unomi.api.services.ProfileService;
+import org.apache.unomi.graphql.schema.GraphQLSchemaUpdater;
 import org.apache.unomi.graphql.types.input.CDPPropertyInput;
 import org.apache.unomi.graphql.types.input.property.BaseCDPPropertyInput;
 import org.apache.unomi.graphql.types.input.property.CDPSetPropertyInput;
@@ -38,7 +39,7 @@ public class CreateOrUpdateProfilePropertiesCommand extends BaseCommand<Boolean>
         super(builder);
 
         this.properties = builder.properties;
-        this.profileService = serviceManager.getProfileService();
+        this.profileService = serviceManager.getService(ProfileService.class);
     }
 
     public static Builder create(List<CDPPropertyInput> properties) {
@@ -53,7 +54,7 @@ public class CreateOrUpdateProfilePropertiesCommand extends BaseCommand<Boolean>
             profileService.setPropertyType(propertyType);
         });
 
-        serviceManager.getGraphQLSchemaUpdater().updateSchema();
+        serviceManager.getService(GraphQLSchemaUpdater.class).updateSchema();
 
         return true;
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/DeleteAllPersonalDataCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/DeleteAllPersonalDataCommand.java
@@ -18,6 +18,8 @@ package org.apache.unomi.graphql.commands;
 
 import com.google.common.base.Strings;
 import org.apache.unomi.api.Profile;
+import org.apache.unomi.api.services.PrivacyService;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.services.ServiceManager;
 
 import java.util.Map;
@@ -37,13 +39,13 @@ public class DeleteAllPersonalDataCommand extends BaseCommand<Boolean> {
 
         final String profileId = (String) cdpProfileIdInput.get("id");
 
-        final Profile profile = serviceManager.getProfileService().load(profileId);
+        final Profile profile = serviceManager.getService(ProfileService.class).load(profileId);
 
         if (profile == null) {
             return false;
         }
 
-        return serviceManager.getPrivacyService().deleteProfileData(profileId, false);
+        return serviceManager.getService(PrivacyService.class).deleteProfileData(profileId, false);
     }
 
     public static Builder create() {

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/DeleteProfileCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/DeleteProfileCommand.java
@@ -17,6 +17,7 @@
 package org.apache.unomi.graphql.commands;
 
 import org.apache.unomi.api.Profile;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.services.ServiceManager;
 
 import java.util.Map;
@@ -35,13 +36,14 @@ public class DeleteProfileCommand extends BaseCommand<Boolean> {
 
         final String profileId = (String) cdpProfileIdInput.get("id");
 
-        final Profile profile = serviceManager.getProfileService().load(profileId);
+        ProfileService profileService = serviceManager.getService(ProfileService.class);
+        final Profile profile = profileService.load(profileId);
 
         if (profile == null) {
             throw new IllegalStateException(String.format("The profile with id \"%s\" not found", profileId));
         }
 
-        serviceManager.getProfileService().delete(profileId, false);
+        profileService.delete(profileId, false);
 
         return true;
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/DeleteProfilePropertiesCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/DeleteProfilePropertiesCommand.java
@@ -17,6 +17,8 @@
 package org.apache.unomi.graphql.commands;
 
 import org.apache.unomi.api.PropertyType;
+import org.apache.unomi.api.services.ProfileService;
+import org.apache.unomi.graphql.schema.GraphQLSchemaUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +41,8 @@ public class DeleteProfilePropertiesCommand extends BaseCommand<Boolean> {
 
     @Override
     public Boolean execute() {
-        final Collection<PropertyType> propertyTypes = serviceManager.getProfileService().getTargetPropertyTypes("profiles");
+        ProfileService profileService = serviceManager.getService(ProfileService.class);
+        final Collection<PropertyType> propertyTypes = profileService.getTargetPropertyTypes("profiles");
 
         final List<String> persistedPropertyNames = propertyTypes.stream().map(PropertyType::getItemId).collect(Collectors.toList());
 
@@ -52,7 +55,7 @@ public class DeleteProfilePropertiesCommand extends BaseCommand<Boolean> {
 
         for (String propertyName : propertyNames) {
             try {
-                boolean deleted = serviceManager.getProfileService().deletePropertyType(propertyName);
+                boolean deleted = profileService.deletePropertyType(propertyName);
 
                 if (deleted) {
                     LOG.info("The property \"{}\" of profile was deleted successfully", propertyName);
@@ -64,7 +67,7 @@ public class DeleteProfilePropertiesCommand extends BaseCommand<Boolean> {
             }
         }
 
-        serviceManager.getGraphQLSchemaUpdater().updateSchema();
+        serviceManager.getService(GraphQLSchemaUpdater.class).updateSchema();
 
         return true;
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/ProcessEventsCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/ProcessEventsCommand.java
@@ -21,6 +21,7 @@ import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
 import org.apache.unomi.api.Event;
 import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.CDPGraphQLConstants;
 import org.apache.unomi.graphql.types.input.CDPConsentUpdateEventInput;
 import org.apache.unomi.graphql.types.input.CDPEventInput;
@@ -158,10 +159,10 @@ public class ProcessEventsCommand extends BaseCommand<Integer> {
     }
 
     private void processEvent(final Event event) {
-        int eventCode = serviceManager.getEventService().send(event);
+        int eventCode = serviceManager.getService(EventService.class).send(event);
 
         if (eventCode == EventService.PROFILE_UPDATED) {
-            serviceManager.getProfileService().save(event.getProfile());
+            serviceManager.getService(ProfileService.class).save(event.getProfile());
         }
         processedEventsQty.incrementAndGet();
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/list/AddProfileToListCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/list/AddProfileToListCommand.java
@@ -19,6 +19,7 @@ package org.apache.unomi.graphql.commands.list;
 import org.apache.unomi.api.Event;
 import org.apache.unomi.api.Profile;
 import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.CDPGraphQLConstants;
 import org.apache.unomi.graphql.commands.BaseCommand;
 import org.apache.unomi.graphql.converters.UserListConverter;
@@ -26,6 +27,7 @@ import org.apache.unomi.graphql.types.input.CDPProfileIDInput;
 import org.apache.unomi.graphql.types.output.CDPList;
 import org.apache.unomi.graphql.utils.EventBuilder;
 import org.apache.unomi.lists.UserList;
+import org.apache.unomi.services.UserListService;
 
 import java.util.Collections;
 import java.util.Objects;
@@ -46,13 +48,13 @@ public class AddProfileToListCommand extends BaseCommand<CDPList> {
 
     @Override
     public CDPList execute() {
-        final UserList userList = serviceManager.getUserListServiceExt().load(listId);
+        final UserList userList = serviceManager.getService(UserListService.class).load(listId);
 
         if (userList == null) {
             return null;
         }
 
-        final Profile profile = serviceManager.getProfileService().load(profileIDInput.getId());
+        final Profile profile = serviceManager.getService(ProfileService.class).load(profileIDInput.getId());
 
         if (profile == null) {
             return null;
@@ -63,8 +65,8 @@ public class AddProfileToListCommand extends BaseCommand<CDPList> {
                 .setPersistent(true)
                 .build();
 
-        if (serviceManager.getEventService().send(event) == EventService.PROFILE_UPDATED) {
-            serviceManager.getProfileService().save(event.getProfile());
+        if (serviceManager.getService(EventService.class).send(event) == EventService.PROFILE_UPDATED) {
+            serviceManager.getService(ProfileService.class).save(event.getProfile());
         }
 
         return new CDPList(UserListConverter.convertToUnomiList(userList));

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/list/AddProfileToListCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/list/AddProfileToListCommand.java
@@ -54,7 +54,8 @@ public class AddProfileToListCommand extends BaseCommand<CDPList> {
             return null;
         }
 
-        final Profile profile = serviceManager.getService(ProfileService.class).load(profileIDInput.getId());
+        ProfileService profileService = serviceManager.getService(ProfileService.class);
+        final Profile profile = profileService.load(profileIDInput.getId());
 
         if (profile == null) {
             return null;
@@ -66,7 +67,7 @@ public class AddProfileToListCommand extends BaseCommand<CDPList> {
                 .build();
 
         if (serviceManager.getService(EventService.class).send(event) == EventService.PROFILE_UPDATED) {
-            serviceManager.getService(ProfileService.class).save(event.getProfile());
+            profileService.save(event.getProfile());
         }
 
         return new CDPList(UserListConverter.convertToUnomiList(userList));

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/list/CreateOrUpdateListCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/list/CreateOrUpdateListCommand.java
@@ -39,7 +39,7 @@ public class CreateOrUpdateListCommand extends BaseCommand<CDPList> {
 
     @Override
     public CDPList execute() {
-        final UserListService userListService = serviceManager.getUserListServiceExt();
+        final UserListService userListService = serviceManager.getService(UserListService.class);
 
         final String listId = Strings.isNullOrEmpty(listInput.getId())
                 ? listInput.getName()

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/list/DeleteListCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/list/DeleteListCommand.java
@@ -17,6 +17,7 @@
 package org.apache.unomi.graphql.commands.list;
 
 import org.apache.unomi.graphql.commands.BaseCommand;
+import org.apache.unomi.services.UserListService;
 
 import java.util.Objects;
 
@@ -32,13 +33,14 @@ public class DeleteListCommand extends BaseCommand<Boolean> {
 
     @Override
     public Boolean execute() {
-        if (serviceManager.getUserListServiceExt().load(listId) == null) {
+        UserListService userListService = serviceManager.getService(UserListService.class);
+        if (userListService.load(listId) == null) {
             return false;
         }
 
-        serviceManager.getUserListServiceExt().delete(listId);
+        userListService.delete(listId);
 
-        return serviceManager.getUserListServiceExt().load(listId) == null;
+        return userListService.load(listId) == null;
     }
 
     public static Builder create(final String listId) {

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/list/RemoveProfileFromListCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/list/RemoveProfileFromListCommand.java
@@ -50,7 +50,8 @@ public class RemoveProfileFromListCommand extends BaseCommand<Boolean> {
             return null;
         }
 
-        final Profile profile = serviceManager.getService(ProfileService.class).load(profileIDInput.getId());
+        ProfileService profileService = serviceManager.getService(ProfileService.class);
+        final Profile profile = profileService.load(profileIDInput.getId());
 
         if (profile == null) {
             return null;
@@ -64,7 +65,7 @@ public class RemoveProfileFromListCommand extends BaseCommand<Boolean> {
         int eventCode = serviceManager.getService(EventService.class).send(event);
 
         if (eventCode == EventService.PROFILE_UPDATED) {
-            serviceManager.getService(ProfileService.class).save(event.getProfile());
+            profileService.save(event.getProfile());
 
             return true;
         }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/list/RemoveProfileFromListCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/list/RemoveProfileFromListCommand.java
@@ -19,11 +19,13 @@ package org.apache.unomi.graphql.commands.list;
 import org.apache.unomi.api.Event;
 import org.apache.unomi.api.Profile;
 import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.CDPGraphQLConstants;
 import org.apache.unomi.graphql.commands.BaseCommand;
 import org.apache.unomi.graphql.types.input.CDPProfileIDInput;
 import org.apache.unomi.graphql.utils.EventBuilder;
 import org.apache.unomi.lists.UserList;
+import org.apache.unomi.services.UserListService;
 
 import java.util.Collections;
 import java.util.Objects;
@@ -42,13 +44,13 @@ public class RemoveProfileFromListCommand extends BaseCommand<Boolean> {
 
     @Override
     public Boolean execute() {
-        final UserList userList = serviceManager.getUserListServiceExt().load(listId);
+        final UserList userList = serviceManager.getService(UserListService.class).load(listId);
 
         if (userList == null) {
             return null;
         }
 
-        final Profile profile = serviceManager.getProfileService().load(profileIDInput.getId());
+        final Profile profile = serviceManager.getService(ProfileService.class).load(profileIDInput.getId());
 
         if (profile == null) {
             return null;
@@ -59,10 +61,10 @@ public class RemoveProfileFromListCommand extends BaseCommand<Boolean> {
                 .setPersistent(true)
                 .build();
 
-        int eventCode = serviceManager.getEventService().send(event);
+        int eventCode = serviceManager.getService(EventService.class).send(event);
 
         if (eventCode == EventService.PROFILE_UPDATED) {
-            serviceManager.getProfileService().save(event.getProfile());
+            serviceManager.getService(ProfileService.class).save(event.getProfile());
 
             return true;
         }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/segments/BaseCreateOrUpdateSegmentCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/segments/BaseCreateOrUpdateSegmentCommand.java
@@ -34,7 +34,7 @@ public abstract class BaseCreateOrUpdateSegmentCommand<INPUT extends BaseSegment
     }
 
     protected Segment preparedSegmentWithoutCondition(final INPUT segmentInput) {
-        final SegmentService segmentService = serviceManager.getSegmentService();
+        final SegmentService segmentService = serviceManager.getService(SegmentService.class);
 
         final String segmentId = Strings.isNullOrEmpty(segmentInput.getId())
                 ? segmentInput.getName()

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/segments/CreateOrUpdateSegmentCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/segments/CreateOrUpdateSegmentCommand.java
@@ -18,6 +18,7 @@ package org.apache.unomi.graphql.commands.segments;
 
 import org.apache.unomi.api.conditions.Condition;
 import org.apache.unomi.api.segments.Segment;
+import org.apache.unomi.api.services.SegmentService;
 import org.apache.unomi.graphql.condition.factories.ProfileConditionFactory;
 import org.apache.unomi.graphql.types.input.CDPSegmentInput;
 import org.apache.unomi.graphql.types.output.CDPSegment;
@@ -51,7 +52,7 @@ public class CreateOrUpdateSegmentCommand extends BaseCreateOrUpdateSegmentComma
 
         segment.setCondition(condition);
 
-        serviceManager.getSegmentService().setSegmentDefinition(segment);
+        serviceManager.getService(SegmentService.class).setSegmentDefinition(segment);
 
         return new CDPSegment(segment);
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/segments/CreateOrUpdateUnomiSegmentCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/segments/CreateOrUpdateUnomiSegmentCommand.java
@@ -18,6 +18,7 @@ package org.apache.unomi.graphql.commands.segments;
 
 import org.apache.unomi.api.conditions.Condition;
 import org.apache.unomi.api.segments.Segment;
+import org.apache.unomi.api.services.DefinitionsService;
 import org.apache.unomi.api.services.SegmentService;
 import org.apache.unomi.graphql.types.output.UnomiSegment;
 import org.apache.unomi.graphql.types.input.UnomiSegmentInput;
@@ -40,7 +41,7 @@ public class CreateOrUpdateUnomiSegmentCommand extends BaseCreateOrUpdateSegment
 
     @Override
     public UnomiSegment execute() {
-        final SegmentService segmentService = serviceManager.getSegmentService();
+        final SegmentService segmentService = serviceManager.getService(SegmentService.class);
 
         Segment segment = preparedSegmentWithoutCondition(segmentInput);
 
@@ -57,7 +58,7 @@ public class CreateOrUpdateUnomiSegmentCommand extends BaseCreateOrUpdateSegment
 
     @SuppressWarnings("unchecked")
     private Condition decorateCondition(final Condition condition) {
-        condition.setConditionType(serviceManager.getDefinitionsService().getConditionType(condition.getConditionTypeId()));
+        condition.setConditionType(serviceManager.getService(DefinitionsService.class).getConditionType(condition.getConditionTypeId()));
 
         if (condition.containsParameter("subConditions")) {
             final List<LinkedHashMap<String, Object>> subConditions = (List<LinkedHashMap<String, Object>>) condition.getParameter("subConditions");

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/segments/DeleteSegmentCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/segments/DeleteSegmentCommand.java
@@ -18,6 +18,7 @@ package org.apache.unomi.graphql.commands.segments;
 
 import com.google.common.base.Strings;
 import org.apache.unomi.api.segments.DependentMetadata;
+import org.apache.unomi.api.services.SegmentService;
 import org.apache.unomi.graphql.commands.BaseCommand;
 
 public class DeleteSegmentCommand extends BaseCommand<Boolean> {
@@ -32,7 +33,7 @@ public class DeleteSegmentCommand extends BaseCommand<Boolean> {
 
     @Override
     public Boolean execute() {
-        final DependentMetadata dependentMetadata = serviceManager.getSegmentService().removeSegmentDefinition(segmentId, true);
+        final DependentMetadata dependentMetadata = serviceManager.getService(SegmentService.class).removeSegmentDefinition(segmentId, true);
 
         return dependentMetadata.getScorings().isEmpty() && dependentMetadata.getSegments().isEmpty();
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/condition/factories/ConditionFactory.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/condition/factories/ConditionFactory.java
@@ -46,7 +46,7 @@ public class ConditionFactory {
         this.conditionTypeId = conditionTypeId;
 
         final ServiceManager context = environment.getContext();
-        this.definitionsService = context.getDefinitionsService();
+        this.definitionsService = context.getService(DefinitionsService.class);
 
         this.conditionTypesMap = definitionsService.getAllConditionTypes().stream()
                 .collect(Collectors.toMap(ConditionType::getItemId, Function.identity()));

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/condition/factories/ProfileConditionFactory.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/condition/factories/ProfileConditionFactory.java
@@ -21,6 +21,7 @@ import graphql.schema.DataFetchingEnvironment;
 import org.apache.unomi.api.GeoPoint;
 import org.apache.unomi.api.PropertyType;
 import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.schema.ComparisonConditionTranslator;
 import org.apache.unomi.graphql.schema.PropertyNameTranslator;
 import org.apache.unomi.graphql.schema.PropertyValueTypeHelper;
@@ -248,7 +249,7 @@ public class ProfileConditionFactory extends ConditionFactory {
     private void addDynamicProfilePropertiesCondition(final Map<String, Object> filterAsMap, final List<Condition> subConditions) {
         final ServiceManager serviceManager = environment.getContext();
 
-        final Map<String, PropertyType> propertyTypeMap = serviceManager.getProfileService().getTargetPropertyTypes("profiles")
+        final Map<String, PropertyType> propertyTypeMap = serviceManager.getService(ProfileService.class).getTargetPropertyTypes("profiles")
                 .stream().collect(Collectors.toMap(PropertyType::getItemId, Function.identity()));
 
         filterAsMap.forEach((propertyName, propertyValue) -> {

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/condition/parsers/SegmentProfilePropertiesConditionParser.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/condition/parsers/SegmentProfilePropertiesConditionParser.java
@@ -19,6 +19,7 @@ package org.apache.unomi.graphql.condition.parsers;
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.unomi.api.PropertyType;
 import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.schema.ComparisonConditionTranslator;
 import org.apache.unomi.graphql.services.ServiceManager;
 import org.apache.unomi.graphql.utils.DateUtils;
@@ -48,7 +49,7 @@ public class SegmentProfilePropertiesConditionParser {
 
         final ServiceManager serviceManager = environment.getContext();
 
-        profilePropertiesAsMap = serviceManager.getProfileService().getTargetPropertyTypes("profiles").stream()
+        profilePropertiesAsMap = serviceManager.getService(ProfileService.class).getTargetPropertyTypes("profiles").stream()
                 .collect(Collectors.toMap(PropertyType::getItemId, Function.identity()));
     }
 

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/consent/ConsentEventConnectionDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/consent/ConsentEventConnectionDataFetcher.java
@@ -21,6 +21,8 @@ import graphql.schema.DataFetchingEnvironment;
 import org.apache.unomi.api.Event;
 import org.apache.unomi.api.PartialList;
 import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.api.services.DefinitionsService;
+import org.apache.unomi.api.services.EventService;
 import org.apache.unomi.graphql.condition.factories.EventConditionFactory;
 import org.apache.unomi.graphql.fetchers.ConnectionParams;
 import org.apache.unomi.graphql.fetchers.EventConnectionDataFetcher;
@@ -39,11 +41,12 @@ public class ConsentEventConnectionDataFetcher extends EventConnectionDataFetche
 
         final EventConditionFactory factory = EventConditionFactory.get(environment);
 
-        final Condition eventCondition = factory.propertyCondition("eventType", "modifyConsent", serviceManager.getDefinitionsService());
-        final Condition consentCondition = factory.propertyCondition("target.token", consent.getToken(), serviceManager.getDefinitionsService());
+        DefinitionsService definitionsService = serviceManager.getService(DefinitionsService.class);
+        final Condition eventCondition = factory.propertyCondition("eventType", "modifyConsent", definitionsService);
+        final Condition consentCondition = factory.propertyCondition("target.token", consent.getToken(), definitionsService);
 
         final Condition andCondition = factory.booleanCondition("and", Arrays.asList(eventCondition, consentCondition));
-        final PartialList<Event> events = serviceManager.getEventService().searchEvents(andCondition, 0, ConnectionParams.DEFAULT_PAGE_SIZE);
+        final PartialList<Event> events = serviceManager.getService(EventService.class).searchEvents(andCondition, 0, ConnectionParams.DEFAULT_PAGE_SIZE);
 
         return createEventConnection(events);
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/event/EventDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/event/EventDataFetcher.java
@@ -21,6 +21,7 @@ import graphql.schema.DataFetchingEnvironment;
 import org.apache.unomi.api.Event;
 import org.apache.unomi.api.services.EventService;
 import org.apache.unomi.graphql.fetchers.BaseDataFetcher;
+import org.apache.unomi.graphql.schema.CDPEventInterfaceRegister;
 import org.apache.unomi.graphql.services.ServiceManager;
 import org.apache.unomi.graphql.types.output.CDPEventInterface;
 
@@ -35,10 +36,10 @@ public class EventDataFetcher extends BaseDataFetcher<CDPEventInterface> {
     @Override
     public CDPEventInterface get(DataFetchingEnvironment environment) throws Exception {
         final ServiceManager serviceManager = environment.getContext();
-        final EventService eventService = serviceManager.getEventService();
+        final EventService eventService = serviceManager.getService(EventService.class);
         final Event event = eventService.getEvent(id);
 
-        return event == null ? null : serviceManager.getEventInterfaceRegister().getEvent(event);
+        return event == null ? null : serviceManager.getService(CDPEventInterfaceRegister.class).getEvent(event);
     }
 
 }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/event/FindEventsConnectionDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/event/FindEventsConnectionDataFetcher.java
@@ -22,6 +22,7 @@ import org.apache.unomi.api.Event;
 import org.apache.unomi.api.PartialList;
 import org.apache.unomi.api.conditions.Condition;
 import org.apache.unomi.api.query.Query;
+import org.apache.unomi.api.services.EventService;
 import org.apache.unomi.graphql.condition.factories.EventConditionFactory;
 import org.apache.unomi.graphql.fetchers.ConnectionParams;
 import org.apache.unomi.graphql.fetchers.EventConnectionDataFetcher;
@@ -56,7 +57,7 @@ public class FindEventsConnectionDataFetcher extends EventConnectionDataFetcher 
 
         final Query query = buildQuery(condition, orderByInput, params);
 
-        PartialList<Event> events = serviceManager.getEventService().search(query);
+        PartialList<Event> events = serviceManager.getService(EventService.class).search(query);
 
         return createEventConnection(events);
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/list/GetListDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/list/GetListDataFetcher.java
@@ -22,6 +22,7 @@ import org.apache.unomi.graphql.converters.UserListConverter;
 import org.apache.unomi.graphql.services.ServiceManager;
 import org.apache.unomi.graphql.types.output.CDPList;
 import org.apache.unomi.lists.UserList;
+import org.apache.unomi.services.UserListService;
 
 public class GetListDataFetcher implements DataFetcher<CDPList> {
 
@@ -35,7 +36,7 @@ public class GetListDataFetcher implements DataFetcher<CDPList> {
     public CDPList get(final DataFetchingEnvironment environment) throws Exception {
         final ServiceManager serviceManager = environment.getContext();
 
-        final UserList userList = serviceManager.getUserListServiceExt().load(listId);
+        final UserList userList = serviceManager.getService(UserListService.class).load(listId);
 
         return userList != null ? new CDPList(UserListConverter.convertToUnomiList(userList)) : null;
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/list/ListConnectionDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/list/ListConnectionDataFetcher.java
@@ -28,6 +28,7 @@ import org.apache.unomi.graphql.services.ServiceManager;
 import org.apache.unomi.graphql.types.input.CDPListFilterInput;
 import org.apache.unomi.graphql.types.input.CDPOrderByInput;
 import org.apache.unomi.graphql.types.output.CDPListConnection;
+import org.apache.unomi.services.UserListService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +52,7 @@ public class ListConnectionDataFetcher extends BaseConnectionDataFetcher<CDPList
 
         final Query query = buildQuery(createCondition(environment), orderByInput, params);
 
-        final PartialList<Metadata> metadataPartialList = serviceManager.getUserListServiceExt().getListMetadatas(query);
+        final PartialList<Metadata> metadataPartialList = serviceManager.getService(UserListService.class).getListMetadatas(query);
 
         return new CDPListConnection(metadataPartialList);
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/list/ListProfileConnectionDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/list/ListProfileConnectionDataFetcher.java
@@ -22,6 +22,7 @@ import org.apache.unomi.api.PartialList;
 import org.apache.unomi.api.Profile;
 import org.apache.unomi.api.conditions.Condition;
 import org.apache.unomi.api.query.Query;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.condition.factories.ProfileConditionFactory;
 import org.apache.unomi.graphql.fetchers.ConnectionParams;
 import org.apache.unomi.graphql.fetchers.ProfileConnectionDataFetcher;
@@ -42,7 +43,7 @@ public class ListProfileConnectionDataFetcher extends ProfileConnectionDataFetch
 
         final Query query = buildQuery(listIdCondition, null, params);
 
-        PartialList<Profile> profiles = serviceManager.getProfileService().search(query, Profile.class);
+        PartialList<Profile> profiles = serviceManager.getService(ProfileService.class).search(query, Profile.class);
 
         return createProfileConnection(profiles);
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/FindProfilesConnectionDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/FindProfilesConnectionDataFetcher.java
@@ -22,6 +22,7 @@ import org.apache.unomi.api.PartialList;
 import org.apache.unomi.api.Profile;
 import org.apache.unomi.api.conditions.Condition;
 import org.apache.unomi.api.query.Query;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.condition.factories.ProfileConditionFactory;
 import org.apache.unomi.graphql.fetchers.ConnectionParams;
 import org.apache.unomi.graphql.fetchers.ProfileConnectionDataFetcher;
@@ -51,7 +52,7 @@ public class FindProfilesConnectionDataFetcher extends ProfileConnectionDataFetc
                 .profileFilterInputCondition(filterInput, environment.getArgument("filter"));
         final Query query = buildQuery(condition, orderByInput, params);
 
-        PartialList<Profile> profiles = serviceManager.getProfileService().search(query, Profile.class);
+        PartialList<Profile> profiles = serviceManager.getService(ProfileService.class).search(query, Profile.class);
 
         return createProfileConnection(profiles);
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileAllEventsConnectionDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileAllEventsConnectionDataFetcher.java
@@ -22,6 +22,7 @@ import org.apache.unomi.api.Event;
 import org.apache.unomi.api.PartialList;
 import org.apache.unomi.api.Profile;
 import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.api.services.EventService;
 import org.apache.unomi.graphql.condition.factories.EventConditionFactory;
 import org.apache.unomi.graphql.fetchers.ConnectionParams;
 import org.apache.unomi.graphql.fetchers.EventConnectionDataFetcher;
@@ -58,7 +59,7 @@ public class ProfileAllEventsConnectionDataFetcher extends EventConnectionDataFe
             condition = eventConditionFactory.eventFilterInputCondition(filterInput, filterInputAsMap);
         }
 
-        final PartialList<Event> events = serviceManager.getEventService().searchEvents(condition, params.getOffset(), params.getSize());
+        final PartialList<Event> events = serviceManager.getService(EventService.class).searchEvents(condition, params.getOffset(), params.getSize());
 
         return createEventConnection(events);
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileDataFetcher.java
@@ -38,7 +38,7 @@ public class ProfileDataFetcher extends BaseDataFetcher<CDPProfile> {
     @Override
     public CDPProfile get(DataFetchingEnvironment environment) throws Exception {
         final ServiceManager serviceManager = environment.getContext();
-        final ProfileService profileService = serviceManager.getProfileService();
+        final ProfileService profileService = serviceManager.getService(ProfileService.class);
 
         Profile profile = profileService.load(profileIDInput.getId());
 

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileLastEventsConnectionDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileLastEventsConnectionDataFetcher.java
@@ -22,6 +22,7 @@ import org.apache.unomi.api.Event;
 import org.apache.unomi.api.PartialList;
 import org.apache.unomi.api.Profile;
 import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.api.services.EventService;
 import org.apache.unomi.graphql.condition.factories.EventConditionFactory;
 import org.apache.unomi.graphql.fetchers.EventConnectionDataFetcher;
 import org.apache.unomi.graphql.services.ServiceManager;
@@ -45,7 +46,7 @@ public class ProfileLastEventsConnectionDataFetcher extends EventConnectionDataF
 
         final Condition condition = EventConditionFactory.get(environment)
                 .propertyCondition("profileId", profile.getItemId());
-        final PartialList<Event> events = serviceManager.getEventService().searchEvents(condition, 0, count);
+        final PartialList<Event> events = serviceManager.getService(EventService.class).searchEvents(condition, 0, count);
 
         return createEventConnection(events);
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileListsDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileListsDataFetcher.java
@@ -47,7 +47,7 @@ public class ProfileListsDataFetcher extends BaseDataFetcher<List<CDPList>> {
     @SuppressWarnings("unchecked")
     public List<CDPList> get(DataFetchingEnvironment environment) throws Exception {
         final ServiceManager serviceManager = environment.getContext();
-        final UserListService userListService = serviceManager.getUserListService();
+        final UserListService userListService = serviceManager.getService(UserListService.class);
         final Map<String, Object> systemProperties = profile.getSystemProperties();
         if (systemProperties == null) {
             return null;

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileMatchesDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileMatchesDataFetcher.java
@@ -53,7 +53,7 @@ public class ProfileMatchesDataFetcher implements DataFetcher<List<CDPFilterMatc
         }
 
         final ServiceManager serviceManager = environment.getContext();
-        final ProfileService profileService = serviceManager.getProfileService();
+        final ProfileService profileService = serviceManager.getService(ProfileService.class);
         final Date now = new Date();
         final Session session = new Session("profile-matcher-" + now.getTime(), profile, now, "digitall");
 

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileSegmentsDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileSegmentsDataFetcher.java
@@ -43,7 +43,7 @@ public class ProfileSegmentsDataFetcher extends BaseDataFetcher<List<CDPSegment>
     @Override
     public List<CDPSegment> get(DataFetchingEnvironment environment) throws Exception {
         final ServiceManager serviceManager = environment.getContext();
-        final SegmentService segmentService = serviceManager.getSegmentService();
+        final SegmentService segmentService = serviceManager.getService(SegmentService.class);
 
         final List<Metadata> metadata = segmentService.getSegmentMetadatasForProfile(profile);
 

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/PropertiesConnectionDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/PropertiesConnectionDataFetcher.java
@@ -20,6 +20,7 @@ package org.apache.unomi.graphql.fetchers.profile;
 
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.unomi.api.PropertyType;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.fetchers.BaseConnectionDataFetcher;
 import org.apache.unomi.graphql.fetchers.ConnectionParams;
 import org.apache.unomi.graphql.services.ServiceManager;
@@ -38,7 +39,7 @@ public class PropertiesConnectionDataFetcher extends BaseConnectionDataFetcher<C
     public CDPPropertyConnection get(DataFetchingEnvironment environment) throws Exception {
         final ServiceManager serviceManager = environment.getContext();
         final ConnectionParams params = parseConnectionParams(environment);
-        final Collection<PropertyType> properties = serviceManager.getProfileService().getTargetPropertyTypes("profiles");
+        final Collection<PropertyType> properties = serviceManager.getService(ProfileService.class).getTargetPropertyTypes("profiles");
 
         return createPropertiesConnection(properties, params);
     }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/segment/FindSegmentsConnectionDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/segment/FindSegmentsConnectionDataFetcher.java
@@ -23,6 +23,7 @@ import org.apache.unomi.api.PartialList;
 import org.apache.unomi.api.conditions.Condition;
 import org.apache.unomi.api.query.Query;
 import org.apache.unomi.api.segments.Segment;
+import org.apache.unomi.api.services.SegmentService;
 import org.apache.unomi.graphql.condition.factories.ProfileConditionFactory;
 import org.apache.unomi.graphql.fetchers.ConnectionParams;
 import org.apache.unomi.graphql.fetchers.SegmentConnectionDataFetcher;
@@ -52,10 +53,11 @@ public class FindSegmentsConnectionDataFetcher extends SegmentConnectionDataFetc
 
         final Condition condition = ProfileConditionFactory.get(environment).segmentFilterInputCondition(filterInput);
         final Query query = buildQuery(condition, orderByInput, params);
-        final PartialList<Metadata> metas = serviceManager.getSegmentService().getSegmentMetadatas(query);
+        SegmentService segmentService = serviceManager.getService(SegmentService.class);
+        final PartialList<Metadata> metas = segmentService.getSegmentMetadatas(query);
 
         final List<Segment> segmentList = metas.getList().stream()
-                .map(meta -> serviceManager.getSegmentService().getSegmentDefinition(meta.getId()))
+                .map(meta -> segmentService.getSegmentDefinition(meta.getId()))
                 .collect(Collectors.toList());
 
         PartialList<Segment> segments = new PartialList<>(segmentList, metas.getOffset(), metas.getPageSize(), metas.getTotalSize(), metas.getTotalSizeRelation());

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/segment/SegmentDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/segment/SegmentDataFetcher.java
@@ -19,6 +19,7 @@ package org.apache.unomi.graphql.fetchers.segment;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.unomi.api.segments.Segment;
+import org.apache.unomi.api.services.SegmentService;
 import org.apache.unomi.graphql.services.ServiceManager;
 import org.apache.unomi.graphql.types.output.CDPSegment;
 
@@ -34,7 +35,7 @@ public class SegmentDataFetcher implements DataFetcher<CDPSegment> {
     public CDPSegment get(DataFetchingEnvironment environment) throws Exception {
         final ServiceManager serviceManager = environment.getContext();
 
-        final Segment segment = serviceManager.getSegmentService().getSegmentDefinition(segmentId);
+        final Segment segment = serviceManager.getService(SegmentService.class).getSegmentDefinition(segmentId);
 
         if (segment != null) {
             return new CDPSegment(segment);

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/segment/UnomiSegmentDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/segment/UnomiSegmentDataFetcher.java
@@ -19,6 +19,7 @@ package org.apache.unomi.graphql.fetchers.segment;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.unomi.api.segments.Segment;
+import org.apache.unomi.api.services.SegmentService;
 import org.apache.unomi.graphql.services.ServiceManager;
 import org.apache.unomi.graphql.types.output.UnomiSegment;
 
@@ -34,7 +35,7 @@ public class UnomiSegmentDataFetcher implements DataFetcher<UnomiSegment> {
     public UnomiSegment get(final DataFetchingEnvironment environment) throws Exception {
         final ServiceManager serviceManager = environment.getContext();
 
-        final Segment segment = serviceManager.getSegmentService().getSegmentDefinition(segmentId);
+        final Segment segment = serviceManager.getService(SegmentService.class).getSegmentDefinition(segmentId);
 
         if (segment != null) {
             return new UnomiSegment(segment);

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/services/ServiceManager.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/services/ServiceManager.java
@@ -27,130 +27,24 @@ import org.apache.unomi.graphql.schema.CDPProfileInterfaceRegister;
 import org.apache.unomi.graphql.schema.CDPPropertyInterfaceRegister;
 import org.apache.unomi.graphql.schema.GraphQLSchemaUpdater;
 import org.apache.unomi.persistence.spi.PersistenceService;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 @Component(service = ServiceManager.class)
 public class ServiceManager {
 
-    private ProfileService profileService;
-    private SegmentService segmentService;
-    private EventService eventService;
-    private DefinitionsService definitionsService;
-    private GraphQLSchemaUpdater graphQLSchemaUpdater;
-    private PrivacyService privacyService;
-    private UserListService userListService;
-    private org.apache.unomi.services.UserListService userListServiceExt;
-    private CDPEventInterfaceRegister eventInterfaceRegister;
-    private CDPProfileInterfaceRegister profileInterfaceRegister;
-    private CDPPropertyInterfaceRegister propertyInterfaceRegister;
-    private PersistenceService persistenceService;
+    private BundleContext bundleContext;
 
-    @Reference
-    public void setProfileService(ProfileService profileService) {
-        this.profileService = profileService;
+    @Activate
+    private void activate(BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+    }
+    public <T> T getService(Class<T> serviceClass) {
+        ServiceReference<T> serviceReference = bundleContext.getServiceReference(serviceClass);
+        return bundleContext.getService(serviceReference);
     }
 
-    @Reference
-    public void setSegmentService(SegmentService segmentService) {
-        this.segmentService = segmentService;
-    }
-
-    @Reference
-    public void setDefinitionsService(DefinitionsService definitionsService) {
-        this.definitionsService = definitionsService;
-    }
-
-    @Reference
-    public void setEventService(EventService eventService) {
-        this.eventService = eventService;
-    }
-
-    @Reference
-    public void setGraphQLSchemaUpdater(GraphQLSchemaUpdater graphQLSchemaUpdater) {
-        this.graphQLSchemaUpdater = graphQLSchemaUpdater;
-    }
-
-    @Reference
-    public void setUserListService(UserListService userListService) {
-        this.userListService = userListService;
-    }
-
-    @Reference
-    public void setPrivacyService(PrivacyService privacyService) {
-        this.privacyService = privacyService;
-    }
-
-    @Reference
-    public void setEventInterfaceRegister(CDPEventInterfaceRegister eventInterfaceRegister) {
-        this.eventInterfaceRegister = eventInterfaceRegister;
-    }
-
-    @Reference
-    public void setProfileInterfaceRegister(CDPProfileInterfaceRegister profileInterfaceRegister) {
-        this.profileInterfaceRegister = profileInterfaceRegister;
-    }
-
-    @Reference
-    public void setPropertyInterfaceRegister(CDPPropertyInterfaceRegister propertyInterfaceRegister) {
-        this.propertyInterfaceRegister = propertyInterfaceRegister;
-    }
-
-    @Reference
-    public void setUserListServiceExt(org.apache.unomi.services.UserListService userListServiceExt) {
-        this.userListServiceExt = userListServiceExt;
-    }
-
-    @Reference
-    public void setPersistenceService(PersistenceService persistenceService) {
-        this.persistenceService = persistenceService;
-    }
-
-    public ProfileService getProfileService() {
-        return profileService;
-    }
-
-    public SegmentService getSegmentService() {
-        return segmentService;
-    }
-
-    public DefinitionsService getDefinitionsService() {
-        return definitionsService;
-    }
-
-    public EventService getEventService() {
-        return eventService;
-    }
-
-    public GraphQLSchemaUpdater getGraphQLSchemaUpdater() {
-        return graphQLSchemaUpdater;
-    }
-
-    public PrivacyService getPrivacyService() {
-        return privacyService;
-    }
-
-    public UserListService getUserListService() {
-        return userListService;
-    }
-
-    public CDPEventInterfaceRegister getEventInterfaceRegister() {
-        return eventInterfaceRegister;
-    }
-
-    public CDPProfileInterfaceRegister getProfileInterfaceRegister() {
-        return profileInterfaceRegister;
-    }
-
-    public org.apache.unomi.services.UserListService getUserListServiceExt() {
-        return userListServiceExt;
-    }
-
-    public CDPPropertyInterfaceRegister getPropertyInterfaceRegister() {
-        return propertyInterfaceRegister;
-    }
-
-    public PersistenceService getPersistenceService() {
-        return persistenceService;
-    }
 }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/BaseProfileEventProcessor.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/BaseProfileEventProcessor.java
@@ -18,6 +18,7 @@ package org.apache.unomi.graphql.types.input;
 
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.unomi.api.Profile;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.services.ServiceManager;
 import org.apache.unomi.graphql.utils.EventBuilder;
 
@@ -29,7 +30,7 @@ public abstract class BaseProfileEventProcessor implements CDPEventProcessor {
     protected Profile loadProfile(final Map<String, Object> eventInputAsMap, final DataFetchingEnvironment environment) {
         final Map<String, Object> cdpProfileId = (Map<String, Object>) eventInputAsMap.get("cdp_profileID");
         final ServiceManager serviceManager = environment.getContext();
-        return serviceManager.getProfileService().load((String) cdpProfileId.get("id"));
+        return serviceManager.getService(ProfileService.class).load((String) cdpProfileId.get("id"));
     }
 
     protected final EventBuilder eventBuilder(final Profile profile) {

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPEventEdge.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPEventEdge.java
@@ -21,6 +21,7 @@ import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.unomi.api.Event;
+import org.apache.unomi.graphql.schema.CDPEventInterfaceRegister;
 import org.apache.unomi.graphql.services.ServiceManager;
 
 @GraphQLName("CDP_EventEdge")
@@ -46,7 +47,7 @@ public class CDPEventEdge {
     public CDPEventInterface node(final DataFetchingEnvironment environment) {
         final ServiceManager serviceManager = environment.getContext();
 
-        return serviceManager.getEventInterfaceRegister().getEvent(getEvent());
+        return serviceManager.getService(CDPEventInterfaceRegister.class).getEvent(getEvent());
     }
 
 }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPEventInterface.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPEventInterface.java
@@ -26,6 +26,7 @@ import graphql.schema.DataFetchingEnvironment;
 import org.apache.unomi.api.Event;
 import org.apache.unomi.api.GeoPoint;
 import org.apache.unomi.api.Profile;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.services.ServiceManager;
 import org.apache.unomi.graphql.types.resolvers.CDPEventInterfaceResolver;
 import org.apache.unomi.graphql.utils.DateUtils;
@@ -79,7 +80,7 @@ public interface CDPEventInterface {
         } else if (getEvent().getProfileId() != null) {
             ServiceManager serviceManager = environment.getContext();
 
-            Profile profile = serviceManager.getProfileService().load(getEvent().getProfileId());
+            Profile profile = serviceManager.getService(ProfileService.class).load(getEvent().getProfileId());
 
             return new CDPProfile(profile);
         } else {

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPListsUpdateEvent.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPListsUpdateEvent.java
@@ -27,6 +27,7 @@ import org.apache.unomi.api.query.Query;
 import org.apache.unomi.graphql.condition.factories.ConditionFactory;
 import org.apache.unomi.graphql.converters.UserListConverter;
 import org.apache.unomi.graphql.services.ServiceManager;
+import org.apache.unomi.services.UserListService;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -75,7 +76,7 @@ public class CDPListsUpdateEvent implements CDPEventInterface {
         final Query query = new Query();
         query.setCondition(factory.propertiesCondition("itemId", "in", listIds));
 
-        final PartialList<Metadata> partialList = serviceManager.getUserListServiceExt().getListMetadatas(query);
+        final PartialList<Metadata> partialList = serviceManager.getService(UserListService.class).getListMetadatas(query);
 
         if (partialList == null || partialList.getList() == null) {
             return null;

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPProfileEdge.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPProfileEdge.java
@@ -21,6 +21,7 @@ import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.unomi.api.Profile;
+import org.apache.unomi.graphql.schema.CDPProfileInterfaceRegister;
 import org.apache.unomi.graphql.services.ServiceManager;
 
 @GraphQLName("CDP_ProfileEdge")
@@ -42,7 +43,7 @@ public class CDPProfileEdge {
     public CDPProfileInterface node(final DataFetchingEnvironment environment) {
         final ServiceManager serviceManager = environment.getContext();
 
-        return serviceManager.getProfileInterfaceRegister().getProfile(profile);
+        return serviceManager.getService(CDPProfileInterfaceRegister.class).getProfile(profile);
     }
 
 }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPPropertyEdge.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPPropertyEdge.java
@@ -22,6 +22,7 @@ import graphql.annotations.annotationTypes.GraphQLNonNull;
 import graphql.annotations.annotationTypes.GraphQLPrettify;
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.unomi.api.PropertyType;
+import org.apache.unomi.graphql.schema.CDPPropertyInterfaceRegister;
 import org.apache.unomi.graphql.services.ServiceManager;
 
 @GraphQLName("CDP_ProfilePropertyEdge")
@@ -38,7 +39,7 @@ public class CDPPropertyEdge {
     public CDPPropertyInterface getNode(final DataFetchingEnvironment environment) {
         final ServiceManager serviceManager = environment.getContext();
 
-        return serviceManager.getPropertyInterfaceRegister().getProperty(type);
+        return serviceManager.getService(CDPPropertyInterfaceRegister.class).getProperty(type);
     }
 
     @GraphQLNonNull

--- a/manual/src/archives/1.5/asciidoc/configuration.adoc
+++ b/manual/src/archives/1.5/asciidoc/configuration.adoc
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-=== Configuration
+== Configuration
 
-==== Centralized configuration
+=== Centralized configuration
 
 Apache Unomi uses a centralized configuration file that contains both system properties and configuration properties.
 These settings are then fed to the OSGi and other configuration files using placeholder that look something like this:
@@ -32,7 +32,7 @@ this file directly, as an override mechanism is available. Simply create a file 
 and put your own property values in their to override the defaults OR you can use environment variables to also override
 the values in the `$MY_KARAF_HOME/etc/custom.system.properties`. See the next section for more information about that.
 
-==== Changing the default configuration using environment variables (i.e. Docker configuration)
+=== Changing the default configuration using environment variables (i.e. Docker configuration)
 
 You might want to use environment variables to change the default system configuration, especially if you intend to run
 Apache Unomi inside a Docker container. You can find the list of all the environment variable names in the following file:
@@ -45,7 +45,7 @@ Docker Compose you can put the environment variables in the docker-compose.yml f
 If you want to "save" the environment values in a file, you can use the `bin/setenv(.bat)` to setup the environment
 variables you want to use.
 
-==== Changing the default configuration using property files
+=== Changing the default configuration using property files
 
 If you want to change the default configuration using property files instead of environment variables, you can perform
 any modification you want in the `$MY_KARAF_HOME/etc/unomi.custom.system.properties` file.
@@ -84,7 +84,7 @@ org.apache.unomi.elasticsearch.cluster.name=contextElasticSearch
 org.apache.unomi.elasticsearch.addresses=localhost:9200
 ----
 
-==== Secured events configuration
+=== Secured events configuration
 
 Apache Unomi secures some events by default. It comes out of the box with a default configuration that you can adjust
 by using the centralized configuration file override in `$MY_KARAF_HOME/etc/unomi.custom.system.properties`
@@ -146,7 +146,7 @@ thirdparty.provider1.allowedEvents=login,updateProperties
 ----
 
 
-==== Installing the MaxMind GeoIPLite2 IP lookup database
+=== Installing the MaxMind GeoIPLite2 IP lookup database
 
 Apache Unomi requires an IP database in order to resolve IP addresses to user location.
 The GeoLite2 database can be downloaded from MaxMind here :
@@ -154,7 +154,7 @@ http://dev.maxmind.com/geoip/geoip2/geolite2/[http://dev.maxmind.com/geoip/geoip
 
 Simply download the GeoLite2-City.mmdb file into the "etc" directory.
 
-==== Installing Geonames database
+=== Installing Geonames database
 
 Apache Unomi includes a geocoding service based on the geonames database ( http://www.geonames.org/[http://www.geonames.org/] ). It can be
 used to create conditions on countries or cities.
@@ -168,7 +168,7 @@ import should start right away.
 Otherwise, import should start at the next startup. Import runs in background, but can take about 15 minutes.
 At the end, you should have about 4 million entries in the geonames index.
 
-==== REST API Security
+=== REST API Security
 
 The Apache Unomi Context Server REST API is protected using JAAS authentication and using Basic or Digest HTTP auth.
 By default, the login/password for the REST API full administrative access is "karaf/karaf".
@@ -193,7 +193,7 @@ You should now have SSL setup on Karaf with your certificate, and you can test i
 Changing the default Karaf password can be done by modifying the `org.apache.unomi.security.root.password` in the
 `$MY_KARAF_HOME/etc/unomi.custom.system.properties` file
 
-==== Scripting security
+=== Scripting security
 
 By default, scripting (using in conditions, segments and rules) is controlled by a custom classloader that is quite
 restrictive and using a white-list/black list system. It is controlled through the following property in the
@@ -211,7 +211,7 @@ restrictive configuration.
 If you need, for example when adding a custom item type, to adjust these, please be careful as scripts may be called
 directly from the context.json personalization conditions and therefore should be kept minimal.
 
-==== Automatic profile merging
+=== Automatic profile merging
 
 Apache Unomi is capable of merging profiles based on a common property value. In order to use this, you must
 add the MergeProfileOnPropertyAction to a rule (such as a login rule for example), and configure it with the name
@@ -226,7 +226,7 @@ will use the merged profile.
 To test, simply configure the action in the "login" or "facebookLogin" rules and set it up on the "email" property.
 Upon sending one of the events, all matching profiles will be merged.
 
-==== Securing a production environment
+=== Securing a production environment
 
 Before going live with a project, you should _absolutely_ read the following section that will help you setup a proper
 secure environment for running your context server. 
@@ -293,7 +293,7 @@ Step 4 : Setup a proxy in front of the context server
 As an alternative to an application-level firewall, you could also route all traffic to the context server through
 a proxy, and use it to filter any communication.
 
-==== Integrating with an Apache HTTP web server
+=== Integrating with an Apache HTTP web server
 
 If you want to setup an Apache HTTP web server in from of Apache Unomi, here is an example configuration using
 mod_proxy.
@@ -383,7 +383,7 @@ ProxyPass / http://localhost:8181/ connectiontimeout=20 timeout=300 ttl=120
 ProxyPassReverse / http://localhost:8181/
 ----
 
-==== Changing the default tracking location
+=== Changing the default tracking location
 
 When performing localhost requests to Apache Unomi, a default location will be used to insert values into the session
 to make the location-based personalization still work. You can modify the default location settings using the
@@ -407,7 +407,7 @@ org.apache.unomi.ip.default.longitude=${env:UNOMI_IP_DEFAULT_LONGITUDE:-6.128250
 
 You might want to change these for testing or for demonstration purposes.
 
-==== Apache Karaf SSH Console
+=== Apache Karaf SSH Console
 
 The Apache Karaf SSH console is available inside Apache Unomi, but the port has been changed from the default value of
 8101 to 8102 to avoid conflicts with other Karaf-based products. So to connect to the SSH console you should use:
@@ -420,13 +420,13 @@ ssh -p 8102 karaf@localhost
 or the user/password you have setup to protect the system if you have changed it. You can find the list of Apache Unomi
 shell commands in the "Shell commands" section of the documentation.
 
-==== ElasticSearch authentication and security
+=== ElasticSearch authentication and security
 
 With ElasticSearch 7, it's possible to secure the access to your data. (https://www.elastic.co/guide/en/elasticsearch/reference/7.5/secure-cluster.html[https://www.elastic.co/guide/en/elasticsearch/reference/7.5/secure-cluster.html])
 
 Depending on your ElasticSearch license you may need to install Kibana and enable xpack security: https://www.elastic.co/guide/en/elasticsearch/reference/7.5/configuring-security.html[https://www.elastic.co/guide/en/elasticsearch/reference/7.5/configuring-security.html]
 
-===== User authentication !
+==== User authentication !
 
 If your ElasticSearch have been configured to be only accessible by authenticated users (https://www.elastic.co/guide/en/elasticsearch/reference/7.5/setting-up-authentication.html[https://www.elastic.co/guide/en/elasticsearch/reference/7.5/setting-up-authentication.html])
 
@@ -438,7 +438,7 @@ username=USER
 password=PASSWORD
 ----
 
-===== SSL communication
+==== SSL communication
 
 By default Unomi will communicate with ElasticSearch using `http`
 but you can configure your ElasticSearch server(s) to allow encrypted request using `https`.

--- a/manual/src/archives/1.5/asciidoc/index.adoc
+++ b/manual/src/archives/1.5/asciidoc/index.adoc
@@ -40,11 +40,7 @@ include::web-tracker.adoc[]
 
 include::configuration.adoc[]
 
-include::useful-unomi-urls.adoc[]
-
-include::how-profile-tracking-works.adoc[]
-
-include::context-request-flow.adoc[]
+include::migrations/migrations.adoc[]
 
 == Queries and aggregations
 
@@ -68,9 +64,13 @@ include::clustering.adoc[]
 
 == Reference
 
-include::datamodel.adoc[]
+include::useful-unomi-urls.adoc[]
 
-include::new-data-model.adoc[]
+include::how-profile-tracking-works.adoc[]
+
+include::context-request-flow.adoc[]
+
+include::datamodel.adoc[]
 
 include::builtin-event-types.adoc[]
 

--- a/manual/src/archives/1.5/asciidoc/migrations/migrate-1.4-to-1.5.adoc
+++ b/manual/src/archives/1.5/asciidoc/migrations/migrate-1.4-to-1.5.adoc
@@ -12,8 +12,6 @@
 // limitations under the License.
 //
 
-=== Data Model changes for Apache Unomi 1.5.0
-
 ==== Data model and ElasticSearch 7
 
 Since Apache Unomi version 1.5.0 we decided to upgrade the supported ElasticSearch version to the latest 7.4.2.
@@ -51,26 +49,30 @@ Because of this changes the geonames DB index name is now respecting the index n
 Previously named: `geonames` is now using the index name `context-geonameentry`
 (see: link:#_installing_geonames_database[Documentation about geonames extension]).
 
-===== Migration
+==== Migration steps
 
 In order to migrate the data from ElasticSearch 5 to 7, Unomi provides a migration tool that is directly integrated.
 
-In these migration steps the following is assumed:
+In this migration the following is assumed:
 
-- the ElasticSearch 5 installation is referred to as the `source`
-- the ElasticSearch 7 installation is referred to as the `target`
-- the Unomi 1.4 installation is completely stopped
-- the Unomi 1.5 installation has never been started (just uncompressed)
-- the Unomi 1.5 installation has been configured to connect to the `target` (ElasticSearch 7) cluster
+- the ElasticSearch 5 cluster installation is referred to as the `source`
+- the ElasticSearch 7 cluster installation is referred to as the `target`
+- the Unomi 1.4 cluster installation is completely stopped
+- the Unomi 1.5 cluster installation has never been started (just uncompressed)
+- the Unomi 1.5 cluster installation has been configured to connect to the `target` (ElasticSearch 7) cluster
 
-It is HIGHLY RECOMMENDED to perform a full cluster backup/snapshot of the `source` cluster, and ideally to perform the
-migration on a restore of the `source` cluster. For more information on ElasticSearch 5 snapshots and restore you can
-find it here: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/modules-snapshots.html
+It is HIGHLY RECOMMENDED to perform a full cluster backup/snapshot of the `source` clusters (including ElasticSearch and
+Unomi clusters), and ideally to perform the migration on a restored snapshot of the `source` cluster. For more information
+on ElasticSearch 5 snapshots and restore you can find it here:
 
-Note that it is possible to do the migration procedure on a single machine, but you will need to change the ports on one
-of the ElasticSearch cluster. In the following example we have changed the ports on the `source` cluster, which requires
-a cluster restart to take effect. It is also possible to change the ports on the `target` cluster but those would have
-to be then changed again to your final setting.
+    https://www.elastic.co/guide/en/elasticsearch/reference/5.6/modules-snapshots.html
+
+The way the migration works is that both ElasticSearch 5 AND an ElasticSearch 7 clusters (or just single nodes) will
+be started at the same time, and data will be migrated from the ES 5 to the ES 7 cluster. Note that it is possible to use
+a single node for both the `source` and the `target` clusters to - for example - perform the migration on a single
+machine. If you choose to do that you will have to adjust port numbers on either the `source` or `target` cluster node.
+Changing ports requires a restart of the ES cluster you are modifying. In this example we will illustrate how to migrate
+by modifying the `source` cluster node ports.
 
 So in the `source` 's ElasticSearch 5 `config/elasticsearch.yml` file we have modified the default ports to:
 
@@ -99,6 +101,10 @@ Once in the console launch the migration using the following command:
 
     migrate 1.4.0
 
+Note: the 1.4.0 version is the starting version. If you are starting from a different version (for example a fork), make
+sure that you know what official version of Apache Unomi it corresponds to and you can use the official version number
+as a start version for the migration.
+
 Follow the instructions and answer the prompts. If you used the above configuration as an example you can simply use the
 default values.
 
@@ -108,5 +114,14 @@ ES 5 one.
 Note that it is also possible to change the index prefix to be different from the default `context` value
 so that you could host multiple Apache Unomi instances on the same ElasticSearch cluster.
 
-Important note: only the data that Apache Unomi manages will be migrate. If you have any other data (for example Kibana
+Important note: only the data that Apache Unomi manages will be migrated. If you have any other data (for example Kibana
 or ElasticSearch monitoring indices) they will not be migrated by this migration tool.
+
+Once the migration has completed, you can start the new Unomi instance using:
+
+    unomi:start
+
+You should then validate that all the data has been properly migrated. For example you could issue a command to list
+the profiles:
+
+    profile-list

--- a/manual/src/archives/1.5/asciidoc/migrations/migrations.adoc
+++ b/manual/src/archives/1.5/asciidoc/migrations/migrations.adoc
@@ -1,0 +1,20 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+== Migrations
+
+This section contains information and steps to migrate between major Unomi versions.
+
+=== From version 1.4 to 1.5
+
+include::migrate-1.4-to-1.5.adoc[]

--- a/manual/src/main/asciidoc/configuration.adoc
+++ b/manual/src/main/asciidoc/configuration.adoc
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-=== Configuration
+== Configuration
 
-==== Centralized configuration
+=== Centralized configuration
 
 Apache Unomi uses a centralized configuration file that contains both system properties and configuration properties.
 These settings are then fed to the OSGi and other configuration files using placeholder that look something like this:
@@ -32,7 +32,7 @@ this file directly, as an override mechanism is available. Simply create a file 
 and put your own property values in their to override the defaults OR you can use environment variables to also override
 the values in the `$MY_KARAF_HOME/etc/custom.system.properties`. See the next section for more information about that.
 
-==== Changing the default configuration using environment variables (i.e. Docker configuration)
+=== Changing the default configuration using environment variables (i.e. Docker configuration)
 
 You might want to use environment variables to change the default system configuration, especially if you intend to run
 Apache Unomi inside a Docker container. You can find the list of all the environment variable names in the following file:
@@ -45,7 +45,7 @@ Docker Compose you can put the environment variables in the docker-compose.yml f
 If you want to "save" the environment values in a file, you can use the `bin/setenv(.bat)` to setup the environment
 variables you want to use.
 
-==== Changing the default configuration using property files
+=== Changing the default configuration using property files
 
 If you want to change the default configuration using property files instead of environment variables, you can perform
 any modification you want in the `$MY_KARAF_HOME/etc/unomi.custom.system.properties` file.
@@ -84,7 +84,7 @@ org.apache.unomi.elasticsearch.cluster.name=contextElasticSearch
 org.apache.unomi.elasticsearch.addresses=localhost:9200
 ----
 
-==== Secured events configuration
+=== Secured events configuration
 
 Apache Unomi secures some events by default. It comes out of the box with a default configuration that you can adjust
 by using the centralized configuration file override in `$MY_KARAF_HOME/etc/unomi.custom.system.properties`
@@ -146,7 +146,7 @@ thirdparty.provider1.allowedEvents=login,updateProperties
 ----
 
 
-==== Installing the MaxMind GeoIPLite2 IP lookup database
+=== Installing the MaxMind GeoIPLite2 IP lookup database
 
 Apache Unomi requires an IP database in order to resolve IP addresses to user location.
 The GeoLite2 database can be downloaded from MaxMind here :
@@ -154,7 +154,7 @@ http://dev.maxmind.com/geoip/geoip2/geolite2/[http://dev.maxmind.com/geoip/geoip
 
 Simply download the GeoLite2-City.mmdb file into the "etc" directory.
 
-==== Installing Geonames database
+=== Installing Geonames database
 
 Apache Unomi includes a geocoding service based on the geonames database ( http://www.geonames.org/[http://www.geonames.org/] ). It can be
 used to create conditions on countries or cities.
@@ -168,7 +168,7 @@ import should start right away.
 Otherwise, import should start at the next startup. Import runs in background, but can take about 15 minutes.
 At the end, you should have about 4 million entries in the geonames index.
 
-==== REST API Security
+=== REST API Security
 
 The Apache Unomi Context Server REST API is protected using JAAS authentication and using Basic or Digest HTTP auth.
 By default, the login/password for the REST API full administrative access is "karaf/karaf".
@@ -193,7 +193,7 @@ You should now have SSL setup on Karaf with your certificate, and you can test i
 Changing the default Karaf password can be done by modifying the `org.apache.unomi.security.root.password` in the
 `$MY_KARAF_HOME/etc/unomi.custom.system.properties` file
 
-==== Scripting security
+=== Scripting security
 
 By default, scripting (using in conditions, segments and rules) is controlled by a custom classloader that is quite
 restrictive and using a white-list/black list system. It is controlled through the following property in the
@@ -211,7 +211,7 @@ restrictive configuration.
 If you need, for example when adding a custom item type, to adjust these, please be careful as scripts may be called
 directly from the context.json personalization conditions and therefore should be kept minimal.
 
-==== Automatic profile merging
+=== Automatic profile merging
 
 Apache Unomi is capable of merging profiles based on a common property value. In order to use this, you must
 add the MergeProfileOnPropertyAction to a rule (such as a login rule for example), and configure it with the name
@@ -226,7 +226,7 @@ will use the merged profile.
 To test, simply configure the action in the "login" or "facebookLogin" rules and set it up on the "email" property.
 Upon sending one of the events, all matching profiles will be merged.
 
-==== Securing a production environment
+=== Securing a production environment
 
 Before going live with a project, you should _absolutely_ read the following section that will help you setup a proper
 secure environment for running your context server. 
@@ -293,7 +293,7 @@ Step 4 : Setup a proxy in front of the context server
 As an alternative to an application-level firewall, you could also route all traffic to the context server through
 a proxy, and use it to filter any communication.
 
-==== Integrating with an Apache HTTP web server
+=== Integrating with an Apache HTTP web server
 
 If you want to setup an Apache HTTP web server in from of Apache Unomi, here is an example configuration using
 mod_proxy.
@@ -383,7 +383,7 @@ ProxyPass / http://localhost:8181/ connectiontimeout=20 timeout=300 ttl=120
 ProxyPassReverse / http://localhost:8181/
 ----
 
-==== Changing the default tracking location
+=== Changing the default tracking location
 
 When performing localhost requests to Apache Unomi, a default location will be used to insert values into the session
 to make the location-based personalization still work. You can modify the default location settings using the
@@ -407,7 +407,7 @@ org.apache.unomi.ip.default.longitude=${env:UNOMI_IP_DEFAULT_LONGITUDE:-6.128250
 
 You might want to change these for testing or for demonstration purposes.
 
-==== Apache Karaf SSH Console
+=== Apache Karaf SSH Console
 
 The Apache Karaf SSH console is available inside Apache Unomi, but the port has been changed from the default value of
 8101 to 8102 to avoid conflicts with other Karaf-based products. So to connect to the SSH console you should use:
@@ -420,13 +420,13 @@ ssh -p 8102 karaf@localhost
 or the user/password you have setup to protect the system if you have changed it. You can find the list of Apache Unomi
 shell commands in the "Shell commands" section of the documentation.
 
-==== ElasticSearch authentication and security
+=== ElasticSearch authentication and security
 
 With ElasticSearch 7, it's possible to secure the access to your data. (https://www.elastic.co/guide/en/elasticsearch/reference/7.5/secure-cluster.html[https://www.elastic.co/guide/en/elasticsearch/reference/7.5/secure-cluster.html])
 
 Depending on your ElasticSearch license you may need to install Kibana and enable xpack security: https://www.elastic.co/guide/en/elasticsearch/reference/7.5/configuring-security.html[https://www.elastic.co/guide/en/elasticsearch/reference/7.5/configuring-security.html]
 
-===== User authentication !
+==== User authentication !
 
 If your ElasticSearch have been configured to be only accessible by authenticated users (https://www.elastic.co/guide/en/elasticsearch/reference/7.5/setting-up-authentication.html[https://www.elastic.co/guide/en/elasticsearch/reference/7.5/setting-up-authentication.html])
 
@@ -438,7 +438,7 @@ username=USER
 password=PASSWORD
 ----
 
-===== SSL communication
+==== SSL communication
 
 By default Unomi will communicate with ElasticSearch using `http`
 but you can configure your ElasticSearch server(s) to allow encrypted request using `https`.

--- a/manual/src/main/asciidoc/index.adoc
+++ b/manual/src/main/asciidoc/index.adoc
@@ -40,11 +40,7 @@ include::web-tracker.adoc[]
 
 include::configuration.adoc[]
 
-include::useful-unomi-urls.adoc[]
-
-include::how-profile-tracking-works.adoc[]
-
-include::context-request-flow.adoc[]
+include::migrations/migrations.adoc[]
 
 == Queries and aggregations
 
@@ -68,9 +64,13 @@ include::clustering.adoc[]
 
 == Reference
 
-include::datamodel.adoc[]
+include::useful-unomi-urls.adoc[]
 
-include::new-data-model.adoc[]
+include::how-profile-tracking-works.adoc[]
+
+include::context-request-flow.adoc[]
+
+include::datamodel.adoc[]
 
 include::builtin-event-types.adoc[]
 

--- a/manual/src/main/asciidoc/migrations/migrate-1.4-to-1.5.adoc
+++ b/manual/src/main/asciidoc/migrations/migrate-1.4-to-1.5.adoc
@@ -12,8 +12,6 @@
 // limitations under the License.
 //
 
-=== Data Model changes for Apache Unomi 1.5.0
-
 ==== Data model and ElasticSearch 7
 
 Since Apache Unomi version 1.5.0 we decided to upgrade the supported ElasticSearch version to the latest 7.4.2.
@@ -51,26 +49,30 @@ Because of this changes the geonames DB index name is now respecting the index n
 Previously named: `geonames` is now using the index name `context-geonameentry`
 (see: link:#_installing_geonames_database[Documentation about geonames extension]).
 
-===== Migration
+==== Migration steps
 
 In order to migrate the data from ElasticSearch 5 to 7, Unomi provides a migration tool that is directly integrated.
 
-In these migration steps the following is assumed:
+In this migration the following is assumed:
 
-- the ElasticSearch 5 installation is referred to as the `source`
-- the ElasticSearch 7 installation is referred to as the `target`
-- the Unomi 1.4 installation is completely stopped
-- the Unomi 1.5 installation has never been started (just uncompressed)
-- the Unomi 1.5 installation has been configured to connect to the `target` (ElasticSearch 7) cluster
+- the ElasticSearch 5 cluster installation is referred to as the `source`
+- the ElasticSearch 7 cluster installation is referred to as the `target`
+- the Unomi 1.4 cluster installation is completely stopped
+- the Unomi 1.5 cluster installation has never been started (just uncompressed)
+- the Unomi 1.5 cluster installation has been configured to connect to the `target` (ElasticSearch 7) cluster
 
-It is HIGHLY RECOMMENDED to perform a full cluster backup/snapshot of the `source` cluster, and ideally to perform the
-migration on a restore of the `source` cluster. For more information on ElasticSearch 5 snapshots and restore you can
-find it here: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/modules-snapshots.html
+It is HIGHLY RECOMMENDED to perform a full cluster backup/snapshot of the `source` clusters (including ElasticSearch and
+Unomi clusters), and ideally to perform the migration on a restored snapshot of the `source` cluster. For more information
+on ElasticSearch 5 snapshots and restore you can find it here:
 
-Note that it is possible to do the migration procedure on a single machine, but you will need to change the ports on one
-of the ElasticSearch cluster. In the following example we have changed the ports on the `source` cluster, which requires
-a cluster restart to take effect. It is also possible to change the ports on the `target` cluster but those would have
-to be then changed again to your final setting.
+    https://www.elastic.co/guide/en/elasticsearch/reference/5.6/modules-snapshots.html
+
+The way the migration works is that both ElasticSearch 5 AND an ElasticSearch 7 clusters (or just single nodes) will
+be started at the same time, and data will be migrated from the ES 5 to the ES 7 cluster. Note that it is possible to use
+a single node for both the `source` and the `target` clusters to - for example - perform the migration on a single
+machine. If you choose to do that you will have to adjust port numbers on either the `source` or `target` cluster node.
+Changing ports requires a restart of the ES cluster you are modifying. In this example we will illustrate how to migrate
+by modifying the `source` cluster node ports.
 
 So in the `source` 's ElasticSearch 5 `config/elasticsearch.yml` file we have modified the default ports to:
 
@@ -99,6 +101,10 @@ Once in the console launch the migration using the following command:
 
     migrate 1.4.0
 
+Note: the 1.4.0 version is the starting version. If you are starting from a different version (for example a fork), make
+sure that you know what official version of Apache Unomi it corresponds to and you can use the official version number
+as a start version for the migration.
+
 Follow the instructions and answer the prompts. If you used the above configuration as an example you can simply use the
 default values.
 
@@ -108,5 +114,14 @@ ES 5 one.
 Note that it is also possible to change the index prefix to be different from the default `context` value
 so that you could host multiple Apache Unomi instances on the same ElasticSearch cluster.
 
-Important note: only the data that Apache Unomi manages will be migrate. If you have any other data (for example Kibana
+Important note: only the data that Apache Unomi manages will be migrated. If you have any other data (for example Kibana
 or ElasticSearch monitoring indices) they will not be migrated by this migration tool.
+
+Once the migration has completed, you can start the new Unomi instance using:
+
+    unomi:start
+
+You should then validate that all the data has been properly migrated. For example you could issue a command to list
+the profiles:
+
+    profile-list

--- a/manual/src/main/asciidoc/migrations/migrations.adoc
+++ b/manual/src/main/asciidoc/migrations/migrations.adoc
@@ -1,0 +1,20 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+== Migrations
+
+This section contains information and steps to migrate between major Unomi versions.
+
+=== From version 1.4 to 1.5
+
+include::migrate-1.4-to-1.5.adoc[]


### PR DESCRIPTION
In this PR the idea is to avoid having a ServiceManager class that is hardcoded to specific services, so that it becomes easy to access new services, especially if plugins are added overtime.