### PR TITLE
fix(ContextServletIT) - fix failing integration test

### DIFF
--- a/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/actions/SetEventOccurenceCountAction.java
+++ b/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/actions/SetEventOccurenceCountAction.java
@@ -90,8 +90,8 @@ public class SetEventOccurenceCountAction implements ActionExecutor {
         //Only increase the counter by 1 if the current event is in the now-numberOfDays range
         LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
         LocalDateTime eventTime = LocalDateTime.ofInstant(event.getTimeStamp().toInstant(),ZoneId.of("UTC"));
-        long daysDiff = Duration.between(eventTime,now).toDays();
-        if (daysDiff >= 0 && daysDiff <= numberOfDays) {
+        Duration durationDiff = Duration.between(eventTime,now);
+        if (!durationDiff.isNegative() && durationDiff.toDays() <= numberOfDays) {
             count++;
         }
 


### PR DESCRIPTION
There was an error when checking if the event's timestamp is in the future. 
When calling Duration.toDays(), negative durations are rounded to 0. This caused future events to be calculated as if they match the "pastEvent" condition