### PR TITLE
Use profile id session is in null to see if event has already been raised

### DIFF
--- a/itests/src/test/java/org/apache/unomi/itests/AllITs.java
+++ b/itests/src/test/java/org/apache/unomi/itests/AllITs.java
@@ -39,6 +39,7 @@ import org.junit.runners.Suite.SuiteClasses;
         ProfileImportRankingIT.class,
         ProfileImportActorsIT.class,
         ProfileExportIT.class,
+        EventServiceIT.class,
         PropertiesUpdateActionIT.class,
         ModifyConsentIT.class,
         PatchIT.class,

--- a/itests/src/test/java/org/apache/unomi/itests/EventServiceIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/EventServiceIT.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package org.apache.unomi.itests;
+
+import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.api.services.ProfileService;
+import org.apache.unomi.api.Event;
+import org.apache.unomi.api.Profile;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerSuite;
+import org.ops4j.pax.exam.util.Filter;
+
+import javax.inject.Inject;
+import java.util.Date;
+import org.junit.Assert;
+
+
+/**
+ * An integration test for the event service
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerSuite.class)
+public class EventServiceIT extends BaseIT {
+
+    private final static String TEST_PROFILE_ID = "test-profile-id";
+
+    @Inject @Filter(timeout = 600000)
+    protected EventService eventService;
+
+    @Inject
+    @Filter(timeout = 600000)
+    protected ProfileService profileService;
+
+    @Test
+    public void test_EventExistenceWithProfileId() throws InterruptedException{
+        String eventId = "test-event-id2";
+        String profileId = "test-profile-id";
+        String eventType = "test-type";
+        Profile profile = new Profile(profileId);
+        Event event = new Event(eventId, eventType, null, profile, null, null, null, new Date());
+        profileService.save(profile);
+        eventService.send(event);
+        refreshPersistence();
+        Thread.sleep(2000);
+        boolean exist = eventService.hasEventAlreadyBeenRaised(event);
+        Assert.assertTrue(exist);
+    }
+
+}

--- a/services/src/main/java/org/apache/unomi/services/impl/events/EventServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/events/EventServiceImpl.java
@@ -348,7 +348,13 @@ public class EventServiceImpl implements EventService {
 
     public boolean hasEventAlreadyBeenRaised(Event event) {
         Event pastEvent = this.persistenceService.load(event.getItemId(), Event.class);
-        return pastEvent != null && pastEvent.getVersion() >= 1 && pastEvent.getSessionId().equals(event.getSessionId());
+        if (pastEvent != null && pastEvent.getVersion() >= 1) {
+            if ((pastEvent.getSessionId() != null && pastEvent.getSessionId().equals(event.getSessionId())) ||
+                    (pastEvent.getProfileId() != null && pastEvent.getProfileId().equals(event.getProfileId())))  {
+                return true;
+            }
+        }
+        return false;
     }
 
     public boolean hasEventAlreadyBeenRaised(Event event, boolean session) {


### PR DESCRIPTION
Since adding events with profile ID instead of session ID is now supported, it should be supported also when checking if event has already been raised (otherwise null pointer exception will be thrown)