### PR TITLE
UNOMI-411 Bug fix in profile property condition and add getNestedProperty method

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -37,7 +37,10 @@
             <version>2.2.11</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/api/src/main/java/org/apache/unomi/api/Event.java
+++ b/api/src/main/java/org/apache/unomi/api/Event.java
@@ -17,6 +17,7 @@
 
 package org.apache.unomi.api;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.unomi.api.actions.ActionPostExecutor;
 
 import javax.xml.bind.annotation.XmlTransient;
@@ -321,6 +322,26 @@ public class Event extends Item implements TimestampedItem {
      */
     public Object getProperty(String name) {
         return properties.get(name);
+    }
+
+    /**
+     * Retrieves the value of the nested property identified by the specified name.
+     *
+     * @param name the name of the property to be retrieved, splited in the nested properties with "."
+     * @return the value of the property identified by the specified name
+     */
+    public Object getNestedProperty(String name) {
+        Map properties = this.properties;
+        String[] propertyPath = StringUtils.substringBeforeLast(name, ".").split("\\.");
+        String propertyName = StringUtils.substringAfterLast(name, ".");
+
+        for (String property: propertyPath) {
+            properties = (Map) properties.get(property);
+            if (properties == null) {
+                return null;
+            }
+        }
+        return properties.get(propertyName);
     }
 
     /**

--- a/api/src/main/java/org/apache/unomi/api/Event.java
+++ b/api/src/main/java/org/apache/unomi/api/Event.java
@@ -331,6 +331,10 @@ public class Event extends Item implements TimestampedItem {
      * @return the value of the property identified by the specified name
      */
     public Object getNestedProperty(String name) {
+        if (!name.contains(".")) {
+            return getProperty(name);
+        }
+
         Map properties = this.properties;
         String[] propertyPath = StringUtils.substringBeforeLast(name, ".").split("\\.");
         String propertyName = StringUtils.substringAfterLast(name, ".");

--- a/api/src/main/java/org/apache/unomi/api/Profile.java
+++ b/api/src/main/java/org/apache/unomi/api/Profile.java
@@ -102,6 +102,10 @@ public class Profile extends Item {
      * @return the value of the property identified by the specified name
      */
     public Object getNestedProperty(String name) {
+        if (!name.contains(".")) {
+            return getProperty(name);
+        }
+
         Map properties = this.properties;
         String[] propertyPath = StringUtils.substringBeforeLast(name, ".").split("\\.");
         String propertyName = StringUtils.substringAfterLast(name, ".");

--- a/api/src/main/java/org/apache/unomi/api/Profile.java
+++ b/api/src/main/java/org/apache/unomi/api/Profile.java
@@ -17,6 +17,7 @@
 
 package org.apache.unomi.api;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.unomi.api.segments.Scoring;
 import org.apache.unomi.api.segments.Segment;
 
@@ -92,6 +93,26 @@ public class Profile extends Item {
      */
     public Object getProperty(String name) {
         return properties.get(name);
+    }
+
+    /**
+     * Retrieves the value of the nested property identified by the specified name.
+     *
+     * @param name the name of the property to be retrieved, splited in the nested properties with "."
+     * @return the value of the property identified by the specified name
+     */
+    public Object getNestedProperty(String name) {
+        Map properties = this.properties;
+        String[] propertyPath = StringUtils.substringBeforeLast(name, ".").split("\\.");
+        String propertyName = StringUtils.substringAfterLast(name, ".");
+
+        for (String property: propertyPath) {
+            properties = (Map) properties.get(property);
+            if (properties == null) {
+                return null;
+            }
+        }
+        return properties.get(propertyName);
     }
 
     /**

--- a/itests/src/test/java/org/apache/unomi/itests/EventServiceIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/EventServiceIT.java
@@ -38,12 +38,15 @@ import org.ops4j.pax.exam.util.Filter;
 
 import javax.inject.Inject;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import java.text.SimpleDateFormat;
 import java.text.ParseException;
 
 
 import org.junit.Assert;
+
 
 
 /**
@@ -148,6 +151,22 @@ public class EventServiceIT extends BaseIT {
 
         PartialList<Profile> profiles = profileService.search(query, Profile.class);
         Assert.assertEquals(0, profiles.getList().size());
+    }
+
+    @Test
+    public void test_EventGetNestedProperty() {
+        String nestedProperty = "outerProperty.innerProperty";
+        String testValue = "test-value";
+        String eventId = "test-event-id-" + System.currentTimeMillis();
+        String profileId = "test-profile-id";
+        String eventType = "test-type";
+        Profile profile = new Profile(profileId);
+        Event event = new Event(eventId, eventType, null, profile, null, null, null, new Date());
+        final Map<String, String> innerProperty = new HashMap<>();
+        innerProperty.put("innerProperty", testValue);
+        event.setProperty("outerProperty", innerProperty);
+        String value = (String) event.getNestedProperty(nestedProperty);
+        Assert.assertEquals(testValue, value);
     }
 
 }

--- a/itests/src/test/java/org/apache/unomi/itests/ProfileServiceIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/ProfileServiceIT.java
@@ -37,6 +37,9 @@ import org.ops4j.pax.exam.util.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.inject.Inject;
 
 /**
@@ -133,6 +136,19 @@ public class ProfileServiceIT extends BaseIT {
         finally {
             esPersistenceService.setThrowExceptions(false);
         }
+    }
+
+    @Test
+    public void test_EventGetNestedProperty() {
+        String nestedProperty = "outerProperty.innerProperty";
+        String testValue = "test-value";
+        String profileId = "test-profile-id";
+        Profile profile = new Profile(profileId);
+        final Map<String, String> innerProperty = new HashMap<>();
+        innerProperty.put("innerProperty", testValue);
+        profile.setProperty("outerProperty", innerProperty);
+        String value = (String) profile.getNestedProperty(nestedProperty);
+        assertEquals(testValue, value);
     }
 
 

--- a/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/PropertyConditionEvaluator.java
+++ b/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/PropertyConditionEvaluator.java
@@ -199,6 +199,9 @@ public class PropertyConditionEvaluator implements ConditionEvaluator {
         } else if (actualValue == null) {
             return op.equals("missing");
         } else if (op.equals("exists")) {
+            if (actualValue instanceof List) {
+                return ((List) actualValue).size() > 0;
+            }
             return true;
         } else if (op.equals("equals")) {
             if (actualValue instanceof Collection) {


### PR DESCRIPTION
When querying using "exist" operator in Condition, an existQuery is created and sent to Elasticsearch. According to ES documentation, exist return false the the field in null or empty list - "[]".

The case of an empty list wasn't handled in the eval() method of profile property condition evaluator. Need to return false if the field exist but has a value which is empty list.