### PR TITLE
UNOMI-410 : add patch template

### DIFF
--- a/persistence-elasticsearch/core/src/main/resources/META-INF/cxs/mappings/patch.json
+++ b/persistence-elasticsearch/core/src/main/resources/META-INF/cxs/mappings/patch.json
@@ -1,0 +1,37 @@
+{
+  "dynamic_templates": [
+    {
+      "all": {
+        "match": "*",
+        "match_mapping_type": "string",
+        "mapping": {
+          "type": "text",
+          "analyzer": "folding",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "patchedItemId": {
+      "type": "text"
+    },
+    "patchedItemType": {
+      "type": "text"
+    },
+    "operation": {
+      "type": "text"
+    },
+    "data": {
+      "type": "object"
+    },
+    "lastApplication": {
+      "type": "date"
+    }
+  }
+}


### PR DESCRIPTION
### Description

The patch.json is added with this PR to allow to create the indexes in elastic search for the patch index, this taking into account the configuration file.

### JIRA issue
https://issues.apache.org/jira/browse/UNOMI-410