### PR TITLE
Fix URL for testing in twitter sample documentation

### DIFF
--- a/manual/src/archives/1.3/asciidoc/samples/twitter-sample.adoc
+++ b/manual/src/archives/1.3/asciidoc/samples/twitter-sample.adoc
@@ -47,7 +47,7 @@ cp target/tweet-button-plugin-1.0.0-incubating-SNAPSHOT.jar ../../package/target
 
 ===== Testing the samples
 
-You can now go to http://localhost:8181/index.html[http://localhost:8181/index.html] to test the samples code. The page is very simple, you will see a Twitter button, which, once clicked, will open a new window to tweet about the current page. The original page should be updated with the new values of the properties coming from Unomi. Additionnally, the raw JSON response is displayed.
+You can now go to http://localhost:8181/twitter/index.html[http://localhost:8181/twitter/index.html] to test the samples code. The page is very simple, you will see a Twitter button, which, once clicked, will open a new window to tweet about the current page. The original page should be updated with the new values of the properties coming from Unomi. Additionnally, the raw JSON response is displayed.
 
 We will now explain in greater details some concepts and see how the example works.
 

--- a/manual/src/archives/1.4/asciidoc/samples/twitter-sample.adoc
+++ b/manual/src/archives/1.4/asciidoc/samples/twitter-sample.adoc
@@ -47,7 +47,7 @@ cp target/tweet-button-plugin-1.5.0-SNAPSHOT.jar ../../package/target/unomi-1.5.
 
 ===== Testing the samples
 
-You can now go to http://localhost:8181/index.html[http://localhost:8181/index.html] to test the samples code. The page is very simple, you will see a Twitter button, which, once clicked, will open a new window to tweet about the current page. The original page should be updated with the new values of the properties coming from Unomi. Additionnally, the raw JSON response is displayed.
+You can now go to http://localhost:8181/twitter/index.html[http://localhost:8181/twitter/index.html] to test the samples code. The page is very simple, you will see a Twitter button, which, once clicked, will open a new window to tweet about the current page. The original page should be updated with the new values of the properties coming from Unomi. Additionnally, the raw JSON response is displayed.
 
 We will now explain in greater details some concepts and see how the example works.
 

--- a/manual/src/archives/1.5/asciidoc/samples/twitter-sample.adoc
+++ b/manual/src/archives/1.5/asciidoc/samples/twitter-sample.adoc
@@ -47,7 +47,7 @@ cp target/tweet-button-plugin-2.0.0-SNAPSHOT.jar ../../package/target/unomi-2.0.
 
 ===== Testing the samples
 
-You can now go to http://localhost:8181/index.html[http://localhost:8181/index.html] to test the samples code. The page is very simple, you will see a Twitter button, which, once clicked, will open a new window to tweet about the current page. The original page should be updated with the new values of the properties coming from Unomi. Additionnally, the raw JSON response is displayed.
+You can now go to http://localhost:8181/twitter/index.html[http://localhost:8181/twitter/index.html] to test the samples code. The page is very simple, you will see a Twitter button, which, once clicked, will open a new window to tweet about the current page. The original page should be updated with the new values of the properties coming from Unomi. Additionnally, the raw JSON response is displayed.
 
 We will now explain in greater details some concepts and see how the example works.
 

--- a/manual/src/main/asciidoc/samples/twitter-sample.adoc
+++ b/manual/src/main/asciidoc/samples/twitter-sample.adoc
@@ -47,7 +47,7 @@ cp target/tweet-button-plugin-2.0.0-SNAPSHOT.jar ../../package/target/unomi-2.0.
 
 ===== Testing the samples
 
-You can now go to http://localhost:8181/index.html[http://localhost:8181/index.html] to test the samples code. The page is very simple, you will see a Twitter button, which, once clicked, will open a new window to tweet about the current page. The original page should be updated with the new values of the properties coming from Unomi. Additionnally, the raw JSON response is displayed.
+You can now go to http://localhost:8181/twitter/index.html[http://localhost:8181/twitter/index.html] to test the samples code. The page is very simple, you will see a Twitter button, which, once clicked, will open a new window to tweet about the current page. The original page should be updated with the new values of the properties coming from Unomi. Additionnally, the raw JSON response is displayed.
 
 We will now explain in greater details some concepts and see how the example works.
 


### PR DESCRIPTION
In http://unomi.apache.org/manual/1_5_x/index.html#_twitter_sample it is mentioned "You can now go to http://localhost:8181/index.html to test the samples code. ".

The URL should be http://localhost:8181/twitter/index.html.