### PR TITLE
UNOMI-428: Configure max profiles to merge instead use max size

### DIFF
--- a/kar/src/main/feature/feature.xml
+++ b/kar/src/main/feature/feature.xml
@@ -35,6 +35,7 @@
         <configfile finalname="/etc/org.apache.unomi.web.cfg">mvn:org.apache.unomi/unomi-wab/${project.version}/cfg/unomicfg</configfile>
         <configfile finalname="/etc/org.apache.unomi.persistence.elasticsearch.cfg">mvn:org.apache.unomi/unomi-persistence-elasticsearch-core/${project.version}/cfg/elasticsearchcfg</configfile>
         <configfile finalname="/etc/org.apache.unomi.plugins.request.cfg">mvn:org.apache.unomi/unomi-plugins-request/${project.version}/cfg/requestcfg</configfile>
+        <configfile finalname="/etc/org.apache.unomi.plugins.base.cfg">mvn:org.apache.unomi/unomi-plugins-base/${project.version}/cfg/pluginsbasecfg</configfile>
         <configfile finalname="/etc/org.apache.unomi.services.cfg">mvn:org.apache.unomi/unomi-services/${project.version}/cfg/servicescfg</configfile>
         <configfile finalname="/etc/org.apache.unomi.thirdparty.cfg">mvn:org.apache.unomi/unomi-services/${project.version}/cfg/thirdpartycfg</configfile>
         <configfile finalname="/etc/org.apache.unomi.cluster.cfg">mvn:org.apache.unomi/unomi-services/${project.version}/cfg/clustercfg</configfile>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -238,6 +238,17 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.apache.unomi</groupId>
+                                    <artifactId>unomi-plugins-base</artifactId>
+                                    <version>${project.version}</version>
+                                    <classifier>pluginsbasecfg</classifier>
+                                    <type>cfg</type>
+                                    <outputDirectory>
+                                        ${project.build.directory}/assembly/etc
+                                    </outputDirectory>
+                                    <destFileName>org.apache.unomi.plugins.base.cfg</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.unomi</groupId>
                                     <artifactId>unomi-plugins-mail</artifactId>
                                     <version>${project.version}</version>
                                     <classifier>mailcfg</classifier>

--- a/package/src/main/resources/etc/custom.system.properties
+++ b/package/src/main/resources/etc/custom.system.properties
@@ -278,6 +278,11 @@ org.apache.unomi.mail.server.password=${env:UNOMI_MAIL_PASSWORD:-}
 org.apache.unomi.mail.server.sslOnConnect=${env:UNOMI_MAIL_SSLONCONNECT:-true}
 
 #######################################################################################################################
+## baseplugin settings                                                                                                 ##
+#######################################################################################################################
+org.apache.unomi.plugins.base.maxProfilesInOneMerge=${env:UNOMI_MAX_PROFILES_IN_ONE_MERGE:--1}
+
+#######################################################################################################################
 ## Security settings                                                                                                 ##
 #######################################################################################################################
 org.apache.unomi.security.encryption.enabled=${env:UNOMI_ENCRYPTION_ENABLED:-false}

--- a/plugins/baseplugin/pom.xml
+++ b/plugins/baseplugin/pom.xml
@@ -132,6 +132,30 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>
+                                        src/main/resources/org.apache.unomi.plugins.base.cfg
+                                    </file>
+                                    <type>cfg</type>
+                                    <classifier>pluginsbasecfg</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/actions/MergeProfilesOnPropertyAction.java
+++ b/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/actions/MergeProfilesOnPropertyAction.java
@@ -45,6 +45,7 @@ public class MergeProfilesOnPropertyAction implements ActionExecutor {
     private DefinitionsService definitionsService;
     private PrivacyService privacyService;
     private ConfigSharingService configSharingService;
+    private int maxProfilesInOneMerge = -1;
 
     public int execute(Action action, Event event) {
         String profileIdCookieName = (String) configSharingService.getProperty("profileIdCookieName");
@@ -86,7 +87,7 @@ public class MergeProfilesOnPropertyAction implements ActionExecutor {
         c.setParameter("operator", "and");
         c.setParameter("subConditions", Arrays.asList(propertyCondition, excludeMergedProfilesCondition));
 
-        final List<Profile> profiles = persistenceService.query(c, "properties.firstVisit", Profile.class);
+        final List<Profile> profiles = persistenceService.query(c, "properties.firstVisit", Profile.class, 0, maxProfilesInOneMerge).getList();
 
         // Check if the user switched to another profile
         if (StringUtils.isNotEmpty(mergeProfilePreviousPropertyValue) && !mergeProfilePreviousPropertyValue.equals(mergeProfilePropertyValue)) {
@@ -245,6 +246,10 @@ public class MergeProfilesOnPropertyAction implements ActionExecutor {
 
     public void setConfigSharingService(ConfigSharingService configSharingService) {
         this.configSharingService = configSharingService;
+    }
+
+    public void setMaxProfilesInOneMerge(String maxProfilesInOneMerge) {
+        this.maxProfilesInOneMerge = Integer.parseInt(maxProfilesInOneMerge);
     }
 
 }

--- a/plugins/baseplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/plugins/baseplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,6 +26,7 @@
         <cm:default-properties>
             <cm:property name="useEventToUpdateProfile" value="false"/>
             <cm:property name="usePropertyConditionOptimizations" value="true"/>
+            <cm:property name="maxProfilesInOneMerge" value="-1"/>
         </cm:default-properties>
     </cm:property-placeholder>
 
@@ -272,6 +273,7 @@
             <property name="definitionsService" ref="definitionsService"/>
             <property name="privacyService" ref="privacyService"/>
             <property name="configSharingService" ref="configSharingService"/>
+            <property name="maxProfilesInOneMerge" value="${base.maxProfilesInOneMerge}"/>
         </bean>
     </service>
 

--- a/plugins/baseplugin/src/main/resources/org.apache.unomi.plugins.base.cfg
+++ b/plugins/baseplugin/src/main/resources/org.apache.unomi.plugins.base.cfg
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+maxProfilesInOneMerge=${org.apache.unomi.plugins.base.maxProfilesInOneMerge:--1}


### PR DESCRIPTION
JIRA ticket - https://issues.apache.org/jira/browse/UNOMI-428
Added the ability to configure max profiles to merge in a merge action (instead using "-1" hard coded), due to performance issues - when the size is "-1" , the `query()` call generates additional 2 calls - scroll query and the deletion of the scroll.
This is not needed when we know there is a few profiles to merge.

note - since the baseplugin has no cgf file, I wasn't sure what should be done in order to expose it to environment variable (currently it is configurable only from the blueprint file). Would be glad to get your advise about that. Thanks