### PR TITLE
UNOMI-438 Fix broken GraphQL Playground

### DIFF
--- a/graphql/graphql-playground/pom.xml
+++ b/graphql/graphql-playground/pom.xml
@@ -30,7 +30,7 @@
     <packaging>bundle</packaging>
 
     <properties>
-        <yarn.arguments>build:production</yarn.arguments>
+        <yarn.arguments>build</yarn.arguments>
     </properties>
 
     <dependencies>

--- a/graphql/graphql-playground/webpack.config.js
+++ b/graphql/graphql-playground/webpack.config.js
@@ -23,15 +23,9 @@ module.exports = (env, argv) => {
         output: {
             path: path.resolve(__dirname, 'target/javascript'),
             filename: 'unomi-graphql-playground.js',
-            chunkFilename: '[name].[chunkhash:6].js'
         },
         resolve: {
             extensions: ['*', '.js', '.jsx']
-        },
-        optimization: {
-            splitChunks: {
-                maxSize: 400000
-            }
         },
         module: {
             rules: [


### PR DESCRIPTION
- Remove chunking optimization from Webpack configuration
- Switch Webpack back to development mode.
