### PR TITLE
UNOMI-440: Add explicit call to update the current profile id of the event

### DIFF
--- a/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/actions/MergeProfilesOnPropertyAction.java
+++ b/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/actions/MergeProfilesOnPropertyAction.java
@@ -179,6 +179,13 @@ public class MergeProfilesOnPropertyAction implements ActionExecutor {
                     @Override
                     public boolean execute() {
                         try {
+                            Event currentEvent = event;
+                            // Update current event explicitly, as it might not return from search query if there wasn't a refresh in ES
+                            if (!StringUtils.equals(profileId, masterProfileId)) {
+                                if (currentEvent.isPersistent()) {
+                                    persistenceService.update(currentEvent, currentEvent.getTimeStamp(), Event.class, "profileId", anonymousBrowsing ? null : masterProfileId);
+                                }                            }
+
                             for (Profile profile : profiles) {
                                 String profileId = profile.getItemId();
                                 if (!StringUtils.equals(profileId, masterProfileId)) {
@@ -195,7 +202,9 @@ public class MergeProfilesOnPropertyAction implements ActionExecutor {
 
                                     List<Event> events = persistenceService.query("profileId", profileId, null, Event.class);
                                     for (Event event : events) {
-                                        persistenceService.update(event, event.getTimeStamp(), Event.class, "profileId", anonymousBrowsing ? null : masterProfileId);
+                                        if (!event.getItemId().equals(currentEvent.getItemId())) {
+                                            persistenceService.update(event, event.getTimeStamp(), Event.class, "profileId", anonymousBrowsing ? null : masterProfileId);
+                                        }
                                     }
                                     // we must mark all the profiles that we merged into the master as merged with the master, and they will
                                     // be deleted upon next load


### PR DESCRIPTION
Jira task - https://issues.apache.org/jira/browse/UNOMI-440

On merge action, the profile id of the events is updated to be the master profile.
Since the event is saved in ES and right after is updated - it might not return in the query. As a result, the profile id might not be updated.

Added an explicit update.