### PR TITLE
[UNOMI-479] Docker: Checks if there is auth needed for ES and adds credentials to url in entrypoint.sh

### DIFF
--- a/docker/src/main/docker/entrypoint.sh
+++ b/docker/src/main/docker/entrypoint.sh
@@ -18,10 +18,17 @@
 ################################################################################
 # Wait for heathy ElasticSearch
 # next wait for ES status to turn to Green
-health_check="$(curl -fsSL "$UNOMI_ELASTICSEARCH_ADDRESSES/_cat/health?h=status")"
+
+if [ -v UNOMI_ELASTICSEARCH_USERNAME ] && [ -v UNOMI_ELASTICSEARCH_PASSWORD ]; then
+  elasticsearch_addresses="$UNOMI_ELASTICSEARCH_USERNAME:$UNOMI_ELASTICSEARCH_PASSWORD@$UNOMI_ELASTICSEARCH_ADDRESSES/_cat/health?h=status"
+else
+  elasticsearch_addresses="$UNOMI_ELASTICSEARCH_ADDRESSES/_cat/health?h=status"
+fi
+
+health_check="$(curl -fsSL "$elasticsearch_addresses")"
 
 until ([ "$health_check" = 'yellow' ] || [ "$health_check" = 'green' ]); do
-    health_check="$(curl -fsSL "$UNOMI_ELASTICSEARCH_ADDRESSES/_cat/health?h=status")"
+    health_check="$(curl -fsSL $elasticsearch_addresses)"
     >&2 echo "Elastic Search is not yet available - waiting (health check=$health_check)..."
     sleep 1
 done


### PR DESCRIPTION
PR Title format: 

    [UNOMI-479] Docker image will not start if elastic search needs authorization 

Checks if there is authorization needed and adds credentials to url. 

----

**Please** following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/UNOMI) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[UNOMI-479] - Title of the pull request`
 - [ ] Provide integration tests for your changes, especially if you are changing the behavior of existing code or adding
       significant new parts of code.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why. 
       Copy the description to the related JIRA issue
 - [x] Run `mvn clean install -P integration-tests` to make sure basic checks pass. A more thorough check will be 
        performed on your pull request automatically.
 
Trivial changes like typos do not require a JIRA issue (javadoc, project build changes, small doc changes, comments...). 
 
If this is your first contribution, you have to read the [Contribution Guidelines](https://unomi.apache.org/contribute.html)

If your pull request is about ~20 lines of code you don't need to sign an [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) 
if you are unsure please ask on the developers list.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
