### PR TITLE
UNOMI-496 Fix NestedNulllException on increment property/interest integration tests

### DIFF
--- a/itests/src/test/java/org/apache/unomi/itests/IncrementInterestsIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/IncrementInterestsIT.java
@@ -76,7 +76,7 @@ public class IncrementInterestsIT extends BaseIT {
     public void setup() throws Exception {
         topic = createTopic("topicId");
         profile = createProfile();
-        rule = new Rule();
+        rule = new Rule(new Metadata(null, UUID.randomUUID().toString(), "IncrementInterestRule", "Test rule for IncrementInterestIT automated tests"));
     }
 
     @After
@@ -140,7 +140,16 @@ public class IncrementInterestsIT extends BaseIT {
 
         Map<String, Object> properties = new HashMap<>();
 
+        Map<String,Object> pageInfo = new HashMap<>();
+        pageInfo.put("language", "en");
+        pageInfo.put("destinationURL", "https://www.acme.com/test-page.html");
+        pageInfo.put("referringURL", "https://unomi.apache.org");
+        pageInfo.put("pageID", "ITEM_ID_PAGE");
+        pageInfo.put("pagePath", "/test-page.html");
+        pageInfo.put("pageName", "Test page");
+
         properties.put("interests", interestsAsMap);
+        properties.put("pageInfo", pageInfo);
 
         CustomItem item = new CustomItem("page", ITEM_TYPE_PAGE);
         item.setProperties(properties);

--- a/itests/src/test/java/org/apache/unomi/itests/IncrementPropertyIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/IncrementPropertyIT.java
@@ -385,7 +385,18 @@ public class IncrementPropertyIT extends BaseIT {
 
         CustomItem target = new CustomItem("ITEM_ID_PAGE", ITEM_TYPE_PAGE);
         target.setScope("acme-space");
-        if (targetProperties != null) target.setProperties(targetProperties);
+        if (targetProperties == null) {
+            targetProperties = new HashMap<>();
+        }
+        Map<String, Object> pageInfo = new HashMap<>();
+        pageInfo.put("language", "en");
+        pageInfo.put("destinationURL", "https://www.acme.com/test-page.html");
+        pageInfo.put("referringURL", "https://unomi.apache.org");
+        pageInfo.put("pageID", "ITEM_ID_PAGE");
+        pageInfo.put("pagePath", "/test-page.html");
+        pageInfo.put("pageName", "Test page");
+        targetProperties.put("pageInfo", pageInfo);
+        target.setProperties(targetProperties);
 
         event = new Event("view", null, profile, null, null, target, new Date());
         event.setPersistent(false);


### PR DESCRIPTION
This PR contains the following fixes:
- Proper rule setup with an itemId that was causing the improper teardown of the IncrementInterestsIT
- Proper creation of the pageInfo structure that was causing the NestedNullException on the integration tests