### PR TITLE
UNOMI-188 Replace persistence service settings with OSGi config admin properties

### DIFF
--- a/itests/src/test/java/org/apache/unomi/itests/ProfileServiceIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/ProfileServiceIT.java
@@ -34,9 +34,11 @@ import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerSuite;
 import org.ops4j.pax.exam.util.Filter;
+import org.osgi.service.cm.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -119,9 +121,14 @@ public class ProfileServiceIT extends BaseIT {
 
     // Relevant only when throwExceptions system property is true
     @Test
-    public void testGetProfileWithWrongScrollerIdThrowException() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
-        boolean throwExceptionCurrent = (boolean) persistenceService.getSetting("throwExceptions");
-        persistenceService.setSetting("throwExceptions", true);
+    public void testGetProfileWithWrongScrollerIdThrowException() throws InterruptedException, NoSuchFieldException, IllegalAccessException, IOException {
+        boolean throwExceptionCurrent = false;
+        Configuration elasticSearchConfiguration = configurationAdmin.getConfiguration("org.apache.unomi.persistence.elasticsearch");
+        if (elasticSearchConfiguration != null) {
+            throwExceptionCurrent = Boolean.getBoolean((String) elasticSearchConfiguration.getProperties().get("throwExceptions"));
+        }
+
+        updateConfiguration(PersistenceService.class.getName(), "org.apache.unomi.persistence.elasticsearch", "throwExceptions", true);
 
         Query query = new Query();
         query.setLimit(2);
@@ -135,7 +142,7 @@ public class ProfileServiceIT extends BaseIT {
             // Should get here since this scenario should throw exception
         }
         finally {
-            persistenceService.setSetting("throwExceptions", throwExceptionCurrent);
+            updateConfiguration(PersistenceService.class.getName(), "org.apache.unomi.persistence.elasticsearch", "throwExceptions", throwExceptionCurrent);
         }
     }
 

--- a/persistence-spi/src/main/java/org/apache/unomi/persistence/spi/PersistenceService.java
+++ b/persistence-spi/src/main/java/org/apache/unomi/persistence/spi/PersistenceService.java
@@ -82,35 +82,6 @@ public interface PersistenceService {
     <T extends Item> PartialList<T> getAllItems(final Class<T> clazz, int offset, int size, String sortBy, String scrollTimeValidity);
 
     /**
-     * Set settings of the persistence service
-     *
-     * @param settings map of setting name and it's value
-     * @throws NoSuchFieldException if the field does not exist
-     * @throws IllegalAccessException field is not accessible to be changed
-     */
-    void setSettings(Map<String, Object> settings) throws NoSuchFieldException, IllegalAccessException;
-
-    /**
-     * Set settings of the persistence service
-     *
-     * @param fieldName name of the field to set
-     * @param value value of the field to set
-     * @throws NoSuchFieldException if the field does not exist
-     * @throws IllegalAccessException field is not accessible to be changed
-     */
-    void setSetting(String fieldName, Object value) throws NoSuchFieldException, IllegalAccessException;
-
-    /**
-     * Get settings of the persistence service
-     *
-     * @param fieldName name of the field to get
-     * @return an object corresponding to the field that was accessed
-     * @throws NoSuchFieldException if the field does not exist
-     * @throws IllegalAccessException field is not accessible to be changed
-     */
-    Object getSetting(String fieldName) throws NoSuchFieldException, IllegalAccessException;
-
-    /**
      * Return true if the item which is saved in the persistence service is consistent
      *
      * @param item the item to the check if consistent


### PR DESCRIPTION

- The getSetting/setSettings(s) methods on the persistence service could be potentially abused and cause security issues so they are replaced by using OSGi configuration administration property updates

