### PR TITLE
[UNOMI-445] Implement support for multiple profile IDs on Unomi profiles

### DIFF
--- a/api/src/main/java/org/apache/unomi/api/ContextRequest.java
+++ b/api/src/main/java/org/apache/unomi/api/ContextRequest.java
@@ -73,6 +73,8 @@ public class ContextRequest {
     @Pattern(regexp = ValidationPattern.TEXT_VALID_CHARACTERS_PATTERN)
     private String profileId;
 
+    private String clientId;
+
     /**
      * Retrieves the source of the context request.
      *
@@ -270,5 +272,13 @@ public class ContextRequest {
      */
     public void setProfileId(String profileId) {
         this.profileId = profileId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
     }
 }

--- a/api/src/main/java/org/apache/unomi/api/Event.java
+++ b/api/src/main/java/org/apache/unomi/api/Event.java
@@ -46,6 +46,12 @@ public class Event extends Item implements TimestampedItem {
      * A constant for the name of the attribute that can be used to retrieve the current HTTP response.
      */
     public static final String HTTP_RESPONSE_ATTRIBUTE = "http_response";
+
+    /**
+     * A constant for the name of the attribute that can be used to retrieve the current clientID.
+     */
+    public static final String CLIENT_ID_ATTRIBUTE = "client_id";
+
     private static final long serialVersionUID = -1096874942838593575L;
     private String eventType;
     private String sessionId = null;

--- a/api/src/main/java/org/apache/unomi/api/ProfileAlias.java
+++ b/api/src/main/java/org/apache/unomi/api/ProfileAlias.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.unomi.api;
+
+import java.util.Date;
+
+public class ProfileAlias extends Item {
+
+    public static final String ITEM_TYPE = "profileAlias";
+
+    private String profileID;
+
+    private String clientID;
+
+    private Date creationTime;
+
+    private Date modifiedTime;
+
+    public ProfileAlias() {
+    }
+
+    public String getProfileID() {
+        return profileID;
+    }
+
+    public void setProfileID(String profileID) {
+        this.profileID = profileID;
+    }
+
+    public String getClientID() {
+        return clientID;
+    }
+
+    public void setClientID(String clientID) {
+        this.clientID = clientID;
+    }
+
+    public Date getCreationTime() {
+        return creationTime;
+    }
+
+    public void setCreationTime(Date creationTime) {
+        this.creationTime = creationTime;
+    }
+
+    public Date getModifiedTime() {
+        return modifiedTime;
+    }
+
+    public void setModifiedTime(Date modifiedTime) {
+        this.modifiedTime = modifiedTime;
+    }
+}

--- a/api/src/main/java/org/apache/unomi/api/services/ProfileService.java
+++ b/api/src/main/java/org/apache/unomi/api/services/ProfileService.java
@@ -108,6 +108,8 @@ public interface ProfileService {
      */
     Profile save(Profile profile);
 
+    void addAliasToProfile(String profileID, String alias, String clientID);
+
     /**
      * Merge the specified profile properties in an existing profile,or save new profile if it does not exist yet
      *

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileDataFetcher.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/fetchers/profile/ProfileDataFetcher.java
@@ -52,6 +52,9 @@ public class ProfileDataFetcher extends BaseDataFetcher<CDPProfile> {
             profile.setItemType("profile");
 
             profile = profileService.save(profile);
+
+            profileService.addAliasToProfile(profile.getItemId(), profile.getItemId(), profileIDInput.getClient().getId());
+
             return new CDPProfile(profile);
         }
 

--- a/itests/src/test/java/org/apache/unomi/itests/ProfileMergeIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/ProfileMergeIT.java
@@ -19,12 +19,15 @@ package org.apache.unomi.itests;
 import org.apache.unomi.api.Event;
 import org.apache.unomi.api.Metadata;
 import org.apache.unomi.api.Profile;
+import org.apache.unomi.api.ProfileAlias;
 import org.apache.unomi.api.actions.Action;
 import org.apache.unomi.api.conditions.Condition;
 import org.apache.unomi.api.rules.Rule;
 import org.apache.unomi.api.services.DefinitionsService;
 import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.api.services.RulesService;
+import org.apache.unomi.persistence.spi.PersistenceService;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -38,6 +41,7 @@ import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Integration test for MergeProfilesOnPropertyAction
@@ -52,6 +56,10 @@ public class ProfileMergeIT extends BaseIT {
     protected RulesService rulesService;
     @Inject @Filter(timeout = 600000)
     protected DefinitionsService definitionsService;
+    @Inject @Filter(timeout = 600000)
+    protected ProfileService profileService;
+    @Inject @Filter(timeout = 600000)
+    protected PersistenceService persistenceService;
 
     private final static String TEST_EVENT_TYPE = "mergeProfileTestEventType";
     private final static String TEST_RULE_ID = "mergeOnPropertyTest";
@@ -79,6 +87,59 @@ public class ProfileMergeIT extends BaseIT {
 
         // No new profile should be created, instead the profile of the event should be used.
         Assert.assertEquals(sendEvent().getProfile().getItemId(), TEST_PROFILE_ID);
+    }
+
+    @Test
+    public void test() throws InterruptedException {
+        // create rule
+        Condition condition = new Condition(definitionsService.getConditionType("eventTypeCondition"));
+        condition.setParameter("eventTypeId", TEST_EVENT_TYPE);
+
+        final Action action = new Action( definitionsService.getActionType( "mergeProfilesOnPropertyAction"));
+        action.setParameter("mergeProfilePropertyValue", "eventProperty::target.properties(email)");
+        action.setParameter("mergeProfilePropertyName", "mergeIdentifier");
+        action.setParameter("forceEventProfileAsMaster", false);
+
+        Rule rule = new Rule();
+        rule.setMetadata(new Metadata(null, TEST_RULE_ID, TEST_RULE_ID, "Description"));
+        rule.setCondition(condition);
+        rule.setActions(Collections.singletonList(action));
+
+        rulesService.setRule(rule);
+        refreshPersistence();
+
+        // create master profile
+        Profile masterProfile = new Profile();
+        masterProfile.setItemId("masterProfileID");
+        masterProfile.setProperty("email", "username@domain.com");
+        masterProfile.setSystemProperty("mergeIdentifier", "username@domain.com");
+        profileService.save(masterProfile);
+
+        // create event profile
+        Profile eventProfile = new Profile();
+        eventProfile.setItemId("eventProfileID");
+        eventProfile.setProperty("email", "username@domain.com");
+        profileService.save(eventProfile);
+
+        refreshPersistence();
+
+        Event event = new Event(TEST_EVENT_TYPE, null, eventProfile, null, null, eventProfile, new Date());
+        eventService.send(event);
+
+        refreshPersistence();
+
+        Assert.assertNotNull(event.getProfile());
+
+        List<ProfileAlias> profileAliases = persistenceService.getAllItems(ProfileAlias.class);
+
+        Assert.assertFalse(profileAliases.isEmpty());
+
+        List<ProfileAlias> aliases = persistenceService.query("profileID", masterProfile.getItemId(), null, ProfileAlias.class);
+
+        Assert.assertFalse(aliases.isEmpty());
+        Assert.assertEquals(masterProfile.getItemId(), aliases.get(0).getProfileID());
+        Assert.assertEquals(eventProfile.getItemId(), aliases.get(0).getItemId());
+        Assert.assertEquals("defaultClientId", aliases.get(0).getClientID());
     }
 
     private Event sendEvent() {

--- a/itests/src/test/java/org/apache/unomi/itests/ProfileServiceIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/ProfileServiceIT.java
@@ -17,6 +17,7 @@
 package org.apache.unomi.itests;
 
 import org.apache.unomi.api.Profile;
+import org.apache.unomi.api.ProfileAlias;
 import org.apache.unomi.api.query.Query;
 import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.persistence.spi.PersistenceService;
@@ -25,6 +26,7 @@ import org.apache.unomi.api.PartialList;
 import org.apache.unomi.persistence.elasticsearch.*;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import javax.inject.Inject;
 
@@ -159,5 +162,42 @@ public class ProfileServiceIT extends BaseIT {
         assertEquals(testValue, value);
     }
 
+    @Test
+    public void testLoadProfileByAlias() throws Exception {
+        String profileID = "profileID_testLoadProfileByAlias";
+        try {
+            Profile profile = new Profile();
+            profile.setItemId(profileID);
+            profileService.save(profile);
+
+            refreshPersistence();
+
+            IntStream.range(1, 3).forEach(index -> {
+                final String profileAlias = profileID + "_alias_" + index;
+                profileService.addAliasToProfile(profileID, profileAlias, "clientID");
+            });
+
+            refreshPersistence();
+
+            Profile storedProfile = profileService.load(profileID);
+            assertNotNull(storedProfile);
+            assertEquals(profileID, storedProfile.getItemId());
+
+            storedProfile = profileService.load(profileID + "_alias_1");
+            assertNotNull(storedProfile);
+            assertEquals(profileID, storedProfile.getItemId());
+
+            storedProfile = profileService.load(profileID + "_alias_2");
+            assertNotNull(storedProfile);
+            assertEquals(profileID, storedProfile.getItemId());
+        } finally {
+            profileService.delete(profileID, false);
+
+            IntStream.range(1, 3).forEach(index -> {
+                final String profileAlias = profileID + "_alias_" + index;
+                persistenceService.remove(profileAlias, ProfileAlias.class);
+            });
+        }
+    }
 
 }

--- a/persistence-spi/src/main/java/org/apache/unomi/persistence/spi/CustomObjectMapper.java
+++ b/persistence-spi/src/main/java/org/apache/unomi/persistence/spi/CustomObjectMapper.java
@@ -79,6 +79,7 @@ public class CustomObjectMapper extends ObjectMapper {
         classes.put(ActionType.ITEM_TYPE, ActionType.class);
         classes.put(Topic.ITEM_TYPE, Topic.class);
         classes.put(SourceItem.ITEM_TYPE, SourceItem.class);
+        classes.put(ProfileAlias.ITEM_TYPE, ProfileAlias.class);
         for (Map.Entry<String, Class<? extends Item>> entry : classes.entrySet()) {
             propertyTypedObjectDeserializer.registerMapping("itemType=" + entry.getKey(), entry.getValue());
             itemDeserializer.registerMapping(entry.getKey(), entry.getValue());


### PR DESCRIPTION
This PR introduces aliases on Unomi profiles. Using these aliases we are able to lookup the same profile for different clients.
----

**Please** following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [UNOMI-445](https://issues.apache.org/jira/browse/UNOMI-445) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[UNOMI-XXX] - Title of the pull request`
 - [x] Provide integration tests for your changes, especially if you are changing the behavior of existing code or adding
       significant new parts of code.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why. 
       Copy the description to the related JIRA issue
 - [x] Run `mvn clean install -P integration-tests` to make sure basic checks pass. A more thorough check will be 
        performed on your pull request automatically.
