### PR TITLE
UNOMI-516 Fix bug in migration

### DIFF
--- a/tools/shell-commands/src/main/java/org/apache/unomi/shell/migration/impl/MigrationTo150.java
+++ b/tools/shell-commands/src/main/java/org/apache/unomi/shell/migration/impl/MigrationTo150.java
@@ -259,7 +259,11 @@ public class MigrationTo150 implements Migration {
             mappings.put("dynamic_templates", newTypeMappings.getJSONArray("dynamic_templates"));
         }
         if (newTypeMappings.has("properties")) {
-            mappings.put("properties", getMergedPropertyMappings(mappings.getJSONObject("properties"), newTypeMappings.getJSONObject("properties")));
+            if (mappings.has("properties")) {
+                mappings.put("properties", getMergedPropertyMappings(mappings.getJSONObject("properties"), newTypeMappings.getJSONObject("properties")));
+            } else {
+                mappings.put("properties", newTypeMappings.getJSONObject("properties"));
+            }
         }
         return new JSONObject().put("mappings", mappings);
     }


### PR DESCRIPTION
This PR fixes an issue when the source ES 5.6 ElasticSearch contains types that have no mappings (such as the importconfig if never used).