### PR TITLE
UNOMI-518 : improve tracked conditions parameter resolution

### DIFF
--- a/itests/src/test/java/org/apache/unomi/itests/RuleServiceIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/RuleServiceIT.java
@@ -196,14 +196,16 @@ public class RuleServiceIT extends BaseIT {
             ConditionBuilder builder = new ConditionBuilder(definitionsService);
             Rule trackParameterRule = new Rule(new Metadata(TEST_SCOPE, "tracked-parameter-rule", "Tracked parameter rule", "A rule with tracked parameter"));
             Condition trackedCondition = builder.condition("clickEventCondition").build();
-            trackedCondition.setParameter("tracked_properties_pageInfo_pagePath", "/test-page.html");
+            trackedCondition.setParameter("path", "/test-page.html");
+            trackedCondition.setParameter("referrer", "https://unomi.apache.org");
             trackedCondition.getConditionType().getMetadata().getSystemTags().add("trackedCondition");
             trackParameterRule.setCondition(trackedCondition);
             rulesService.setRule(trackParameterRule);
             // Add rule that has a trackParameter condition that does not match
             Rule unTrackParameterRule = new Rule(new Metadata(TEST_SCOPE, "not-tracked-parameter-rule", "Not Tracked parameter rule", "A rule that has a parameter not tracked"));
             Condition unTrackedCondition = builder.condition("clickEventCondition").build();
-            unTrackedCondition.setParameter("tracked_properties_pageInfo_pagePath", "/test-page-that-does-not-exist.html");
+            unTrackedCondition.setParameter("path", "/test-page.html");
+            unTrackedCondition.setParameter("referrer", "https://localhost");
             unTrackedCondition.getConditionType().getMetadata().getSystemTags().add("trackedCondition");
             unTrackParameterRule.setCondition(unTrackedCondition);
             rulesService.setRule(unTrackParameterRule);

--- a/itests/src/test/resources/testClickEventCondition.json
+++ b/itests/src/test/resources/testClickEventCondition.json
@@ -26,9 +26,11 @@
           }
         },
         {
-          "type": "sourceEventPropertyCondition",
+          "type": "eventPropertyCondition",
           "parameterValues": {
-            "path": "parameter::tracked_properties_pageInfo_pagePath"
+            "propertyName": "source.properties.pageInfo.pagePath",
+            "propertyValue": "parameter::path",
+            "comparisonOperator": "equals"
           }
         },
         {
@@ -45,9 +47,20 @@
   },
   "parameters": [
     {
-      "id": "tracked_properties_pageInfo_pagePath",
+      "id": "path",
       "type": "string",
       "multivalued": false
+    },
+    {
+      "id": "referrer",
+      "type": "string",
+      "multivalued": false
+    },
+    {
+      "id": "trackedConditionParameters",
+      "type": "string",
+      "multivalued": false,
+      "defaultValue": "path:properties.pageInfo.pagePath,referrer:properties.pageInfo.referringURL"
     },
     {
       "id": "itemId",


### PR DESCRIPTION
UNOMI-518 :
Improve tracked condition.
Define list of parameter to check in order to get tracked rules to evaluate.
Use `trackedConditionParameters` as condition parameter to set the mapping between parameters and source item form the event. 
Covered by unit test