### PR TITLE
UNOMI-510 : fix typo in service config

### DIFF
--- a/services/src/main/resources/org.apache.unomi.services.cfg
+++ b/services/src/main/resources/org.apache.unomi.services.cfg
@@ -76,4 +76,4 @@ events.shouldBeCheckedEventSourceId=${org.apache.unomi.events.shouldBeCheckedEve
 rules.optimizationActivated=${org.apache.unomi.rules.optimizationActivated:-true}
 
 # The number of threads to compose the pool size of the scheduler.
-scheduler.thread.poolSize=${env:org.apache.unomi.scheduler.thread.poolSize:-5}
+scheduler.thread.poolSize=${org.apache.unomi.scheduler.thread.poolSize:-5}


### PR DESCRIPTION
Fix typo in configuration variable value (removing unecessary "env:" part)