### PR TITLE
UNOMI-523 : add date expression support to isDay / isNotDay property comparison

### DIFF
--- a/itests/src/test/java/org/apache/unomi/itests/ConditionBuilder.java
+++ b/itests/src/test/java/org/apache/unomi/itests/ConditionBuilder.java
@@ -141,6 +141,10 @@ public class ConditionBuilder {
             return op("in").stringValues(values);
         }
 
+        public ComparisonCondition inDateExpr(String... values) {
+            return op("in").dateExprValues(values);
+        }
+
         public ComparisonCondition in(Date... values) {
             return op("in").dateValues(values);
         }
@@ -229,6 +233,10 @@ public class ConditionBuilder {
             return op("notIn").dateValues(values);
         }
 
+        public ComparisonCondition notInDateExpr(String... values) {
+            return op("notIn").dateExprValues(values);
+        }
+
         public ComparisonCondition notIn(Integer... values) {
             return op("notIn").integerValues(values);
         }
@@ -288,6 +296,10 @@ public class ConditionBuilder {
 
         private ComparisonCondition dateValues(Date... values) {
             return parameter("propertyValuesDate", values != null ? Arrays.asList(values) : null);
+        }
+
+        private ComparisonCondition dateExprValues(String... values) {
+            return parameter("propertyValuesDateExpr", values != null ? Arrays.asList(values) : null);
         }
     }
 

--- a/itests/src/test/java/org/apache/unomi/itests/ConditionBuilder.java
+++ b/itests/src/test/java/org/apache/unomi/itests/ConditionBuilder.java
@@ -149,8 +149,16 @@ public class ConditionBuilder {
             return op("isDay").dateValue(value);
         }
 
+        public ComparisonCondition isDay(String expression) {
+            return op("isDay").dateValueExpr(expression);
+        }
+
         public ComparisonCondition isNotDay(Date value) {
             return op("isNotDay").dateValue(value);
+        }
+
+        public ComparisonCondition isNotDay(String expression) {
+            return op("isNotDay").dateValueExpr(expression);
         }
 
         public ComparisonCondition in(Integer... values) {
@@ -260,6 +268,10 @@ public class ConditionBuilder {
 
         private ComparisonCondition dateValue(Date value) {
             return parameter("propertyValueDate", value);
+        }
+
+        private ComparisonCondition dateValueExpr(String value) {
+            return parameter("propertyValueDateExpr", value);
         }
 
         private ComparisonCondition stringValues(String... values) {

--- a/itests/src/test/java/org/apache/unomi/itests/ConditionEvaluatorIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/ConditionEvaluatorIT.java
@@ -17,6 +17,7 @@
 
 package org.apache.unomi.itests;
 
+import org.apache.commons.lang3.time.DateUtils;
 import org.apache.unomi.api.Item;
 import org.apache.unomi.api.Profile;
 import org.apache.unomi.api.conditions.Condition;
@@ -32,6 +33,7 @@ import org.ops4j.pax.exam.util.Filter;
 
 import javax.inject.Inject;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
@@ -116,6 +118,9 @@ public class ConditionEvaluatorIT extends BaseIT {
 
         assertTrue(eval(builder.profileProperty("properties.lastVisit").isDay(lastVisit).build()));
         assertTrue(eval(builder.profileProperty("properties.lastVisit").isNotDay(new Date(lastVisit.getTime() + (24*60*60*1000))).build()));
+        long daysFromToday = TimeUnit.MILLISECONDS.toDays(DateUtils.round(new Date(), Calendar.DAY_OF_MONTH).getTime() - lastVisit.getTime());
+        assertTrue(eval(builder.profileProperty("properties.lastVisit").isDay("now-" + daysFromToday + "d").build()));
+        assertTrue(eval(builder.profileProperty("properties.lastVisit").isNotDay("now-" + (daysFromToday + 1) + "d").build()));
     }
 
     @Test

--- a/itests/src/test/java/org/apache/unomi/itests/ConditionEvaluatorIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/ConditionEvaluatorIT.java
@@ -118,9 +118,11 @@ public class ConditionEvaluatorIT extends BaseIT {
 
         assertTrue(eval(builder.profileProperty("properties.lastVisit").isDay(lastVisit).build()));
         assertTrue(eval(builder.profileProperty("properties.lastVisit").isNotDay(new Date(lastVisit.getTime() + (24*60*60*1000))).build()));
-        long daysFromToday = TimeUnit.MILLISECONDS.toDays(DateUtils.round(new Date(), Calendar.DAY_OF_MONTH).getTime() - lastVisit.getTime());
+        long daysFromToday = TimeUnit.MILLISECONDS.toDays(DateUtils.truncate(new Date(), Calendar.DAY_OF_MONTH).getTime() - DateUtils.truncate(lastVisit, Calendar.DAY_OF_MONTH).getTime());
         assertTrue(eval(builder.profileProperty("properties.lastVisit").isDay("now-" + daysFromToday + "d").build()));
         assertTrue(eval(builder.profileProperty("properties.lastVisit").isNotDay("now-" + (daysFromToday + 1) + "d").build()));
+        assertTrue(eval(builder.profileProperty("properties.lastVisit").inDateExpr("" + lastVisit.getTime()).build()));
+        assertTrue(eval(builder.profileProperty("properties.lastVisit").notInDateExpr("now-" + (daysFromToday + 1) + "d").build()));
     }
 
     @Test

--- a/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/PropertyConditionESQueryBuilder.java
+++ b/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/PropertyConditionESQueryBuilder.java
@@ -33,6 +33,8 @@ import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.*;
 
+import static org.apache.unomi.plugins.baseplugin.conditions.PropertyConditionEvaluator.getDate;
+
 public class PropertyConditionESQueryBuilder implements ConditionESQueryBuilder {
 
     DateTimeFormatter dateTimeFormatter;
@@ -144,10 +146,10 @@ public class PropertyConditionESQueryBuilder implements ConditionESQueryBuilder 
                 return boolQueryBuilder;
             case "isDay":
                 checkRequiredValue(value, name, comparisonOperator, false);
-                return getIsSameDayRange(value, name);
+                return getIsSameDayRange(getDate(value), name);
             case "isNotDay":
                 checkRequiredValue(value, name, comparisonOperator, false);
-                return QueryBuilders.boolQuery().mustNot(getIsSameDayRange(value, name));
+                return QueryBuilders.boolQuery().mustNot(getIsSameDayRange(getDate(value), name));
             case "distance":
                 final String unitString = (String) condition.getParameter("unit");
                 final Object centerObj = condition.getParameter("center");

--- a/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/PropertyConditionEvaluator.java
+++ b/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/PropertyConditionEvaluator.java
@@ -69,7 +69,7 @@ public class PropertyConditionEvaluator implements ConditionEvaluator {
     }
 
     private int compare(Object actualValue, String expectedValue, Object expectedValueDate, Object expectedValueInteger, Object expectedValueDateExpr, Object expectedValueDouble) {
-        if (expectedValue == null && expectedValueDate == null && expectedValueInteger == null && getDate(expectedValueDateExpr) == null) {
+        if (expectedValue == null && expectedValueDate == null && expectedValueInteger == null && getDate(expectedValueDateExpr) == null && expectedValueDouble == null) {
             return actualValue == null ? 0 : 1;
         } else if (actualValue == null) {
             return -1;
@@ -88,9 +88,9 @@ public class PropertyConditionEvaluator implements ConditionEvaluator {
         }
     }
 
-    private boolean compareMultivalue(Object actualValue, Collection<?> expectedValues, Collection<?> expectedValuesDate, Collection<?> expectedValuesNumber, Collection<?> expectedValuesDateExpr, String op) {
+    private boolean compareValues(Object actualValue, Collection<?> expectedValues, Collection<?> expectedValuesInteger,  Collection<?> expectedValuesDouble,  Collection<?> expectedValuesDate, Collection<?> expectedValuesDateExpr, String op) {
         @SuppressWarnings("unchecked")
-        Collection<?> expected = ObjectUtils.firstNonNull(expectedValues, expectedValuesDate, expectedValuesNumber);
+        Collection<?> expected = ObjectUtils.firstNonNull(expectedValues, expectedValuesDate, expectedValuesInteger, expectedValuesDouble, expectedValuesDateExpr);
         if (actualValue == null) {
             return expected == null;
         } else if (expected == null) {
@@ -202,7 +202,7 @@ public class PropertyConditionEvaluator implements ConditionEvaluator {
     }
 
     protected boolean isMatch(String op, Object actualValue, String expectedValue, Object expectedValueInteger, Object expectedValueDouble,
-                            Object expectedValueDate, Object expectedValueDateExpr, Condition condition) {
+                              Object expectedValueDate, Object expectedValueDateExpr, Condition condition) {
         if (op == null) {
             return false;
         } else if (actualValue == null) {
@@ -266,12 +266,15 @@ public class PropertyConditionEvaluator implements ConditionEvaluator {
             Collection<?> expectedValuesInteger = (Collection<?>) condition.getParameter("propertyValuesInteger");
             Collection<?> expectedValuesDate = (Collection<?>) condition.getParameter("propertyValuesDate");
             Collection<?> expectedValuesDateExpr = (Collection<?>) condition.getParameter("propertyValuesDateExpr");
+            Collection<?> expectedValuesDouble = (Collection<?>) condition.getParameter("propertyValuesDouble");
 
-            return compareMultivalue(actualValue, expectedValues, expectedValuesDate, expectedValuesInteger, expectedValuesDateExpr, op);
-        } else if (op.equals("isDay") && expectedValueDate != null) {
-            return yearMonthDayDateFormat.format(getDate(actualValue)).equals(yearMonthDayDateFormat.format(getDate(expectedValueDate)));
-        } else if (op.equals("isNotDay") && expectedValueDate != null) {
-            return !yearMonthDayDateFormat.format(getDate(actualValue)).equals(yearMonthDayDateFormat.format(getDate(expectedValueDate)));
+            return compareValues(actualValue, expectedValues, expectedValuesInteger, expectedValuesDouble, expectedValuesDate, expectedValuesDateExpr, op);
+        } else if (op.equals("isDay") && (expectedValueDate != null || expectedValueDateExpr != null)) {
+            Object expectedDate = expectedValueDate == null ? expectedValueDateExpr : expectedValueDate;
+            return yearMonthDayDateFormat.format(getDate(actualValue)).equals(yearMonthDayDateFormat.format(getDate(expectedDate)));
+        } else if (op.equals("isNotDay") && (expectedValueDate != null || expectedValueDateExpr != null)) {
+            Object expectedDate = expectedValueDate == null ? expectedValueDateExpr : expectedValueDate;
+            return !yearMonthDayDateFormat.format(getDate(actualValue)).equals(yearMonthDayDateFormat.format(getDate(expectedDate)));
         } else if (op.equals("distance")) {
             GeoPoint actualCenter = null;
             if (actualValue instanceof GeoPoint) {
@@ -433,7 +436,7 @@ public class PropertyConditionEvaluator implements ConditionEvaluator {
         return accessor;
     }
 
-    private Date getDate(Object value) {
+    protected static Date getDate(Object value) {
         if (value == null) {
             return null;
         }

--- a/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/PropertyConditionEvaluator.java
+++ b/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/PropertyConditionEvaluator.java
@@ -42,6 +42,7 @@ import java.lang.reflect.Modifier;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Evaluator for property comparison conditions
@@ -89,8 +90,12 @@ public class PropertyConditionEvaluator implements ConditionEvaluator {
     }
 
     private boolean compareValues(Object actualValue, Collection<?> expectedValues, Collection<?> expectedValuesInteger,  Collection<?> expectedValuesDouble,  Collection<?> expectedValuesDate, Collection<?> expectedValuesDateExpr, String op) {
+        Collection<Object> expectedDateExpr = null;
+        if (expectedValuesDateExpr != null) {
+            expectedDateExpr = expectedValuesDateExpr.stream().map(PropertyConditionEvaluator::getDate).collect(Collectors.toList());
+        }
         @SuppressWarnings("unchecked")
-        Collection<?> expected = ObjectUtils.firstNonNull(expectedValues, expectedValuesDate, expectedValuesInteger, expectedValuesDouble, expectedValuesDateExpr);
+        Collection<?> expected = ObjectUtils.firstNonNull(expectedValues, expectedValuesDate, expectedValuesInteger, expectedValuesDouble, expectedDateExpr);
         if (actualValue == null) {
             return expected == null;
         } else if (expected == null) {
@@ -206,7 +211,7 @@ public class PropertyConditionEvaluator implements ConditionEvaluator {
         if (op == null) {
             return false;
         } else if (actualValue == null) {
-            return op.equals("missing")|| op.equals("notIn") || op.equals("notEquals") || op.equals("hasNoneOf");
+            return op.equals("missing") || op.equals("notIn") || op.equals("notEquals") || op.equals("hasNoneOf");
         } else if (op.equals("exists")) {
             if (actualValue instanceof List) {
                 return ((List) actualValue).size() > 0;


### PR DESCRIPTION
Add date expression support to isDay / isNotDay property comparison operator. (bonus, fix double property type support)

Covered by unit test. 