### PR TITLE
[UNOMI-520] Add possibility to use a "requiresScores" parameter in the ContextRequest

### DIFF
--- a/api/src/main/java/org/apache/unomi/api/ContextRequest.java
+++ b/api/src/main/java/org/apache/unomi/api/ContextRequest.java
@@ -57,6 +57,7 @@ public class ContextRequest {
     private boolean requireSegments;
     private List<String> requiredProfileProperties;
     private List<String> requiredSessionProperties;
+    private boolean requireScores;
     private List<Event> events;
     private List<PersonalizationService.PersonalizedContent> filters;
     private List<PersonalizationService.PersonalizationRequest> personalizations;
@@ -148,6 +149,23 @@ public class ContextRequest {
      */
     public void setRequiredSessionProperties(List<String> requiredSessionProperties) {
         this.requiredSessionProperties = requiredSessionProperties;
+    }
+
+    /**
+     * Specifies whether the profiles scores should be part of the ContextResponse.
+     * @return a boolean indicating if the scores should be part of the response.
+     */
+    public boolean isRequireScores() {
+        return requireScores;
+    }
+
+    /**
+     * Setting this value to true indicates that the profile scores should be included in the response. By default this
+     * value is false.
+     * @param requireScores set to true if you want the scores to be part of the context response
+     */
+    public void setRequireScores(boolean requireScores) {
+        this.requireScores = requireScores;
     }
 
     /**

--- a/api/src/main/java/org/apache/unomi/api/ContextResponse.java
+++ b/api/src/main/java/org/apache/unomi/api/ContextResponse.java
@@ -46,6 +46,8 @@ public class ContextResponse implements Serializable {
 
     private Set<String> profileSegments;
 
+    private Map<String,Integer> profileScores;
+
     private Map<String, Boolean> filteringResults;
 
     private int processedEvents;
@@ -150,6 +152,22 @@ public class ContextResponse implements Serializable {
      */
     public void setProfileSegments(Set<String> profileSegments) {
         this.profileSegments = profileSegments;
+    }
+
+    /**
+     * Retrieve the current scores for the profile if they were requested in the request using the requireScores boolean.
+     * @return a map that contains the score identifier as the key and the score value as the value
+     */
+    public Map<String, Integer> getProfileScores() {
+        return profileScores;
+    }
+
+    /**
+     * Stores the scores for the current profile if requested using the requireScores boolean in the request.
+     * @param profileScores a map that contains the score identifier as the key and the score value as the value
+     */
+    public void setProfileScores(Map<String, Integer> profileScores) {
+        this.profileScores = profileScores;
     }
 
     /**

--- a/itests/src/test/java/org/apache/unomi/itests/BasicIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/BasicIT.java
@@ -59,7 +59,7 @@ import java.util.*;
 public class BasicIT extends BaseIT {
     private final static Logger LOGGER = LoggerFactory.getLogger(BasicIT.class);
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private static final String SESSION_ID_0 = "aa3b04bd-8f4d-4a07-8e96-d33ffa04d3d0";
     private static final String SESSION_ID_1 = "aa3b04bd-8f4d-4a07-8e96-d33ffa04d3d1";

--- a/itests/src/test/resources/score1.json
+++ b/itests/src/test/resources/score1.json
@@ -1,0 +1,17 @@
+{
+  "itemId" : "score1",
+  "metadata" : {
+    "id" : "score1",
+    "name" : "Score 1",
+    "enabled" : true
+  },
+  "elements" : [
+    {
+      "condition" : {
+        "type" : "matchAllCondition",
+        "parameterValues" : {}
+      },
+      "value" : 1
+    }
+  ]
+}

--- a/itests/src/test/resources/withRequireScores.json
+++ b/itests/src/test/resources/withRequireScores.json
@@ -1,0 +1,5 @@
+{
+  "requireScores": true,
+  "profileId": "test-profile-id",
+  "sessionId": "test-session-id"
+}

--- a/itests/src/test/resources/withoutRequireScores.json
+++ b/itests/src/test/resources/withoutRequireScores.json
@@ -1,0 +1,4 @@
+{
+  "profileId": "test-profile-id",
+  "sessionId": "test-session-id"
+}

--- a/manual/src/main/asciidoc/recipes.adoc
+++ b/manual/src/main/asciidoc/recipes.adoc
@@ -23,7 +23,7 @@ Apache Unomi.
 The simplest way to retrieve profile data for the current profile is to simply send a request to the /cxs/context.json
 endpoint. However you will need to send a body along with that request. Here's an example:
 
-Here is an example that will retrieve all the session and profile properties.
+Here is an example that will retrieve all the session and profile properties, as well as the profile's segments and scores
 
 [source]
 ----
@@ -38,7 +38,8 @@ curl -X POST http://localhost:8181/cxs/context.json?sessionId=1234 \
     },
     "requiredProfileProperties":["*"],
     "requiredSessionProperties":["*"],
-    "requireSegments":true
+    "requireSegments":true,
+    "requireScores":true
 }
 EOF
 ----

--- a/manual/src/main/asciidoc/request-examples.adoc
+++ b/manual/src/main/asciidoc/request-examples.adoc
@@ -41,7 +41,8 @@ By default, in order to optimize the amount of data sent over the network, Apach
 the profile or session properties. If you need this data, you must send a JSON object to configure the resulting output
 of the context.js(on) servlet.
 
-Here is an example that will retrieve all the session and profile properties.
+Here is an example that will retrieve all the session and profile properties, as well as the profile's segments and
+scores
 
 [source]
 ----
@@ -56,7 +57,8 @@ curl -X POST http://localhost:8181/cxs/context.json?sessionId=1234 \
     },
     "requiredProfileProperties":["*"],
     "requiredSessionProperties":["*"],
-    "requireSegments":true
+    "requireSegments":true,
+    "requireScores":true
 }
 EOF
 ----

--- a/rest/src/main/java/org/apache/unomi/rest/endpoints/ContextJsonEndpoint.java
+++ b/rest/src/main/java/org/apache/unomi/rest/endpoints/ContextJsonEndpoint.java
@@ -383,6 +383,9 @@ public class ContextJsonEndpoint {
         if (contextRequest.isRequireSegments()) {
             data.setProfileSegments(profile.getSegments());
         }
+        if (contextRequest.isRequireScores()) {
+            data.setProfileScores(profile.getScores());
+        }
 
         if (contextRequest.getRequiredProfileProperties() != null) {
             Map<String, Object> profileProperties = new HashMap<>(profile.getProperties());


### PR DESCRIPTION
- Implement new ContextRequest parameter
- Add integration tests that execute with and without the parameter.
- Update documentation to surface the new parameter
