### PR TITLE
[UNOMI-551] - Utilise SSL in docker entrypoint

### DIFF
--- a/docker/src/main/docker/entrypoint.sh
+++ b/docker/src/main/docker/entrypoint.sh
@@ -19,7 +19,7 @@
 # Wait for healthy ElasticSearch
 # next wait for ES status to turn to Green
 
-if [ $UNOMI_ELASTICSEARCH_SSL_ENABLE ]; then
+if [ "$UNOMI_ELASTICSEARCH_SSL_ENABLE" == 'true' ]; then
   schema='https'
 else
   schema='http'

--- a/docker/src/main/docker/entrypoint.sh
+++ b/docker/src/main/docker/entrypoint.sh
@@ -16,13 +16,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-# Wait for heathy ElasticSearch
+# Wait for healthy ElasticSearch
 # next wait for ES status to turn to Green
 
-if [ -v UNOMI_ELASTICSEARCH_USERNAME ] && [ -v UNOMI_ELASTICSEARCH_PASSWORD ]; then
-  elasticsearch_addresses="$UNOMI_ELASTICSEARCH_USERNAME:$UNOMI_ELASTICSEARCH_PASSWORD@$UNOMI_ELASTICSEARCH_ADDRESSES/_cat/health?h=status"
+if [ $UNOMI_ELASTICSEARCH_SSL_ENABLE ]; then
+  schema='https'
 else
-  elasticsearch_addresses="$UNOMI_ELASTICSEARCH_ADDRESSES/_cat/health?h=status"
+  schema='http'
+fi
+
+if [ -v UNOMI_ELASTICSEARCH_USERNAME ] && [ -v UNOMI_ELASTICSEARCH_PASSWORD ]; then
+  elasticsearch_addresses="$schema://$UNOMI_ELASTICSEARCH_USERNAME:$UNOMI_ELASTICSEARCH_PASSWORD@$UNOMI_ELASTICSEARCH_ADDRESSES/_cat/health?h=status"
+else
+  elasticsearch_addresses="$schema://$UNOMI_ELASTICSEARCH_ADDRESSES/_cat/health?h=status"
 fi
 
 health_check="$(curl -fsSL "$elasticsearch_addresses")"


### PR DESCRIPTION
Updated the entrypoint file to utilise the $UNOMI_ELASTICSEARCH_SSL_ENABLE environment variable.

Tested locally with the env var absent and with values "true" and "false", don't know how to contribute a test for this.

Also: noticed a spelling error, and IDE wouldn't allow me to save the file without the blank line at the end.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
