### PR TITLE
UNOMI-552 Attempt to fix issue with release:prepare locking Unomi startup.

### DIFF
--- a/extensions/groovy-actions/karaf-kar/src/main/feature/feature.xml
+++ b/extensions/groovy-actions/karaf-kar/src/main/feature/feature.xml
@@ -19,7 +19,7 @@
     <feature name="unomi-groovy-actions" description="${project.name}" version="${project.version}">
         <details>${project.description}</details>
         <feature prerequisite="true" dependency="false">wrap</feature>
-        <feature>unomi-kar</feature>
+        <feature dependency="true">unomi-kar</feature>
         <bundle start-level="85">mvn:org.codehaus.groovy/groovy/3.0.3</bundle>
         <bundle start-level="85">mvn:org.codehaus.groovy/groovy-xml/3.0.3</bundle>
         <bundle start-level="85" start="false">mvn:org.apache.unomi/unomi-groovy-actions-services/${project.version}</bundle>


### PR DESCRIPTION
- Added a dependency to Unomi in Groovy actions feature
- Added a check of bundle states at initialization of Lifecycle Manager, in case it gets started after bundles that are required.

