### PR TITLE
UNOMI-553 Update spelling in docker-compose.yaml comments

### DIFF
--- a/docker/src/main/docker/docker-compose.yml
+++ b/docker/src/main/docker/docker-compose.yml
@@ -18,7 +18,7 @@ version: '2.4'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.4.2
-    volumes: # Persist ES data in seperate "esdata" volume
+    volumes: # Persist ES data in separate "esdata" volume
       - esdata1:/usr/share/elasticsearch/data
     environment:
       - bootstrap.memory_lock=true
@@ -44,6 +44,6 @@ services:
       - elasticsearch
 
 
-volumes: # Define seperate volume for Elasticsearch data
+volumes: # Define separate volume for Elasticsearch data
   esdata1:
     driver: local


### PR DESCRIPTION
I have fixed a few typos with the word `separate` in the `docker-compose.yaml` file.


 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
