### PR TITLE
[UNOMI-564] - Misinformation in some descriptions in online site docs

### DIFF
--- a/manual/src/archives/1.5/asciidoc/connectors/connectors.adoc
+++ b/manual/src/archives/1.5/asciidoc/connectors/connectors.adoc
@@ -22,4 +22,4 @@ Apache Unomi provides the following connectors:
 ==== Call for contributors
 
 We are looking for help with the development of additional connectors. Any contribution (large or small) is more than
-welcome. Feel free to discuss this in our link:http://unomi.apache.org/community.html[mailing list, window="_blank"].
+welcome. Feel free to discuss this in our link:http://unomi.apache.org/community/[mailing list, window="_blank"].

--- a/manual/src/archives/1.5/asciidoc/datamodel.adoc
+++ b/manual/src/archives/1.5/asciidoc/datamodel.adoc
@@ -194,7 +194,7 @@ Inherits all the fields from: <<Item>>
 |===
 | *Field* | *Type* | *Description*
 
-| eventType | String | Contains an identifier for the field type, which may be any value as Apache Unomi does not come with strict event type definitions and accepts custom events types. The system comes with built-in event types such as “view”, “form”, “login”, “updateProperties” but additional event types may of course be used by developers integrating with Apache Unomi.
+| eventType | String | Contains an identifier for the event type, which may be any value as Apache Unomi does not come with strict event type definitions and accepts custom events types. The system comes with built-in event types such as “view”, “form”, “login”, “updateProperties” but additional event types may of course be used by developers integrating with Apache Unomi.
 
 | sessionId | String | The unique identifier of a Session object
 
@@ -415,7 +415,7 @@ Inherits all the fields from: n/a
 
 | typeIdentifier | String | This is a unique consent type identifier, basically a unique name for the consent. Example of such types might include: “newsletter”, “personalization”, “tracking”.
 
-| status | GRANTED / DENIED / REVOKED | A copy of the profile associated with the session
+| status | GRANTED / DENIED / REVOKED | The type of status for this consent
 
 | statusDate | Date | The date (in ISO 8601 format) at which the current status was set
 
@@ -1066,7 +1066,7 @@ Inherits all the fields from: <<MetadataItem>>
 |===
 | *Field name* | *Type* | *Description*
 
-| elements | ScoringElement array | A ScoringElement is composed of:* A Condition* A Score increment valueEach element defines a separate condition (tree) that will increment the defined score for this scoring plan, making it possible to have completely different conditions to augment a score
+| elements | ScoringElement array | A ScoringElement is composed of: a Condition and a score value to increment. Each element defines a separate condition (tree) that will increment the defined score for this scoring plan, making it possible to have completely different conditions to augment a score
 
 |===
 

--- a/manual/src/archives/1.5/asciidoc/datamodel.adoc
+++ b/manual/src/archives/1.5/asciidoc/datamodel.adoc
@@ -1066,7 +1066,7 @@ Inherits all the fields from: <<MetadataItem>>
 |===
 | *Field name* | *Type* | *Description*
 
-| elements | ScoringElement array | A ScoringElement is composed of: a Condition and a score value to increment. Each element defines a separate condition (tree) that will increment the defined score for this scoring plan, making it possible to have completely different conditions to augment a score
+| elements | ScoringElement array | A ScoringElement is composed of: a Condition and a score value to increment. Each element defines a separate condition (tree) that will increment the defined score for this scoring plan, making it possible to have completely different conditions to augment a score.
 
 |===
 

--- a/manual/src/archives/1.6/asciidoc/connectors/connectors.adoc
+++ b/manual/src/archives/1.6/asciidoc/connectors/connectors.adoc
@@ -22,4 +22,4 @@ Apache Unomi provides the following connectors:
 ==== Call for contributors
 
 We are looking for help with the development of additional connectors. Any contribution (large or small) is more than
-welcome. Feel free to discuss this in our link:http://unomi.apache.org/community.html[mailing list, window="_blank"].
+welcome. Feel free to discuss this in our link:http://unomi.apache.org/community/[mailing list, window="_blank"].

--- a/manual/src/archives/1.6/asciidoc/datamodel.adoc
+++ b/manual/src/archives/1.6/asciidoc/datamodel.adoc
@@ -194,7 +194,7 @@ Inherits all the fields from: <<Item>>
 |===
 | *Field* | *Type* | *Description*
 
-| eventType | String | Contains an identifier for the field type, which may be any value as Apache Unomi does not come with strict event type definitions and accepts custom events types. The system comes with built-in event types such as “view”, “form”, “login”, “updateProperties” but additional event types may of course be used by developers integrating with Apache Unomi.
+| eventType | String | Contains an identifier for the event type, which may be any value as Apache Unomi does not come with strict event type definitions and accepts custom events types. The system comes with built-in event types such as “view”, “form”, “login”, “updateProperties” but additional event types may of course be used by developers integrating with Apache Unomi.
 
 | sessionId | String | The unique identifier of a Session object
 
@@ -415,7 +415,7 @@ Inherits all the fields from: n/a
 
 | typeIdentifier | String | This is a unique consent type identifier, basically a unique name for the consent. Example of such types might include: “newsletter”, “personalization”, “tracking”.
 
-| status | GRANTED / DENIED / REVOKED | A copy of the profile associated with the session
+| status | GRANTED / DENIED / REVOKED | The type of status for this consent
 
 | statusDate | Date | The date (in ISO 8601 format) at which the current status was set
 
@@ -1066,7 +1066,7 @@ Inherits all the fields from: <<MetadataItem>>
 |===
 | *Field name* | *Type* | *Description*
 
-| elements | ScoringElement array | A ScoringElement is composed of:* A Condition* A Score increment valueEach element defines a separate condition (tree) that will increment the defined score for this scoring plan, making it possible to have completely different conditions to augment a score
+| elements | ScoringElement array | A ScoringElement is composed of: a Condition and a score value to increment. Each element defines a separate condition (tree) that will increment the defined score for this scoring plan, making it possible to have completely different conditions to augment a score
 
 |===
 

--- a/manual/src/archives/1.6/asciidoc/datamodel.adoc
+++ b/manual/src/archives/1.6/asciidoc/datamodel.adoc
@@ -1066,7 +1066,7 @@ Inherits all the fields from: <<MetadataItem>>
 |===
 | *Field name* | *Type* | *Description*
 
-| elements | ScoringElement array | A ScoringElement is composed of: a Condition and a score value to increment. Each element defines a separate condition (tree) that will increment the defined score for this scoring plan, making it possible to have completely different conditions to augment a score
+| elements | ScoringElement array | A ScoringElement is composed of: a Condition and a score value to increment. Each element defines a separate condition (tree) that will increment the defined score for this scoring plan, making it possible to have completely different conditions to augment a score.
 
 |===
 

--- a/manual/src/main/asciidoc/connectors/connectors.adoc
+++ b/manual/src/main/asciidoc/connectors/connectors.adoc
@@ -22,4 +22,4 @@ Apache Unomi provides the following connectors:
 ==== Call for contributors
 
 We are looking for help with the development of additional connectors. Any contribution (large or small) is more than
-welcome. Feel free to discuss this in our link:http://unomi.apache.org/community.html[mailing list, window="_blank"].
+welcome. Feel free to discuss this in our link:http://unomi.apache.org/community/[mailing list, window="_blank"].

--- a/manual/src/main/asciidoc/datamodel.adoc
+++ b/manual/src/main/asciidoc/datamodel.adoc
@@ -194,7 +194,7 @@ Inherits all the fields from: <<Item>>
 |===
 | *Field* | *Type* | *Description*
 
-| eventType | String | Contains an identifier for the field type, which may be any value as Apache Unomi does not come with strict event type definitions and accepts custom events types. The system comes with built-in event types such as “view”, “form”, “login”, “updateProperties” but additional event types may of course be used by developers integrating with Apache Unomi.
+| eventType | String | Contains an identifier for the event type, which may be any value as Apache Unomi does not come with strict event type definitions and accepts custom events types. The system comes with built-in event types such as “view”, “form”, “login”, “updateProperties” but additional event types may of course be used by developers integrating with Apache Unomi.
 
 | sessionId | String | The unique identifier of a Session object
 
@@ -415,7 +415,7 @@ Inherits all the fields from: n/a
 
 | typeIdentifier | String | This is a unique consent type identifier, basically a unique name for the consent. Example of such types might include: “newsletter”, “personalization”, “tracking”.
 
-| status | GRANTED / DENIED / REVOKED | A copy of the profile associated with the session
+| status | GRANTED / DENIED / REVOKED | The type of status for this consent
 
 | statusDate | Date | The date (in ISO 8601 format) at which the current status was set
 
@@ -1066,7 +1066,7 @@ Inherits all the fields from: <<MetadataItem>>
 |===
 | *Field name* | *Type* | *Description*
 
-| elements | ScoringElement array | A ScoringElement is composed of:* A Condition* A Score increment valueEach element defines a separate condition (tree) that will increment the defined score for this scoring plan, making it possible to have completely different conditions to augment a score
+| elements | ScoringElement array | A ScoringElement is composed of: a Condition and a score value to increment. Each element defines a separate condition (tree) that will increment the defined score for this scoring plan, making it possible to have completely different conditions to augment a score
 
 |===
 

--- a/manual/src/main/asciidoc/datamodel.adoc
+++ b/manual/src/main/asciidoc/datamodel.adoc
@@ -1066,7 +1066,7 @@ Inherits all the fields from: <<MetadataItem>>
 |===
 | *Field name* | *Type* | *Description*
 
-| elements | ScoringElement array | A ScoringElement is composed of: a Condition and a score value to increment. Each element defines a separate condition (tree) that will increment the defined score for this scoring plan, making it possible to have completely different conditions to augment a score
+| elements | ScoringElement array | A ScoringElement is composed of: a Condition and a score value to increment. Each element defines a separate condition (tree) that will increment the defined score for this scoring plan, making it possible to have completely different conditions to augment a score.
 
 |===
 

--- a/wab/src/main/webapp/index.html
+++ b/wab/src/main/webapp/index.html
@@ -79,7 +79,7 @@
               </li>
               <li>Try out some <a href="http://unomi.apache.org/manual/latest/index.html#_integration_samples"
                                   target="_blank">samples</a></li>
-              <li>Join <a href="http://unomi.apache.org/community.html" target="_blank">Apache Unomi's mailing lists</a></li>
+              <li>Join <a href="http://unomi.apache.org/community/" target="_blank">Apache Unomi's mailing lists</a></li>
               <li>Star the project on Github <!-- Place this tag where you want the button to render. -->
                   <a class="github-button" href="https://github.com/apache/incubator-unomi" data-icon="octicon-star"
                      data-show-count="true" aria-label="Star apache/incubator-unomi on GitHub">Star</a>


### PR DESCRIPTION
Some descriptions are not precise in online site docs. Should be self-explanatory in the changes.

----

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/UNOMI) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Format the pull request title like `[UNOMI-XXX] - Title of the pull request`
 - [n/a] Provide integration tests for your changes, especially if you are changing the behavior of existing code or adding
       significant new parts of code.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why. 
       Copy the description to the related JIRA issue
 - [X] Run `mvn clean install -P integration-tests` to make sure basic checks pass. A more thorough check will be 
        performed on your pull request automatically.
 
Trivial changes like typos do not require a JIRA issue (javadoc, project build changes, small doc changes, comments...). 
...oh well, already created one, sorry...

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
