### PR TITLE
UNOMI-567 : filter out warnings from RestClient

### DIFF
--- a/persistence-elasticsearch/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/persistence-elasticsearch/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -68,6 +68,7 @@
             <cm:property name="sslTrustAllCertificates" value="false" />
             <cm:property name="throwExceptions" value="false" />
             <cm:property name="alwaysOverwrite" value="true" />
+            <cm:property name="errorLogLevelRestClient" value="true" />
 
         </cm:default-properties>
     </cm:property-placeholder>
@@ -147,6 +148,7 @@
         <property name="sslTrustAllCertificates" value="${es.sslTrustAllCertificates}" />
         <property name="throwExceptions" value="${es.throwExceptions}" />
         <property name="alwaysOverwrite" value="${es.alwaysOverwrite}" />
+        <property name="errorLogLevelRestClient" value="${es.errorLogLevelRestClient}" />
     </bean>
 
     <!-- We use a listener here because using the list directly for listening to proxies coming from the same bundle didn't seem to work -->

--- a/persistence-elasticsearch/core/src/main/resources/org.apache.unomi.persistence.elasticsearch.cfg
+++ b/persistence-elasticsearch/core/src/main/resources/org.apache.unomi.persistence.elasticsearch.cfg
@@ -81,3 +81,6 @@ throwExceptions=${org.apache.unomi.elasticsearch.throwExceptions:-false}
 
 alwaysOverwrite=${org.apache.unomi.elasticsearch.alwaysOverwrite:-true}
 useBatchingForUpdate=${org.apache.unomi.elasticsearch.useBatchingForUpdate:-true}
+
+# ES logging
+errorLogLevelRestClient=${org.apache.unomi.elasticsearch.errorLogLevelRestClient:-true}


### PR DESCRIPTION
Fixes the issue of logs polluted by ES warnings regarding deprecated parameters.

 We now change the log level of the RestClient to not display warnings.
If one wants to have them back the configuration parameter `errorLogLevelRestClient` restores the original behavior