### PR TITLE
[UNOMI-592] - a tip for building on non-English Windows env

### DIFF
--- a/manual/src/archives/1.5/asciidoc/building-and-deploying.adoc
+++ b/manual/src/archives/1.5/asciidoc/building-and-deploying.adoc
@@ -48,7 +48,17 @@ This will compile Apache Unomi and run all of the tests in the
 +
 This will compile Apache Unomi without running the tests and takes less
  time to build.
-
++
+TIP: On a non-English Windows env, the Asciidoctor Maven Plugin may fail to
+     generate manuals due to an encoding conversion issue.
+     To solve this issue, we recommend setting the *file.encoding* system property
+     to _UTF-8_ like the following example before issuing the commands shown above.
++
+[source]
+----
+     > set MAVEN_OPTS="-Dfile.encoding=UTF-8"
+----
++
 . The distributions will be available under "package/target" directory.
 
 ==== Installing an ElasticSearch server

--- a/manual/src/archives/1.5/asciidoc/building-and-deploying.adoc
+++ b/manual/src/archives/1.5/asciidoc/building-and-deploying.adoc
@@ -52,11 +52,14 @@ This will compile Apache Unomi without running the tests and takes less
 TIP: On a non-English Windows env, the Asciidoctor Maven Plugin may fail to
      generate manuals due to an encoding conversion issue.
      To solve this issue, we recommend setting the *file.encoding* system property
-     to _UTF-8_ like the following example before issuing the commands shown above.
+     to _UTF-8_ like the following examples before issuing the commands shown above.
 +
 [source]
 ----
-     > set MAVEN_OPTS="-Dfile.encoding=UTF-8"
+     > set MAVEN_OPTS=-Dfile.encoding=UTF-8
+     or
+     > set MAVEN_OPTS=-Dfile.encoding=UTF-8 -Xmx2048m
+     ...
 ----
 +
 . The distributions will be available under "package/target" directory.

--- a/manual/src/archives/1.6/asciidoc/building-and-deploying.adoc
+++ b/manual/src/archives/1.6/asciidoc/building-and-deploying.adoc
@@ -48,7 +48,17 @@ This will compile Apache Unomi and run all of the tests in the
 +
 This will compile Apache Unomi without running the tests and takes less
  time to build.
-
++
+TIP: On a non-English Windows env, the Asciidoctor Maven Plugin may fail to
+     generate manuals due to an encoding conversion issue.
+     To solve this issue, we recommend setting the *file.encoding* system property
+     to _UTF-8_ like the following example before issuing the commands shown above.
++
+[source]
+----
+     > set MAVEN_OPTS="-Dfile.encoding=UTF-8"
+----
++
 . The distributions will be available under "package/target" directory.
 
 ==== Installing an ElasticSearch server

--- a/manual/src/archives/1.6/asciidoc/building-and-deploying.adoc
+++ b/manual/src/archives/1.6/asciidoc/building-and-deploying.adoc
@@ -52,11 +52,14 @@ This will compile Apache Unomi without running the tests and takes less
 TIP: On a non-English Windows env, the Asciidoctor Maven Plugin may fail to
      generate manuals due to an encoding conversion issue.
      To solve this issue, we recommend setting the *file.encoding* system property
-     to _UTF-8_ like the following example before issuing the commands shown above.
+     to _UTF-8_ like the following examples before issuing the commands shown above.
 +
 [source]
 ----
-     > set MAVEN_OPTS="-Dfile.encoding=UTF-8"
+     > set MAVEN_OPTS=-Dfile.encoding=UTF-8
+     or
+     > set MAVEN_OPTS=-Dfile.encoding=UTF-8 -Xmx2048m
+     ...
 ----
 +
 . The distributions will be available under "package/target" directory.

--- a/manual/src/main/asciidoc/building-and-deploying.adoc
+++ b/manual/src/main/asciidoc/building-and-deploying.adoc
@@ -48,7 +48,17 @@ This will compile Apache Unomi and run all of the tests in the
 +
 This will compile Apache Unomi without running the tests and takes less
  time to build.
-
++
+TIP: On a non-English Windows env, the Asciidoctor Maven Plugin may fail to
+     generate manuals due to an encoding conversion issue.
+     To solve this issue, we recommend setting the *file.encoding* system property
+     to _UTF-8_ like the following example before issuing the commands shown above.
++
+[source]
+----
+     > set MAVEN_OPTS="-Dfile.encoding=UTF-8"
+----
++
 . The distributions will be available under "package/target" directory.
 
 ==== Installing an ElasticSearch server

--- a/manual/src/main/asciidoc/building-and-deploying.adoc
+++ b/manual/src/main/asciidoc/building-and-deploying.adoc
@@ -52,11 +52,14 @@ This will compile Apache Unomi without running the tests and takes less
 TIP: On a non-English Windows env, the Asciidoctor Maven Plugin may fail to
      generate manuals due to an encoding conversion issue.
      To solve this issue, we recommend setting the *file.encoding* system property
-     to _UTF-8_ like the following example before issuing the commands shown above.
+     to _UTF-8_ like the following examples before issuing the commands shown above.
 +
 [source]
 ----
-     > set MAVEN_OPTS="-Dfile.encoding=UTF-8"
+     > set MAVEN_OPTS=-Dfile.encoding=UTF-8
+     or
+     > set MAVEN_OPTS=-Dfile.encoding=UTF-8 -Xmx2048m
+     ...
 ----
 +
 . The distributions will be available under "package/target" directory.


### PR DESCRIPTION
A tip in manual for non-English Windows users to avoid a build error due to the asciidoc-maven-plugin error.
Building on a non-English Windows machine, it is very likely to see a build error due to an encoding issue like the following example:

    [ERROR] Failed to execute goal org.asciidoctor:asciidoctor-maven-plugin:1.6.0:process-asciidoc (output-html) on project unomi-manual: Execution output-html of goal org.asciidoctor:asciidoctor-maven-plugin:1.6.0:process-asciidoc failed: unknown encoding name - MS949 -> [Help 1]

----

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/UNOMI) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Format the pull request title like `[UNOMI-XXX] - Title of the pull request`
 - [ ] Provide integration tests for your changes, especially if you are changing the behavior of existing code or adding
       significant new parts of code.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why. 
       Copy the description to the related JIRA issue
 - [X] Run `mvn clean install -P integration-tests` to make sure basic checks pass. A more thorough check will be 
        performed on your pull request automatically.
 
To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
