### PR TITLE
UNOMI-583 : add credential support to ES migration data

### DIFF
--- a/itests/src/test/java/org/apache/unomi/itests/migration/Migrate16xTo200IT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/migration/Migrate16xTo200IT.java
@@ -39,7 +39,7 @@ public class Migrate16xTo200IT extends BaseIT {
     public void waitForStartup() throws InterruptedException {
 
         // Restore snapshot from 1.6.x
-        try (CloseableHttpClient httpClient = HttpUtils.initHttpClient(true)) {
+        try (CloseableHttpClient httpClient = HttpUtils.initHttpClient(true, null)) {
             // Create snapshot repo
             HttpUtils.executePutRequest(httpClient, "http://localhost:9400/_snapshot/snapshots_repository/", resourceAsString("migration/create_snapshots_repository.json"), null);
             // Get snapshot, insure it exists

--- a/itests/src/test/resources/migration/org.apache.unomi.migration.cfg
+++ b/itests/src/test/resources/migration/org.apache.unomi.migration.cfg
@@ -18,5 +18,6 @@
 # Migration config used for silent migration
 
 esAddress = http://localhost:9400
+esLogin =
 httpClient.trustAllCertificates = true
 indexPrefix = context

--- a/tools/shell-commands/src/main/java/org/apache/unomi/shell/migration/MigrationConfig.java
+++ b/tools/shell-commands/src/main/java/org/apache/unomi/shell/migration/MigrationConfig.java
@@ -38,6 +38,8 @@ import java.util.Map;
 public class MigrationConfig {
 
     public static final String CONFIG_ES_ADDRESS = "esAddress";
+    public static final String CONFIG_ES_LOGIN = "esLogin";
+    public static final String CONFIG_ES_PASSWORD = "esPassword";
     public static final String CONFIG_TRUST_ALL_CERTIFICATES = "httpClient.trustAllCertificates";
     public static final String INDEX_PREFIX = "indexPrefix";
     public static final String NUMBER_OF_SHARDS = "number_of_shards";
@@ -49,6 +51,8 @@ public class MigrationConfig {
     static {
         Map<String, MigrationConfigProperty> m = new HashMap<>();
         m.put(CONFIG_ES_ADDRESS, new MigrationConfigProperty("Enter ElasticSearch TARGET address (default: http://localhost:9200): ", "http://localhost:9200"));
+        m.put(CONFIG_ES_LOGIN, new MigrationConfigProperty("Enter ElasticSearch TARGET login (default: none): ", ""));
+        m.put(CONFIG_ES_PASSWORD, new MigrationConfigProperty("Enter ElasticSearch TARGET password (default: none): ", ""));
         m.put(CONFIG_TRUST_ALL_CERTIFICATES, new MigrationConfigProperty("We need to initialize a HttpClient, do we need to trust all certificates ?", null));
         m.put(INDEX_PREFIX, new MigrationConfigProperty("Enter ElasticSearch Unomi indices prefix (default: context): ", "context"));
         m.put(NUMBER_OF_SHARDS, new MigrationConfigProperty("Enter ElasticSearch index mapping configuration: number_of_shards (default: 3): ", "3"));

--- a/tools/shell-commands/src/main/java/org/apache/unomi/shell/migration/utils/HttpUtils.java
+++ b/tools/shell-commands/src/main/java/org/apache/unomi/shell/migration/utils/HttpUtils.java
@@ -17,6 +17,7 @@
 package org.apache.unomi.shell.migration.utils;
 
 import org.apache.http.HttpEntity;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.*;
 import org.apache.http.config.Registry;
@@ -52,11 +53,13 @@ import java.util.Map;
 public class HttpUtils {
     private static final Logger logger = LoggerFactory.getLogger(HttpUtils.class);
 
-    public static CloseableHttpClient initHttpClient(boolean trustAllCertificates) throws IOException {
+    public static CloseableHttpClient initHttpClient(boolean trustAllCertificates, CredentialsProvider credentialsProvider) throws IOException {
         long requestStartTime = System.currentTimeMillis();
 
         HttpClientBuilder httpClientBuilder = HttpClients.custom().useSystemProperties();
-
+        if (credentialsProvider != null) {
+            httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+        }
         if (trustAllCertificates) {
             try {
                 SSLContext sslContext = SSLContext.getInstance("SSL");

--- a/tools/shell-commands/src/main/resources/org.apache.unomi.migration.cfg
+++ b/tools/shell-commands/src/main/resources/org.apache.unomi.migration.cfg
@@ -18,5 +18,7 @@
 # Migration config used for silent migration
 
 # esAddress = http://localhost:9200
+# esLogin = elastic
+# esPassword = password
 # httpClient.trustAllCertificates = true
 # indexPrefix = context


### PR DESCRIPTION
UNOMI-583 
Now esLogin and esPassword are available to set up ES credentials at migration time. 