### PR TITLE
UNOMI-656: Fixed typos

### DIFF
--- a/manual/src/main/asciidoc/configuration.adoc
+++ b/manual/src/main/asciidoc/configuration.adoc
@@ -793,5 +793,5 @@ If you are using Elasticsearch in a production environment, you will most likely
 
 The following permissions are required by Unomi:
 
- - required cluster privileges: `manage` OR `al`l
- - required index privileges on unomi indices: ((`write`) AND (`manage`) AND (`read`)) OR `all`
+ - required cluster privileges: `manage` OR `all`
+ - required index privileges on unomi indices: `write, manage, read` OR `all`

--- a/manual/src/main/asciidoc/whats-new.adoc
+++ b/manual/src/main/asciidoc/whats-new.adoc
@@ -74,13 +74,13 @@ If you are using custom events/objects, please refer to the detailed migration g
 
 ==== Removal of the Web Tracker
 
+[TODO: Add more details about the web tracker]
+
 Apache Unomi 2.0 Web Tracker, previously located in `extensions/web-tracker/` has been removed.
 We considered it as outdated and instead recommend implementing your own tracker logic based on your project
 use case.
 
-[TODO: Add more details about the web tracker]
-
-==== GraphQL API (beta)
+==== GraphQL API - beta
 
 Apache Unomi 2.0 sees the introduction of a new (beta) GraphQL API. 
 Available behind a feature flag (the API disabled by default), the GraphQL API is available for you to play with. 


### PR DESCRIPTION
Fixed a few typos in recent updates to the manual.

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
