### PR TITLE
[UNOMI-659] Fix dependabot warnings

### DIFF
--- a/extensions/router/pom.xml
+++ b/extensions/router/pom.xml
@@ -30,6 +30,7 @@
 
     <properties>
         <camel.version>2.20.2</camel.version>
+        <kafka.client.version>0.10.2.2</kafka.client.version>
     </properties>
 
     <build>

--- a/extensions/router/router-core/pom.xml
+++ b/extensions/router/router-core/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>0.10.1.0</version>
+            <version>${kafka.client.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/extensions/router/router-karaf-feature/pom.xml
+++ b/extensions/router/router-karaf-feature/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>0.10.1.0</version>
+            <version>${kafka.client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/extensions/router/router-karaf-feature/src/main/feature/feature.xml
+++ b/extensions/router/router-karaf-feature/src/main/feature/feature.xml
@@ -22,7 +22,7 @@
         <feature>unomi-kar</feature>
         <bundle start-level="90">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jsch/0.1.54_1</bundle>
         <bundle start-level="90">mvn:commons-net/commons-net/3.6</bundle>
-        <bundle start-level="90">wrap:mvn:org.apache.kafka/kafka-clients/0.10.1.0</bundle>
+        <bundle start-level="90">wrap:mvn:org.apache.kafka/kafka-clients/${kafka.client.version}</bundle>
         <bundle start-level="90">mvn:org.apache.camel/camel-core/${camel.version}</bundle>
         <bundle start-level="90">mvn:org.apache.camel/camel-core-osgi/${camel.version}</bundle>
         <bundle start-level="90">mvn:org.apache.camel/camel-blueprint/${camel.version}</bundle>

--- a/extensions/salesforce-connector/services/pom.xml
+++ b/extensions/salesforce-connector/services/pom.xml
@@ -57,37 +57,37 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-client</artifactId>
-            <version>7.4.4.v20110707</version>
+            <version>9.4.48.v20220622</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>7.4.4.v20110707</version>
+            <version>9.4.48.v20220622</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>7.4.4.v20110707</version>
+            <version>9.4.48.v20220622</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>7.4.4.v20110707</version>
+            <version>9.4.48.v20220622</version>
         </dependency>
         <dependency>
             <groupId>org.cometd.java</groupId>
             <artifactId>bayeux-api</artifactId>
-            <version>2.3.1</version>
+            <version>4.0.9</version>
         </dependency>
         <dependency>
             <groupId>org.cometd.java</groupId>
-            <artifactId>cometd-java-common</artifactId>
-            <version>2.3.1</version>
+            <artifactId>cometd-java-client-common</artifactId>
+            <version>5.0.13</version>
         </dependency>
         <dependency>
             <groupId>org.cometd.java</groupId>
-            <artifactId>cometd-java-client</artifactId>
-            <version>2.3.1</version>
+            <artifactId>cometd-java-client-http-jetty</artifactId>
+            <version>5.0.13</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/graphql/graphql-playground/package.json
+++ b/graphql/graphql-playground/package.json
@@ -21,6 +21,12 @@
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.2"
   },
+  "resolutions" : {
+    "**/terser" : "4.8.1",
+    "**/postcss" : "7.0.39",
+    "**/ansi-regex" : "4.1.1",
+    "**/minimist" : "1.2.6"
+  },
   "devDependencies": {
     "@babel/core": "^7.10.4",
     "@babel/preset-env": "^7.10.4",

--- a/graphql/graphql-playground/src/javascript/index.jsx
+++ b/graphql/graphql-playground/src/javascript/index.jsx
@@ -25,6 +25,6 @@ document.addEventListener('DOMContentLoaded', function() {
         <Provider store={store}>
             <Playground endpoint='http://localhost:8181/graphql'/>
         </Provider>,
-        document.body
+        document.getElementById('root')
     )
 }, false);

--- a/graphql/graphql-playground/yarn.lock
+++ b/graphql/graphql-playground/yarn.lock
@@ -1141,10 +1141,10 @@ ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+ansi-regex@4.1.1, ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -3559,10 +3559,10 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@1.2.6, minimist@^1.2.0, minimist@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -3909,6 +3909,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+picocolors@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
+  integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
+
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
@@ -3991,14 +3996,13 @@ postcss-value-parser@^4.1.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
-postcss@^7.0.14, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.35"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
-  integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
+postcss@7.0.39, postcss@^7.0.14, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
+  version "7.0.39"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
+  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
   dependencies:
-    chalk "^2.4.2"
+    picocolors "^0.2.1"
     source-map "^0.6.1"
-    supports-color "^6.1.0"
 
 prettier@2.0.2:
   version "2.0.2"
@@ -4981,10 +4985,10 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@^4.1.2:
-  version "4.8.0"
-  resolved "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
-  integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
+terser@4.8.1, terser@^4.1.2:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.1.tgz#a00e5634562de2239fd404c649051bf6fc21144f"
+  integrity sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"

--- a/pom.xml
+++ b/pom.xml
@@ -788,6 +788,7 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-email</artifactId>
                 <version>1.3.3</version>
+                <!-- This is the latest version we can use right now because of the javax.mail dependency that is still on 1.3 provided by pax-web, standard and cxf features -->
             </dependency>
             <!-- End of Apache Commons dependencies -->
 


### PR DESCRIPTION
- Use resolutions to upgrade the needed graphql-playground dependencies
- Fix small warning in GraphQL Playground init
- Add a comment about why commons-email couldn't be upgrade (before of Karaf features using older versions of the javax.mail/mail bundle)
- Upgrade the Kafka client to a minor version that is recommended by dependabot
- Upgrade the Jetty version used by the CometD library in the Salesforce connector
- Upgrade the CometD library in the Salesforce connector
