### PR TITLE
UNOMI-661: Updated base image to openjdk 11

### DIFF
--- a/docker/src/main/docker/Dockerfile
+++ b/docker/src/main/docker/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 ################################################################################
 
-FROM openjdk:8-jre
+FROM openjdk:11-jre
 
 # Unomi environment variables
 ENV UNOMI_HOME /opt/apache-unomi


### PR DESCRIPTION
As part of Unomi 2.0, we're updating the base image used by Docker to openjdk 11

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
