### PR TITLE
UNOMI-663 : set graphql feature packaging

### DIFF
--- a/graphql/karaf-feature/pom.xml
+++ b/graphql/karaf-feature/pom.xml
@@ -24,7 +24,7 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <packaging>feature</packaging>
+    <packaging>kar</packaging>
 
     <artifactId>cdp-graphql-feature</artifactId>
     <name>Apache Unomi :: GraphQL API :: Karaf Feature</name>


### PR DESCRIPTION
Following a missing signature file while releasing, changing packaging of the feature. 