### PR TITLE
UNOMI-617: Update filters to adapt to interests data model changes

### DIFF
--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/condition/factories/ProfileConditionFactory.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/condition/factories/ProfileConditionFactory.java
@@ -153,44 +153,49 @@ public class ProfileConditionFactory extends ConditionFactory {
         return booleanCondition("or", subConditions);
     }
 
-    private Condition interestFilterInputCondition(final CDPInterestFilterInput filterInput) {
-        final List<Condition> rootSubConditions = new ArrayList<>();
+    private Condition buildConditionInterestValue(Double interestValue, String operator) {
+        return integerPropertyCondition("properties.interests.value", operator, interestValue);
+    }
 
-        final String propertyName = "properties.interests." + filterInput.getTopic_equals();
+    private Condition interestFilterInputCondition(final CDPInterestFilterInput filterInput) {
+        final List<Condition> subConditions = new ArrayList<>();
 
         if (filterInput.getTopic_equals() != null) {
-            rootSubConditions.add(propertyCondition(propertyName, "exists", filterInput.getTopic_equals()));
+            subConditions.add(propertyCondition("properties.interests.key", filterInput.getTopic_equals()));
         }
 
         if (filterInput.getScore_equals() != null) {
-            rootSubConditions.add(integerPropertyCondition(propertyName, filterInput.getScore_equals()));
+            subConditions.add(buildConditionInterestValue(filterInput.getScore_equals(), "equals"));
         }
 
         if (filterInput.getScore_gt() != null) {
-            rootSubConditions.add(integerPropertyCondition(propertyName, "greaterThan", filterInput.getScore_gt()));
+            subConditions.add(buildConditionInterestValue(filterInput.getScore_gt(), "greaterThan"));
         }
 
         if (filterInput.getScore_gte() != null) {
-            rootSubConditions.add(integerPropertyCondition(propertyName, "greaterThanOrEqualTo", filterInput.getScore_gte()));
+            subConditions.add(buildConditionInterestValue(filterInput.getScore_gte(), "greaterThanOrEqualTo"));
         }
 
         if (filterInput.getScore_lt() != null) {
-            rootSubConditions.add(integerPropertyCondition(propertyName, "lessThan", filterInput.getScore_lt()));
+            subConditions.add(buildConditionInterestValue(filterInput.getScore_lt(), "lessThan"));
         }
 
         if (filterInput.getScore_lte() != null) {
-            rootSubConditions.add(integerPropertyCondition(propertyName, "lessThanOrEqualTo", filterInput.getScore_lte()));
+            subConditions.add(buildConditionInterestValue(filterInput.getScore_lte(), "lessThanOrEqualTo"));
         }
 
         if (filterInput.getAnd() != null && !filterInput.getAnd().isEmpty()) {
-            rootSubConditions.add(filtersToCondition(filterInput.getOr(), this::interestFilterInputCondition, "and"));
+            subConditions.add(filtersToCondition(filterInput.getOr(), this::interestFilterInputCondition, "and"));
         }
 
         if (filterInput.getOr() != null && !filterInput.getOr().isEmpty()) {
-            rootSubConditions.add(filtersToCondition(filterInput.getOr(), this::interestFilterInputCondition, "or"));
+            subConditions.add(filtersToCondition(filterInput.getOr(), this::interestFilterInputCondition, "or"));
         }
 
-        return booleanCondition("and", rootSubConditions);
+        final Condition nestedCondition = new Condition(definitionsService.getConditionType("nestedCondition"));
+        nestedCondition.setParameter("path", "properties.interests");
+        nestedCondition.setParameter("subCondition", booleanCondition("and", subConditions));
+        return nestedCondition;
     }
 
     @SuppressWarnings("unchecked")

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/condition/parsers/SegmentProfileInterestsConditionParser.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/condition/parsers/SegmentProfileInterestsConditionParser.java
@@ -67,11 +67,13 @@ public class SegmentProfileInterestsConditionParser {
         final String comparisonOperator =
                 ComparisonConditionTranslator.translateFromUnomiToGraphQL(condition.getParameter("comparisonOperator").toString());
 
-        final String fieldName = "score_" + comparisonOperator;
-
         final Map<String, Object> tuple = new HashMap<>();
 
-        tuple.put(fieldName, condition.getParameter("propertyValueInteger"));
+        if (!"exists".equals(comparisonOperator)) {
+            final String fieldName = "score_" + comparisonOperator;
+            tuple.put(fieldName, condition.getParameter("propertyValueInteger"));
+        }
+
         tuple.put("topic_equals", condition.getParameter("propertyName").toString().replaceAll("properties.interests.", ""));
 
         return tuple;

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPPersona.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPPersona.java
@@ -96,7 +96,7 @@ public class CDPPersona implements CDPProfileInterface {
     public List<CDPInterest> cdp_interests(
             final @GraphQLName("views") List<String> viewIds,
             final DataFetchingEnvironment environment) throws Exception {
-        return persona != null ? new ProfileInterestsDataFetcher(persona).get(environment) : null;
+        return persona != null ? new ProfileInterestsDataFetcher(persona, viewIds).get(environment) : null;
     }
 
     @GraphQLField

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPProfile.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/output/CDPProfile.java
@@ -47,7 +47,7 @@ public class CDPProfile implements CDPProfileInterface {
 
     public static final String TYPE_NAME = "CDP_Profile";
 
-    private Profile profile;
+    private final Profile profile;
 
     public CDPProfile(Profile profile) {
         this.profile = profile;
@@ -73,7 +73,7 @@ public class CDPProfile implements CDPProfileInterface {
     @Override
     @GraphQLField
     public List<CDPInterest> cdp_interests(final @GraphQLName("views") List<String> viewIds, final DataFetchingEnvironment environment) throws Exception {
-        return new ProfileInterestsDataFetcher(profile).get(environment);
+        return new ProfileInterestsDataFetcher(profile, viewIds).get(environment);
     }
 
     @Override

--- a/itests/src/test/java/org/apache/unomi/itests/graphql/GraphQLProfilePropertiesIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/graphql/GraphQLProfilePropertiesIT.java
@@ -21,19 +21,18 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.unomi.api.Consent;
 import org.apache.unomi.api.ConsentStatus;
 import org.apache.unomi.api.Profile;
-import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.graphql.utils.DateUtils;
 import org.junit.Assert;
 import org.junit.Test;
-import org.ops4j.pax.exam.util.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -95,14 +94,16 @@ public class GraphQLProfilePropertiesIT extends BaseGraphQLIT {
         Date revokationDate = DateUtils.toDate(OffsetDateTime.parse("2021-05-14T14:47:28Z"));
         consent.setRevokeDate(revokationDate);
 
-        final Map<String, Double> interestsAsMap = new HashMap<>();
-
-        interestsAsMap.put("interestName", 0.5);
+        final List<Map<String, Object>> interests = new ArrayList<>();
+        Map<String, Object> interest1 = new HashMap<>();
+        interest1.put("key", "interestName");
+        interest1.put("value", 0.5);
+        interests.add(interest1);
 
         final Profile profile = new Profile("profileId_testGetProfile_CDPFields");
 
         profile.setConsent(consent);
-        profile.setProperty("interests", interestsAsMap);
+        profile.setProperty("interests", interests);
 
         profileService.save(profile);
 


### PR DESCRIPTION
[UNOMI-617] Update filters to adapt to interests data model changes

In this PR was done:
- Adopted conditions and condition parser for interests
- Adopted ProfileInterestsDataFetcher according to the new data model
- Added the ability to filter interests by viewIds. It was missed 


