### PR TITLE
UNOMI-708 Invalid "no matching query builder log"

### DIFF
--- a/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/conditions/ConditionESQueryBuilderDispatcher.java
+++ b/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/conditions/ConditionESQueryBuilderDispatcher.java
@@ -83,12 +83,12 @@ public class ConditionESQueryBuilderDispatcher {
             if (contextualCondition != null) {
                 return queryBuilder.buildQuery(contextualCondition, context, this);
             }
-        }
-
-        // if no matching
-        logger.warn("No matching query builder. See debug log level for more information");
-        if (logger.isDebugEnabled()) {
-            logger.debug("No matching query builder for condition {} and context {}", condition, context);
+        } else {
+            // if no matching
+            logger.warn("No matching query builder. See debug log level for more information");
+            if (logger.isDebugEnabled()) {
+                logger.debug("No matching query builder for condition {} and context {}", condition, context);
+            }
         }
 
         return QueryBuilders.matchAllQuery();


### PR DESCRIPTION
- Only display log if we really couldn't find a query builder and not anymore in the case where we couldn't match parameterized values.
