### PR TITLE
UNOMI-720 Switch base Docker image & add support for multi-arch images

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -105,12 +105,20 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.33.0</version>
+                <version>0.40.2</version>
                 <configuration>
                     <images>
                         <image>
                             <alias>unomi</alias>
                             <name>apache/unomi:${project.version}</name>
+                            <build>
+                                <buildx>
+                                    <platforms>
+                                        <platform>linux/amd64</platform>
+                                        <platform>linux/arm64</platform>
+                                    </platforms>
+                                </buildx>
+                            </build>
                             <external>
                                 <type>compose</type>
                                 <basedir>${project.build.directory}/filtered-docker</basedir>

--- a/docker/src/main/docker/Dockerfile
+++ b/docker/src/main/docker/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 ################################################################################
 
-FROM openjdk:11-jre
+FROM library/eclipse-temurin:11
 
 # Unomi environment variables
 ENV UNOMI_HOME /opt/apache-unomi


### PR DESCRIPTION
- Multi-arch support
- Switch to eclipse-termurin (openjdk image is no longer supported)
