### PR TITLE
[UNOMI-662] Update manual to document JDK 11 as minimal supported version

### DIFF
--- a/manual/src/main/asciidoc/5-min-quickstart.adoc
+++ b/manual/src/main/asciidoc/5-min-quickstart.adoc
@@ -25,7 +25,7 @@ services:
     environment:
         - discovery.type=single-node
     ports:
-        - 9200:9200                    
+        - 9200:9200
     unomi:
     # Unomi version can be updated based on your needs
     image: apache/unomi:2.0.0
@@ -39,7 +39,7 @@ services:
     links:
         - elasticsearch
     depends_on:
-        - elasticsearch 
+        - elasticsearch
 ----
 
 From the same folder, start the environment using `docker-compose up` and wait for the startup to complete.
@@ -48,7 +48,7 @@ Try accessing https://localhost:9443/cxs/cluster with username/password: karaf/k
 
 === Quick Start manually
 
-1) Install JDK 8 (https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and make sure you set the
+1) Install JDK 11 (https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and make sure you set the
 JAVA_HOME variable https://docs.oracle.com/cd/E19182-01/820-7851/inst_cli_jdk_javahome_t/ (see our <<JDK compatibility,Getting Started>> guide for more information on JDK compatibility)
 
 2) Download ElasticSearch here : https://www.elastic.co/downloads/past-releases/elasticsearch-7-17-5 (please <strong>make sure</strong> you use the proper version : 7.17.5)

--- a/manual/src/main/asciidoc/building-and-deploying.adoc
+++ b/manual/src/main/asciidoc/building-and-deploying.adoc
@@ -16,7 +16,7 @@
 
 ==== Initial Setup
 
-. Install J2SE 8.0 SDK (or later), which can be downloaded from
+. Install J2SE 11 SDK (or later), which can be downloaded from
  http://www.oracle.com/technetwork/java/javase/downloads/index.html[http://www.oracle.com/technetwork/java/javase/downloads/index.html]
 
 . Make sure that your JAVA_HOME environment variable is set to the newly installed
@@ -191,7 +191,7 @@ You can then select the one you want using :
 
 [source]
 ----
-export JAVA_HOME=`/usr/libexec/java_home -v 1.8.0_181`
+export JAVA_HOME=`/usr/libexec/java_home -v 11.0.5`
 ----
 
 and then check that it was correctly referenced using:
@@ -217,7 +217,7 @@ integration tests at least once before using the server to make sure that everyt
 to use these tests is to run them from a continuous integration server such as Jenkins, Apache Gump, Atlassian Bamboo or
  others.
 
-Note : the integration tests require a JDK 8 or more recent !
+Note : the integration tests require a JDK 11 or more recent !
 
 To run the tests simply activate the following profile :
 

--- a/manual/src/main/asciidoc/getting-started.adoc
+++ b/manual/src/main/asciidoc/getting-started.adoc
@@ -19,14 +19,13 @@ in greater details what just happened.
 ==== Prerequisites
 
 This document assumes working knowledge of https://git-scm.com/[git] to be able to retrieve the code for Unomi and the example.
-Additionally, you will require a working Java 8 or above install. Refer to http://www.oracle.com/technetwork/java/javase/[http://www.oracle.com/technetwork/java/javase/] for details on how to download and install Java SE 8 or greater.
+Additionally, you will require a working Java 11 or above install. Refer to http://www.oracle.com/technetwork/java/javase/[http://www.oracle.com/technetwork/java/javase/] for details on how to download and install Java SE 11 or greater.
 
 ===== JDK compatibility
 
 Starting with Java 9, Oracle made some big changes to the Java platform releases. This is why Apache Unomi is focused on
-supporting the Long Term Supported versions of the JDK, currently versions 8 and 11. We do not test with intermediate
-versions so they may or may not work properly. Currently the most tested version is version 8 and version 11 is also
-supported.
+supporting the Long Term Supported versions of the JDK, currently version 11. We do not test with intermediate
+versions so they may or may not work properly. Currently the most tested version is version 11.
 
 Also, as there are new licensing restrictions on JDKs provided by Oracle for production usages, Apache Unomi has also
 added support for OpenJDK builds. Other JDK distributions might also work but are not regularly tested so you should use


### PR DESCRIPTION
Updated manual to indicate that JDK 11 is now the minimal recommended version