### PR TITLE
UNOMI-729 : Use default RAM settings

### DIFF
--- a/manual/src/main/asciidoc/building-and-deploying.adoc
+++ b/manual/src/main/asciidoc/building-and-deploying.adoc
@@ -133,16 +133,15 @@ environment if you intend to re-deploy the context server KAR iteratively.
 Additional requirements:
 * Apache Karaf 4.2.x, http://karaf.apache.org[http://karaf.apache.org]
 
-Before deploying, make sure that you have Apache Karaf properly installed. You will also have to increase the
-default maximum memory size and perm gen size by adjusting the following environment values in the bin/setenv(.bat)
+Before deploying, make sure that you have Apache Karaf properly installed. Depending of your usage, you may also have to increase the
+ memory size by adjusting the following environment values in the bin/setenv(.bat)
 files (at the end of the file):
 
 [source]
 ----
    MY_DIRNAME=`dirname $0`
    MY_KARAF_HOME=`cd "$MY_DIRNAME/.."; pwd`
-   export JAVA_MAX_MEM=3G
-   export JAVA_MAX_PERM_MEM=384M
+   export KARAF_OPTS="$KARAF_OPTS -Xmx3G"
 ----
 
 Install the WAR support, CXF and Karaf Cellar into Karaf by doing the following in the Karaf command line:

--- a/package/src/main/resources/bin/setenv
+++ b/package/src/main/resources/bin/setenv
@@ -58,5 +58,3 @@ MY_KARAF_HOME=`cd "$MY_DIRNAME/.."; pwd`
 # export YOURKIT_AGENTPATH="/home/jahia/install/yourkit/YourKit-JavaProfiler-2017.02/bin/linux-x86-64/libyjpagent.so"
 # Also activate this line to activate the agent on the JVM command line:
 # export KARAF_OPTS="-agentpath:$YOURKIT_AGENTPATH=disablestacktelemetry,exceptions=disable,delay=10000,probe_disable=*"
-
-export JAVA_MAX_MEM=2G

--- a/package/src/main/resources/bin/setenv.bat
+++ b/package/src/main/resources/bin/setenv.bat
@@ -43,11 +43,11 @@ rem SET JAVA_HOME
 rem Minimum memory for the JVM
 rem SET JAVA_MIN_MEM
 rem Maximum memory for the JVM
-SET JAVA_MAX_MEM=2G
+REM SET JAVA_MAX_MEM
 rem Minimum perm memory for the JVM
 rem SET JAVA_PERM_MEM
 rem Maximum perm memory for the JVM
-SET JAVA_MAX_PERM_MEM=512M
+rem SET JAVA_MAX_PERM_MEM
 rem Karaf home folder
 rem SET KARAF_HOME
 rem Karaf data folder


### PR DESCRIPTION
Remove usage of deprecated parameter to set JVM RAM  