### PR TITLE
UNOMI-760 : fix ClassNotFound Exception while executing groovy script

### DIFF
--- a/package/src/main/resources/etc/custom.properties
+++ b/package/src/main/resources/etc/custom.properties
@@ -28,4 +28,4 @@ karaf.systemBundlesStartLevel=50
 # You can place any customized configuration here.
 #
 
-org.osgi.framework.bootdelegation=org.apache.karaf.jaas.boot,org.apache.karaf.jaas.boot.principal,sun.*,com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,javax.management.remote.rmi,com.yourkit.*
+org.osgi.framework.bootdelegation=jdk.internal.reflect,jdk.internal.reflect.*,org.apache.karaf.jaas.boot,org.apache.karaf.jaas.boot.principal,sun.*,com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,javax.management.remote.rmi,com.yourkit.*


### PR DESCRIPTION
 Avoid class not found issue by adding jdk.internal.reflect,jdk.internal.reflect in the framework runtime (jdk9+ issue)
