### PR TITLE
UNOMI-763: Removed duplicate header

### DIFF
--- a/manual/src/main/asciidoc/jsonSchema/json-schema-develop.adoc
+++ b/manual/src/main/asciidoc/jsonSchema/json-schema-develop.adoc
@@ -49,7 +49,6 @@ For example, sending an event not matching a schema:
 curl --request POST \
   --url http://localhost:8181/cxs/jsonSchema/validateEvent \
   --user karaf:karaf \  
-  --header 'Authorization: Basic a2FyYWY6amN1c3RvbWVyUEA1NQ==' \
   --header 'Content-Type: application/json' \
   --data '{
     "eventType": "no-event",


### PR DESCRIPTION
There was a duplicate header (redundant with --user) in the previous version of the doc.