### PR TITLE
UNOMI-788 : remove missing property warning

### DIFF
--- a/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/HardcodedPropertyAccessorRegistry.java
+++ b/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/HardcodedPropertyAccessorRegistry.java
@@ -134,10 +134,6 @@ public class HardcodedPropertyAccessorRegistry {
                 }
             }
         }
-        logger.warn("Couldn't find any property access for class {}. See debug log level for more information", object.getClass().getName());
-        if (logger.isDebugEnabled()) {
-            logger.debug("Couldn't find any property access for class {} and expression {}", object.getClass().getName(), expression);
-        }
         return HardcodedPropertyAccessor.PROPERTY_NOT_FOUND_MARKER;
     }
 

--- a/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/PropertyConditionEvaluator.java
+++ b/plugins/baseplugin/src/main/java/org/apache/unomi/plugins/baseplugin/conditions/PropertyConditionEvaluator.java
@@ -69,6 +69,12 @@ public class PropertyConditionEvaluator implements ConditionEvaluator {
         this.expressionFilterFactory = expressionFilterFactory;
     }
 
+    public void init() {
+        if (!useOGNLScripting) {
+            logger.info("OGNL Script disabled, properties using OGNL won't be evaluated");
+        }
+    }
+
     private int compare(Object actualValue, String expectedValue, Object expectedValueDate, Object expectedValueInteger, Object expectedValueDateExpr, Object expectedValueDouble) {
         if (expectedValue == null && expectedValueDate == null && expectedValueInteger == null && getDate(expectedValueDateExpr) == null && expectedValueDouble == null) {
             return actualValue == null ? 0 : 1;
@@ -318,13 +324,8 @@ public class PropertyConditionEvaluator implements ConditionEvaluator {
         }
         if (useOGNLScripting) {
             return getOGNLPropertyValue(item, expression);
-        } else {
-            logger.warn("OGNL Off. Expression not evaluated on item {}. See debug log level for more information", item.getClass().getName());
-            if (logger.isDebugEnabled()) {
-                logger.debug("OGNL Off. Expression not evaluated on item {}: {}", item.getClass().getName(), expression);
-            }
-            return null;
         }
+        return null;
     }
 
     protected Object getHardcodedPropertyValue(Item item, String expression) {

--- a/plugins/baseplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/plugins/baseplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -155,7 +155,7 @@
         <bean class="org.apache.unomi.plugins.baseplugin.conditions.NotConditionEvaluator"/>
     </service>
 
-    <bean id="propertyConditionEvaluator" class="org.apache.unomi.plugins.baseplugin.conditions.PropertyConditionEvaluator">
+    <bean id="propertyConditionEvaluator" class="org.apache.unomi.plugins.baseplugin.conditions.PropertyConditionEvaluator" init-method="init">
         <property name="usePropertyConditionOptimizations" value="${base.usePropertyConditionOptimizations}"/>
     </bean>
     <service  interface="org.apache.unomi.persistence.elasticsearch.conditions.ConditionEvaluator" ref="propertyConditionEvaluator">


### PR DESCRIPTION
https://issues.apache.org/jira/browse/UNOMI-788

As the property evaluation can fail by design, some warnings were returning false positive information. 