### PR TITLE
UNOMI-842: Updated version to 2.6.0-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-api</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-common</artifactId>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.unomi</groupId>
             <artifactId>unomi-api</artifactId>
-            <version>2.5.1-SNAPSHOT</version>
+            <version>2.6.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-docker</artifactId>

--- a/extensions/geonames/pom.xml
+++ b/extensions/geonames/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-extensions</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cxs-geonames</artifactId>

--- a/extensions/geonames/rest/pom.xml
+++ b/extensions/geonames/rest/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>cxs-geonames</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/geonames/services/pom.xml
+++ b/extensions/geonames/services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>cxs-geonames</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/groovy-actions/karaf-kar/pom.xml
+++ b/extensions/groovy-actions/karaf-kar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-groovy-actions-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/groovy-actions/pom.xml
+++ b/extensions/groovy-actions/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-extensions</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-groovy-actions-root</artifactId>

--- a/extensions/groovy-actions/rest/pom.xml
+++ b/extensions/groovy-actions/rest/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-groovy-actions-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/groovy-actions/services/pom.xml
+++ b/extensions/groovy-actions/services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-groovy-actions-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/json-schema/pom.xml
+++ b/extensions/json-schema/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-extensions</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-json-schema-root</artifactId>

--- a/extensions/json-schema/rest/pom.xml
+++ b/extensions/json-schema/rest/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-json-schema-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/json-schema/services/pom.xml
+++ b/extensions/json-schema/services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-json-schema-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/lists-extension/actions/pom.xml
+++ b/extensions/lists-extension/actions/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>cxs-lists-extension</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/lists-extension/pom.xml
+++ b/extensions/lists-extension/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-extensions</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cxs-lists-extension</artifactId>

--- a/extensions/lists-extension/rest/pom.xml
+++ b/extensions/lists-extension/rest/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>cxs-lists-extension</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/lists-extension/services/pom.xml
+++ b/extensions/lists-extension/services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>cxs-lists-extension</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-extensions</artifactId>

--- a/extensions/privacy-extension/pom.xml
+++ b/extensions/privacy-extension/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-extensions</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cxs-privacy-extension</artifactId>

--- a/extensions/privacy-extension/rest/pom.xml
+++ b/extensions/privacy-extension/rest/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>cxs-privacy-extension</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/privacy-extension/services/pom.xml
+++ b/extensions/privacy-extension/services/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <artifactId>cxs-privacy-extension</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cxs-privacy-extension-services</artifactId>
     <name>Apache Unomi :: Extensions :: Privacy :: Services</name>
     <description>Privacy management extension service implementation for the Apache Unomi Context Server</description>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/extensions/router/pom.xml
+++ b/extensions/router/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-extensions</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-router</artifactId>

--- a/extensions/router/router-api/pom.xml
+++ b/extensions/router/router-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>unomi-router</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/router/router-core/pom.xml
+++ b/extensions/router/router-core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>unomi-router</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/router/router-karaf-feature/pom.xml
+++ b/extensions/router/router-karaf-feature/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>unomi-router</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/router/router-rest/pom.xml
+++ b/extensions/router/router-rest/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>unomi-router</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/router/router-service/pom.xml
+++ b/extensions/router/router-service/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>unomi-router</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/salesforce-connector/actions/pom.xml
+++ b/extensions/salesforce-connector/actions/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-salesforce-connector</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/salesforce-connector/karaf-kar/pom.xml
+++ b/extensions/salesforce-connector/karaf-kar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-salesforce-connector</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/salesforce-connector/pom.xml
+++ b/extensions/salesforce-connector/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-extensions</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-salesforce-connector</artifactId>

--- a/extensions/salesforce-connector/rest/pom.xml
+++ b/extensions/salesforce-connector/rest/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-salesforce-connector</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/salesforce-connector/services/pom.xml
+++ b/extensions/salesforce-connector/services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-salesforce-connector</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/extensions/weather-update/core/pom.xml
+++ b/extensions/weather-update/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-weather-update</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-weather-update-core</artifactId>

--- a/extensions/weather-update/karaf-kar/pom.xml
+++ b/extensions/weather-update/karaf-kar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-weather-update</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/weather-update/pom.xml
+++ b/extensions/weather-update/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-extensions</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-weather-update</artifactId>

--- a/extensions/web-tracker/pom.xml
+++ b/extensions/web-tracker/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-extensions</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-web-tracker</artifactId>

--- a/extensions/web-tracker/wab/pom.xml
+++ b/extensions/web-tracker/wab/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-web-tracker</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-web-tracker-wab</artifactId>

--- a/graphql/cxs-impl/pom.xml
+++ b/graphql/cxs-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-graphql</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/graphql/graphql-playground/pom.xml
+++ b/graphql/graphql-playground/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-graphql</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-graphql-playground</artifactId>

--- a/graphql/karaf-feature/pom.xml
+++ b/graphql/karaf-feature/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-graphql</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>kar</packaging>

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-graphql</artifactId>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>unomi-itests</artifactId>
     <name>Apache Unomi :: Integration Tests</name>

--- a/kar/pom.xml
+++ b/kar/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-kar</artifactId>

--- a/lifecycle-watcher/pom.xml
+++ b/lifecycle-watcher/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>unomi-root</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/manual/pom.xml
+++ b/manual/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>unomi-root</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-metrics</artifactId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi</artifactId>

--- a/persistence-elasticsearch/core/pom.xml
+++ b/persistence-elasticsearch/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-persistence-elasticsearch</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-persistence-elasticsearch-core</artifactId>

--- a/persistence-elasticsearch/pom.xml
+++ b/persistence-elasticsearch/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-persistence-elasticsearch</artifactId>

--- a/persistence-spi/pom.xml
+++ b/persistence-spi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-persistence-spi</artifactId>

--- a/plugins/baseplugin/pom.xml
+++ b/plugins/baseplugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-plugins</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-plugins-base</artifactId>

--- a/plugins/hover-event/pom.xml
+++ b/plugins/hover-event/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-plugins</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-plugins-hover-event</artifactId>

--- a/plugins/kafka-injector/pom.xml
+++ b/plugins/kafka-injector/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-plugins</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-extension</artifactId>

--- a/plugins/mail/pom.xml
+++ b/plugins/mail/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-plugins</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-plugins-mail</artifactId>

--- a/plugins/optimization-test/pom.xml
+++ b/plugins/optimization-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-plugins</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-plugins-optimization-test</artifactId>

--- a/plugins/past-event/pom.xml
+++ b/plugins/past-event/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-plugins</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-plugins-past-event</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-plugins</artifactId>

--- a/plugins/request/pom.xml
+++ b/plugins/request/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-plugins</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-plugins-request</artifactId>

--- a/plugins/tracked-event/pom.xml
+++ b/plugins/tracked-event/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-plugins</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-plugins-tracked-event</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         event tracking server.
     </description>
     <url>https://unomi.apache.org</url>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <licenses>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-rest</artifactId>

--- a/samples/graphql-providers-feature/pom.xml
+++ b/samples/graphql-providers-feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>samples</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>graphql-providers-sample-feature</artifactId>

--- a/samples/graphql-providers/pom.xml
+++ b/samples/graphql-providers/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>samples</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>graphql-providers-sample</artifactId>

--- a/samples/groovy-actions/pom.xml
+++ b/samples/groovy-actions/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>samples</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>test-groovy-action-sample</artifactId>

--- a/samples/login-integration/pom.xml
+++ b/samples/login-integration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>samples</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>login-integration-sample</artifactId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>unomi-root</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/samples/trainingplugin/pom.xml
+++ b/samples/trainingplugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>samples</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>training-plugin</artifactId>
     <name>Apache Unomi :: Samples :: Training plugin</name>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.apache.unomi</groupId>
             <artifactId>unomi-api</artifactId>
-            <version>2.5.1-SNAPSHOT</version>
+            <version>2.6.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/samples/tweet-button-plugin/pom.xml
+++ b/samples/tweet-button-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>samples</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tweet-button-plugin</artifactId>

--- a/scripting/pom.xml
+++ b/scripting/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-scripting</artifactId>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.apache.unomi</groupId>
             <artifactId>unomi-api</artifactId>
-            <version>2.5.1-SNAPSHOT</version>
+            <version>2.6.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-services</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-tools</artifactId>

--- a/tools/shell-commands/pom.xml
+++ b/tools/shell-commands/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>unomi-tools</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>shell-commands</artifactId>

--- a/tools/shell-dev-commands/pom.xml
+++ b/tools/shell-dev-commands/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>unomi-tools</artifactId>
         <groupId>org.apache.unomi</groupId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>shell-dev-commands</artifactId>

--- a/wab/pom.xml
+++ b/wab/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.unomi</groupId>
         <artifactId>unomi-root</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>unomi-wab</artifactId>


### PR DESCRIPTION
Since the next Unomi version is going to be 2.6.0, updated the codebase to point to that version.

2.5.x remains available as a patch (to be created from the 2.5.0 tag).
