### PR TITLE
[UNOMI-853] Adapt migration job to use asynchronous mode avoiding timeout and connection lost

### DIFF
--- a/manual/src/main/asciidoc/configuration.adoc
+++ b/manual/src/main/asciidoc/configuration.adoc
@@ -637,7 +637,7 @@ highly recommended that you design your client applications to use the HTTPS por
 The user accounts to access the REST API are actually routed through Karaf's JAAS support, which you may find the
 documentation for here :
 
-* http://karaf.apache.org/manual/latest/users-guide/security.html[http://karaf.apache.org/manual/latest/users-guide/security.html]
+* https://karaf.apache.org/manual/latest/#_security_2[https://karaf.apache.org/manual/latest/#_security_2]
 
 The default username/password is
 

--- a/tools/shell-commands/src/main/java/org/apache/unomi/shell/migration/utils/MigrationUtils.java
+++ b/tools/shell-commands/src/main/java/org/apache/unomi/shell/migration/utils/MigrationUtils.java
@@ -291,10 +291,9 @@ public class MigrationUtils {
     }
 
     public static void waitForTaskToFinish(CloseableHttpClient httpClient, String esAddress, String taskId, MigrationContext migrationContext) throws IOException {
-        int cpt = 0;
         while (true) {
             final JSONObject status = new JSONObject(
-                    HttpUtils.executeGetRequest(httpClient, esAddress + "/_tasks/" + taskId + "?wait_for_completion=true&timeout=10s",
+                    HttpUtils.executeGetRequest(httpClient, esAddress + "/_tasks/" + taskId + "?wait_for_completion=true&timeout=15s",
                             null));
             if (status.has("completed") && status.getBoolean("completed")) {
                 if (migrationContext != null) {
@@ -308,14 +307,11 @@ public class MigrationUtils {
                 final JSONObject error = status.getJSONObject("error");
                 throw new IOException("Task error: " + error.getString("type") + " - " + error.getString("reason"));
             }
-            if (cpt % 30 == 0) {
-                if (migrationContext != null) {
-                    migrationContext.printMessage("Waiting for Task " + taskId + " to complete");
-                } else {
-                    LOGGER.info("Waiting for Task {} to complete", taskId);
-                }
+            if (migrationContext != null) {
+                migrationContext.printMessage("Waiting for Task " + taskId + " to complete");
+            } else {
+                LOGGER.info("Waiting for Task {} to complete", taskId);
             }
-            cpt++;
         }
     }
 


### PR DESCRIPTION
[UNOMI-853](https://issues.apache.org/jira/browse/UNOMI-853) **Adapt migration job to use asynchronous mode avoiding timeout and connection lost**

Reindex step during migration has been moved to a async task and check against task completion is done until task finish.  
Update a link to karaf in the doc that was broken.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
