### PR TITLE
[UNOMI-854] Add a HealthCheck Endpoint

### DIFF
--- a/extensions/healthcheck/src/main/java/org/apache/unomi/healthcheck/HealthCheckResponse.java
+++ b/extensions/healthcheck/src/main/java/org/apache/unomi/healthcheck/HealthCheckResponse.java
@@ -17,6 +17,8 @@
 
 package org.apache.unomi.healthcheck;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -77,18 +79,22 @@ public class HealthCheckResponse {
         return named(name).error().build();
     }
 
+    @JsonIgnore
     public boolean isLive() {
         return this.status == Status.LIVE;
     }
 
+    @JsonIgnore
     public boolean isUp() {
         return this.status == Status.UP;
     }
 
+    @JsonIgnore
     public boolean isDown() {
         return this.status == Status.DOWN;
     }
 
+    @JsonIgnore
     public boolean isError() {
         return this.status == Status.ERROR;
     }

--- a/extensions/healthcheck/src/main/resources/org.apache.unomi.healthcheck.cfg
+++ b/extensions/healthcheck/src/main/resources/org.apache.unomi.healthcheck.cfg
@@ -26,6 +26,6 @@ httpClient.trustAllCertificates = ${org.apache.unomi.elasticsearch.sslTrustAllCe
 authentication.realm = ${org.apache.unomi.security.realm:-karaf}
 
 # Health check configuration
-healthcheck.enabled = ${org.apache.unomi.healthcheck.enabled:-true}
+healthcheck.enabled = ${org.apache.unomi.healthcheck.enabled:-false}
 healthcheck.providers = ${org.apache.unomi.healthcheck.providers:-cluster,elasticsearch,unomi,persistence}
 healthcheck.timeout = ${org.apache.unomi.healthcheck.timeout:-400}

--- a/itests/src/test/java/org/apache/unomi/itests/BaseIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/BaseIT.java
@@ -260,6 +260,7 @@ public abstract class BaseIT extends KarafTestSupport {
                 systemProperty("org.apache.unomi.hazelcast.network.port").value("5701"),
                 systemProperty("org.apache.unomi.hazelcast.tcp-ip.members").value("127.0.0.1"),
                 systemProperty("org.apache.unomi.hazelcast.tcp-ip.interface").value("127.0.0.1"),
+                systemProperty("org.apache.unomi.healthcheck.enabled").value("true"),
 
                 logLevel(LogLevel.INFO),
                 keepRuntimeFolder(),

--- a/itests/src/test/resources/org.apache.unomi.healthcheck.cfg
+++ b/itests/src/test/resources/org.apache.unomi.healthcheck.cfg
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Elasticsearch configuration
+esAddresses = ${org.apache.unomi.elasticsearch.addresses:-localhost:9200}
+esSSLEnabled = ${org.apache.unomi.elasticsearch.sslEnable:-false}
+esLogin = ${org.apache.unomi.elasticsearch.username:-}
+esPassword = ${org.apache.unomi.elasticsearch.password:-}
+httpClient.trustAllCertificates = ${org.apache.unomi.elasticsearch.sslTrustAllCertificates:-false}
+
+# Security configuration
+authentication.realm = ${org.apache.unomi.security.realm:-karaf}
+
+# Health check configuration
+healthcheck.enabled = ${org.apache.unomi.healthcheck.enabled:-true}
+healthcheck.providers = ${org.apache.unomi.healthcheck.providers:-cluster,elasticsearch,unomi,persistence}
+healthcheck.timeout = ${org.apache.unomi.healthcheck.timeout:-400}

--- a/manual/src/main/asciidoc/configuration.adoc
+++ b/manual/src/main/asciidoc/configuration.adoc
@@ -859,7 +859,7 @@ is up and running and can serve requests.
 
 The health check endpoint is available at the following URL: /health/check and returns a simple JSON response that includes all health check provider responses.
 
-Basic Http Authentication is enabled by default for the health check endpoint using the existing karaf realm. The user needs to have the specific role **health**
+Basic Http Authentication enforce security for the health check endpoint using the existing karaf realm. The user needs to have the specific role **health**
 to access the endpoint. Users and roles can be configured in the etc/users.properties file. By default, a login/pass health/health is configured.
 
 Specific configuration is located in : org.apache.unomi.healthcheck.cfg  Existing health checks are using configuration from that file, including authentication realm.
@@ -912,7 +912,7 @@ Typical response to /health/check when unomi NOT started is :
 ]
 ----
 
-Existing health check can be extended by adding specific provider in the dedicated extension. A provider is a class that implements the HealthCheckProvider interface.
+Existing health check can be extended by adding specific provider in the extension. A provider is a class that implements the HealthCheckProvider interface.
 
 [source,java]
 ----
@@ -931,7 +931,7 @@ Calls to provider are supposed to be done at a regular rate (every 15 seconds fo
 
 Healthcheck extension configuration is located in the file etc/org.apache.unomi.healthcheck.cfg
 
-Extension can be disabled by setting the property `enabled` to `false`. An environment variable can be used to set this property : UNOMI_HEALTHCHECK_ENABLED.
+Extension can be enabled by setting the property `enabled` to `true`. An environment variable can be used to set this property : UNOMI_HEALTHCHECK_ENABLED.
 You must restart the bundle for that config to take effect.
 
 By default, all healthcheck providers are included but the list of those included providers can be customized by setting the property `providers` with a comma separated list of provider names. An environment variable can be used to set this property : UNOMI_HEALTHCHECK_PROVIDERS.


### PR DESCRIPTION
[UNOMI-854](https://issues.apache.org/jira/browse/UNOMI-854) **Add a Healthcheck Endpoint**

Fix HealthCheckResponse JSON format
Configure the extension as disabled by default. 

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)