### PR TITLE
[UNOMI-896]: updated apache comons beanutils from 1.9.4 to 1.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <bean.validation.version>1.1.0.Final</bean.validation.version>
         <apache.commons.io.version>2.16.1</apache.commons.io.version>
         <apache.commons.lang3.version>3.3.2</apache.commons.lang3.version>
-        <apache.commons.beanutils.version>1.9.4</apache.commons.beanutils.version>
+        <apache.commons.beanutils.version>1.11.0</apache.commons.beanutils.version>
         <apache.commons.collections.version>3.2.2</apache.commons.collections.version>
         <apache.commons.email.version>1.3.3</apache.commons.email.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
Updated to a more recent version of Apache Commons beanutils, to a version not vulnerable to CVE-2025-48734

Note: We haven't investigated exposure of Unomi to that CVE via beanutils, this PR is a precaution to make sure the next unomi release does not include a version of beanutils with a vulnerability.

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/UNOMI) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[UNOMI-XXX] - Title of the pull request`
 - [ ] Run `mvn clean install -P integration-tests` to make sure basic checks pass. A more thorough check will be 
        performed on your pull request automatically.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
