### PR TITLE
[UNOMI-878] Replace TimerTasks with TaskExecutor

### DIFF
--- a/services/src/main/java/org/apache/unomi/services/impl/scope/ScopeServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/scope/ScopeServiceImpl.java
@@ -20,11 +20,14 @@ import org.apache.unomi.api.Item;
 import org.apache.unomi.api.Scope;
 import org.apache.unomi.api.services.SchedulerService;
 import org.apache.unomi.api.services.ScopeService;
+import org.apache.unomi.api.tasks.ScheduledTask;
+import org.apache.unomi.api.tasks.TaskExecutor;
 import org.apache.unomi.persistence.spi.PersistenceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -32,14 +35,14 @@ import java.util.stream.Collectors;
 
 public class ScopeServiceImpl implements ScopeService {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScopeServiceImpl.class.getName());
+
     private PersistenceService persistenceService;
-
     private SchedulerService schedulerService;
-
     private Integer scopesRefreshInterval = 1000;
-
     private ConcurrentMap<String, Scope> scopes = new ConcurrentHashMap<>();
 
+    private static final String REFRESH_SCOPES_TASK_TYPE = "refresh-scopes";
     private String refreshScopesTaskId;
 
     public void setPersistenceService(PersistenceService persistenceService) {
@@ -83,14 +86,31 @@ public class ScopeServiceImpl implements ScopeService {
     }
 
     private void initializeTimers() {
-        TimerTask task = new TimerTask() {
+        TaskExecutor refreshScopesTaskExecutor = new TaskExecutor() {
             @Override
-            public void run() {
-                refreshScopes();
+            public String getTaskType() {
+                return REFRESH_SCOPES_TASK_TYPE;
+            }
+
+            @Override
+            public void execute(ScheduledTask task, TaskExecutor.TaskStatusCallback callback) {
+                try {
+                    refreshScopes();
+                    callback.complete();
+                } catch (Exception e) {
+                    LOGGER.error("Error while refreshing scopes", e);
+                    callback.fail(e.getMessage());
+                }
             }
         };
+
+        schedulerService.registerTaskExecutor(refreshScopesTaskExecutor);
+
         this.resetTimers();
-        this.refreshScopesTaskId = schedulerService.createRecurringTask("refreshScopes", scopesRefreshInterval, TimeUnit.MILLISECONDS, task, false).getItemId();
+        this.refreshScopesTaskId = schedulerService.newTask(REFRESH_SCOPES_TASK_TYPE)
+                .withPeriod(scopesRefreshInterval, TimeUnit.MILLISECONDS)
+                .nonPersistent()
+                .schedule().getItemId();
     }
 
     private void resetTimers() {


### PR DESCRIPTION
Replace existing TimerTasks with dedicated TaskExecutor and update codes accordingly.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
