### PR TITLE
chore: configure github settings to only enable squash commits

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,7 @@
+# Documentation/specs available here: https://github.com/apache/infrastructure-asfyaml
+github:
+  enabled_merge_buttons:
+    squash: true
+    squash_commit_message: PR_TITLE
+    merge: false
+    rebase: false


### PR DESCRIPTION
During the monthly project team meeting (participants: @sergehuber @jayblanc @jsinovassin @Fgerthoffert ) we discussed only enabling squash commits in GitHub UI to prevent the wrong button from being clicked when merging a PR.