### PR TITLE
UNOMI-930: sync startup log display to avoid to see it twice

### DIFF
--- a/lifecycle-watcher/src/main/java/org/apache/unomi/lifecycle/BundleWatcherImpl.java
+++ b/lifecycle-watcher/src/main/java/org/apache/unomi/lifecycle/BundleWatcherImpl.java
@@ -58,6 +58,9 @@ public class BundleWatcherImpl implements SynchronousBundleListener, ServiceList
 
     private List<ServerInfo> serverInfos = new ArrayList<>();
 
+    // Lock object to synchronize startup message display
+    private final Object startupMessageLock = new Object();
+
     public void setRequiredBundles(Map<String, Boolean> requiredBundles) {
         this.requiredBundles = new ConcurrentHashMap<>(requiredBundles);
     }
@@ -274,43 +277,43 @@ public class BundleWatcherImpl implements SynchronousBundleListener, ServiceList
     }
 
     private void checkStartupComplete() {
+        if (scheduledFuture != null) {
+            destroyScheduler();
+        }
         if (!isStartupComplete()) {
             startScheduler(getBundleCheckTask());
             return;
-        }
-        if (scheduledFuture != null) {
-            destroyScheduler();
-        }
-        if (!allAdditionalBundleStarted()) {
+        } else if (!allAdditionalBundleStarted()) {
             startScheduler(getAdditionalBundleCheckTask());
             return;
         }
-        if (scheduledFuture != null) {
-            destroyScheduler();
-        }
         if (!startupMessageAlreadyDisplayed) {
-            long totalStartupTime = System.currentTimeMillis() - startupTime;
+            synchronized (startupMessageLock) {
+                if (!startupMessageAlreadyDisplayed) {
+                    long totalStartupTime = System.currentTimeMillis() - startupTime;
 
-            List<String> logoLines = serverInfos.get(serverInfos.size() - 1).getLogoLines();
-            if (logoLines != null && !logoLines.isEmpty()) {
-                logoLines.forEach(System.out::println);
+                    List<String> logoLines = serverInfos.get(serverInfos.size() - 1).getLogoLines();
+                    if (logoLines != null && !logoLines.isEmpty()) {
+                        logoLines.forEach(System.out::println);
+                    }
+                    System.out.println("--------------------------------------------------------------------------------------------");
+                    serverInfos.forEach(serverInfo -> {
+                        String versionMessage = MessageFormat.format(" {0} {1} ({2,date,yyyy-MM-dd HH:mm:ssZ} // {3} // {4} // {5}) ",
+                                StringUtils.rightPad(serverInfo.getServerIdentifier(), 12, " "), serverInfo.getServerVersion(),
+                                serverInfo.getServerBuildDate(), serverInfo.getServerTimestamp(), serverInfo.getServerScmBranch(),
+                                serverInfo.getServerBuildNumber());
+                        System.out.println(versionMessage);
+                        LOGGER.info(versionMessage);
+                    });
+                    System.out.println("--------------------------------------------------------------------------------------------");
+                    System.out.println("Server successfully started " + requiredBundles.size() + " bundles and " + requiredServicesFilters.size()
+                            + " required " + "services in " + totalStartupTime + " ms");
+                    LOGGER.info("Server successfully started {} bundles and {} required services in {} ms", requiredBundles.size(),
+                            requiredServicesFilters.size(), totalStartupTime);
+                    startupMessageAlreadyDisplayed = true;
+                    shutdownMessageAlreadyDisplayed = false;
+                }
             }
-            System.out.println("--------------------------------------------------------------------------------------------");
-            serverInfos.forEach(serverInfo -> {
-                String versionMessage = MessageFormat.format(" {0} {1} ({2,date,yyyy-MM-dd HH:mm:ssZ} // {3} // {4} // {5}) ",
-                        StringUtils.rightPad(serverInfo.getServerIdentifier(), 12, " "), serverInfo.getServerVersion(),
-                        serverInfo.getServerBuildDate(), serverInfo.getServerTimestamp(), serverInfo.getServerScmBranch(),
-                        serverInfo.getServerBuildNumber());
-                System.out.println(versionMessage);
-                LOGGER.info(versionMessage);
-            });
-            System.out.println("--------------------------------------------------------------------------------------------");
-            System.out.println("Server successfully started " + requiredBundles.size() + " bundles and " + requiredServicesFilters.size()
-                    + " required " + "services in " + totalStartupTime + " ms");
-            LOGGER.info("Server successfully started {} bundles and {} required services in {} ms", requiredBundles.size(),
-                    requiredServicesFilters.size(), totalStartupTime);
-            startupMessageAlreadyDisplayed = true;
-            shutdownMessageAlreadyDisplayed = false;
         }
     }
 

--- a/lifecycle-watcher/src/main/java/org/apache/unomi/lifecycle/BundleWatcherImpl.java
+++ b/lifecycle-watcher/src/main/java/org/apache/unomi/lifecycle/BundleWatcherImpl.java
@@ -51,7 +51,7 @@ public class BundleWatcherImpl implements SynchronousBundleListener, ServiceList
     private long matchedRequiredServicesCount = 0;
 
     private BundleContext bundleContext;
-    private boolean startupMessageAlreadyDisplayed = false;
+    private volatile boolean startupMessageAlreadyDisplayed = false;
     private boolean shutdownMessageAlreadyDisplayed = false;
 
     private Integer checkStartupStateRefreshInterval = 60;
@@ -272,7 +272,7 @@ public class BundleWatcherImpl implements SynchronousBundleListener, ServiceList
     }
 
     private void destroyScheduler() {
-        scheduledFuture.cancel(true);
+        scheduledFuture.cancel(false);
         scheduledFuture = null;
     }
 


### PR DESCRIPTION
PR Title format: 
https://issues.apache.org/jira/browse/UNOMI-930


This pull request refines the startup message display logic in the `BundleWatcherImpl` class to ensure thread safety and prevent duplicate messages. The main changes involve introducing a synchronization mechanism and restructuring the startup completion checks.

**Thread safety and startup logic improvements:**

* Added a `startupMessageLock` object and synchronized the startup message display block to prevent concurrent threads from displaying the startup message multiple times. 
