### PR TITLE
Upgrade CodeQL Action from v2 to v3 in JavaScript workflow

### DIFF
--- a/.github/workflows/codeql-analysis-javascript.yml
+++ b/.github/workflows/codeql-analysis-javascript.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

- Upgrades all `github/codeql-action` references in `.github/workflows/codeql-analysis-javascript.yml` from **v2** to **v3** (`init`, `autobuild`, `analyze`)
- CodeQL Action v2 was retired on January 10, 2025 and is no longer updated or supported. Workflows using v2 may eventually break.
- The Java CodeQL workflow (`codeql-analysis-java.yml`) was already on v3 and required no changes.

## References

- https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/

## Test plan

- [ ] Verify the "CodeQL Javascript" workflow runs successfully on this PR
- [ ] Confirm no v2 references remain in any workflow files

Made with [Cursor](https://cursor.com)