### PR TITLE
fix: Fix unexisting bundle maven type for artefact httpclient-osgi

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -271,12 +271,6 @@
                 <version>${httpclient-osgi.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient-osgi</artifactId>
-                <version>${httpclient-osgi.version}</version>
-                <type>bundle</type>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka-client.version}</version>

--- a/extensions/healthcheck/pom.xml
+++ b/extensions/healthcheck/pom.xml
@@ -96,7 +96,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-osgi</artifactId>
-            <type>bundle</type>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/extensions/router/router-karaf-feature/pom.xml
+++ b/extensions/router/router-karaf-feature/pom.xml
@@ -73,7 +73,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-osgi</artifactId>
-            <type>bundle</type>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/extensions/router/router-rest/pom.xml
+++ b/extensions/router/router-rest/pom.xml
@@ -86,7 +86,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-osgi</artifactId>
-            <type>bundle</type>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tools/shell-commands/pom.xml
+++ b/tools/shell-commands/pom.xml
@@ -55,7 +55,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-osgi</artifactId>
-            <type>bundle</type>
             <scope>provided</scope>
         </dependency>
 

--- a/tools/shell-dev-commands/pom.xml
+++ b/tools/shell-dev-commands/pom.xml
@@ -92,7 +92,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-osgi</artifactId>
-            <type>bundle</type>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION

This PR remove a wrong artefact declared in unomi-bom and fixes references in another pom.
The artefact is httpclient-osgi that was typed as 'bundle' but this type does not exists (it is jar in fact) and is only use by felix during artefact build (to generate MANIFEST)