### PR TITLE
UNOMI-882: Enable AsciiDoctor diagrams (PlantUML/GraphViz) and expand manual

### DIFF
--- a/.github/workflows/unomi-ci-build-tests.yml
+++ b/.github/workflows/unomi-ci-build-tests.yml
@@ -25,6 +25,11 @@ jobs:
         distribution: 'temurin'
         java-version: '17'
         cache: 'maven'
+    - name: Install GraphViz
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y graphviz
+        dot -V
     - name: Build and Unit tests
       run: mvn -U -ntp -e clean install
 

--- a/.github/workflows/unomi-ci-docs-deploy.yml
+++ b/.github/workflows/unomi-ci-docs-deploy.yml
@@ -23,6 +23,11 @@ jobs:
           server-id: apache.snapshots.https
           server-username: NEXUS_USER
           server-password: NEXUS_PW
+      - name: Install GraphViz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
+          dot -V
       - name: Generate documentation
         run: mvn -U -ntp -e clean install -DskipTests javadoc:aggregate source:aggregate
       - name: Build & deploy snapshots

--- a/.github/workflows/unomi-ci-docs.yml
+++ b/.github/workflows/unomi-ci-docs.yml
@@ -35,7 +35,7 @@ jobs:
           mvn -U -ntp clean install
       
       - name: Archive documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unomi-documentation
           path: |

--- a/.github/workflows/unomi-ci-docs.yml
+++ b/.github/workflows/unomi-ci-docs.yml
@@ -1,0 +1,44 @@
+name: Documentation Generation
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - 'manual/**'
+      - '.github/workflows/unomi-ci-docs.yml'
+
+jobs:
+  build-docs:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+      
+      - name: Install GraphViz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
+          dot -V
+      
+      - name: Build Manual
+        run: |
+          cd manual
+          mvn -U -ntp clean install
+      
+      - name: Archive documentation
+        uses: actions/upload-artifact@v3
+        with:
+          name: unomi-documentation
+          path: |
+            manual/target/generated-docs/html/latest/
+            manual/target/generated-docs/pdf/latest/
+            manual/target/*.pdf 

--- a/manual/pom.xml
+++ b/manual/pom.xml
@@ -33,6 +33,8 @@
         <doc.output.html>target/generated-docs/html/latest</doc.output.html>
         <doc.output.pdf>target/generated-docs/pdf/latest</doc.output.pdf>
         <doc.version>${project.version}</doc.version>
+        <!-- Default path to GraphViz dot executable, can be overridden via -Dgraphviz.dot.path=/path/to/dot -->
+        <graphviz.dot.path>${env.GRAPHVIZ_DOT}</graphviz.dot.path>
     </properties>
 
     <build>
@@ -41,12 +43,22 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>1.6.0</version>
+                <version>3.2.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>1.5.3</version>
+                        <version>1.6.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj-diagram</artifactId>
+                        <version>2.2.13</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj-diagram-plantuml</artifactId>
+                        <version>1.2024.5</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -57,14 +69,18 @@
                             <goal>process-asciidoc</goal>
                         </goals>
                         <configuration>
+                            <requires>
+                                <require>asciidoctor-diagram</require>
+                            </requires>
+                            <attributes>
+                                <graphvizdot>${graphviz.dot.path}</graphvizdot>
+                            </attributes>
                             <sourceDocumentName>index.adoc</sourceDocumentName>
                             <sourceDirectory>${doc.source}</sourceDirectory>
                             <outputDirectory>${doc.output.html}</outputDirectory>
                             <preserveDirectories>true</preserveDirectories>
-                            <headerFooter>true</headerFooter>
-                            <imagesDir>${doc.source}/images</imagesDir>
                             <backend>html5</backend>
-                            <doctype>article</doctype>
+                            <doctype>book</doctype>
                             <attributes>
                                 <toc />
                                 <linkcss>true</linkcss>
@@ -80,12 +96,14 @@
                             <goal>process-asciidoc</goal>
                         </goals>
                         <configuration>
+                            <requires>
+                                <require>asciidoctor-diagram</require>
+                            </requires>
                             <sourceDocumentName>index.adoc</sourceDocumentName>
                             <sourceDirectory>${doc.source}</sourceDirectory>
                             <outputDirectory>${doc.output.pdf}</outputDirectory>
                             <outputFile>${project.build.directory}/${project.artifactId}-${doc.version}.pdf</outputFile>
                             <preserveDirectories>true</preserveDirectories>
-                            <headerFooter>true</headerFooter>
                             <backend>pdf</backend>
                             <attributes>
                                 <project-version>${project.version}</project-version>

--- a/manual/src/main/asciidoc/building-and-deploying.adoc
+++ b/manual/src/main/asciidoc/building-and-deploying.adoc
@@ -12,11 +12,12 @@
 // limitations under the License.
 //
 
+[[_building]]
 === Building
 
 Apache Unomi 3.x provides a convenient `build.sh` script that simplifies the build process with
 enhanced error handling, preflight validation, and deployment options. See the
-<<Using the build.sh script>> section below for details. Alternatively, you can build using Maven
+<<_using_the_build_script,Using the build.sh script>> section below for details. Alternatively, you can build using Maven
 directly as described in this section.
 
 ==== Initial Setup
@@ -33,6 +34,8 @@ directly as described in this section.
  the MVN_HOME/bin directory.
 
 ==== Building
+
+===== Unix/Linux/macOS
 
 . Get the code: `git clone https://github.com/apache/unomi.git`
 . Change to the top level directory of Apache Unomi source distribution.
@@ -69,6 +72,7 @@ TIP: On a non-English Windows env, the Asciidoctor Maven Plugin may fail to
 +
 . The distributions will be available under "package/target" directory.
 
+[[_using_the_build_script]]
 ==== Using the build.sh script
 
 Apache Unomi 3.x provides a unified `build.sh` script that simplifies the build, deployment, and execution process.
@@ -79,8 +83,11 @@ The `build.sh` script offers the following features:
 
 * **Preflight validation**: Automatically checks for required tools (Java, Maven, GraphViz), system resources
   (memory, disk space), Maven settings, and port availability
-* **Flexible build options**: Support for skipping tests, running integration tests, using OpenSearch, debug modes,
+* **Flexible build options**: Support for skipping tests, running integration tests, using OpenSearch, setting Unomi distribution, debug modes,
   and more
+* **Distribution management**: The `--distribution` parameter allows you to specify which Unomi distribution to use (e.g., `unomi-distribution-opensearch`, `unomi-distribution-elasticsearch`).
+  When used with `--use-opensearch`, the distribution is automatically set to `unomi-distribution-opensearch` if not explicitly specified.
+  Conversely, if a distribution containing "opensearch" is specified, OpenSearch is automatically enabled for integration tests.
 * **Deployment helpers**: Automatically copies KAR packages to Karaf deploy directory and purges caches
 * **Enhanced output**: Colorized, structured output with progress indicators (respects `NO_COLOR` environment variable)
 
@@ -105,6 +112,20 @@ Common usage examples:
 [source]
 ----
 ./build.sh --integration-tests --use-opensearch
+----
++
+* Build with a specific Unomi distribution (automatically enables OpenSearch for tests if distribution contains "opensearch"):
++
+[source]
+----
+./build.sh --integration-tests --distribution unomi-distribution-opensearch
+----
++
+* Build with OpenSearch using explicit distribution (both parameters work together):
++
+[source]
+----
+./build.sh --integration-tests --use-opensearch --distribution unomi-distribution-opensearch-graphql
 ----
 +
 * Build in debug mode:
@@ -258,8 +279,6 @@ For more information, see the official documentation:
 
 ==== Installing a Search Engine
 
-==== Installing an ElasticSearch server
-
 Starting with version 1.2, Apache Unomi no longer embeds a search engine server. You will need to install either ElasticSearch or OpenSearch as a standalone service.
 
 ===== Option 1: Using ElasticSearch
@@ -274,7 +293,7 @@ Starting with version 1.2, Apache Unomi no longer embeds a search engine server.
 ----
 cluster.name: contextElasticSearch
 ----
-
++
 4. Launch the server using:
 
 [source]
@@ -318,11 +337,11 @@ services:
 volumes:
   opensearch-data1:
 ----
-
++
 2. Set up your Docker host environment:
    * **macOS & Windows**: In Docker _Preferences_ > _Resources_, set RAM to at least 4 GB
    * **Linux**: Ensure `vm.max_map_count` is set to at least 262144
-
++
 3. Start OpenSearch using:
 [source]
 ----
@@ -419,6 +438,62 @@ Create a new $MY_KARAF_HOME/etc/org.apache.cxf.osgi.cfg file and put the followi
 If all went smoothly, you should be able to access the context script here : http://localhost:8181/cxs/cluster[http://localhost:8181/cxs/cluster] .
  You should be able to login with karaf / karaf and see basic server information. If not something went wrong during the install.
 
+==== Installing GraphViz for Manual Generation
+
+The manual project uses PlantUML diagrams which require GraphViz to be installed. Here's how to install it:
+
+===== On macOS using Homebrew
+[source]
+----
+brew install graphviz
+----
+
+===== On Linux (Debian/Ubuntu)
+[source]
+----
+sudo apt-get install graphviz
+----
+
+===== On Linux (RHEL/CentOS/Fedora)
+[source]
+----
+sudo dnf install graphviz
+----
+
+===== On Windows
+1. Download the installer from https://graphviz.org/download/
+2. Run the installer
+3. Add the GraphViz bin directory to your PATH
+
+===== Building the Manual
+
+You can build the manual directly from the manual directory:
+
+[source]
+----
+cd manual
+mvn clean install
+----
+
+The build script will automatically detect and configure the GraphViz path. If you need to set it manually, you can:
+
+1. Set it via environment variable:
+[source]
+----
+export GRAPHVIZ_DOT=/path/to/dot
+mvn clean install
+----
++
+2. Or specify it directly to Maven:
+[source]
+----
+mvn clean install -Dgraphviz.dot.path=/path/to/dot
+----
+
+The generated documentation will be available in:
+- HTML: `target/generated-docs/html/latest/`
+- PDF: `target/generated-docs/pdf/latest/`
+
 ==== JDK Selection on Mac OS X
 
 You might need to select the JDK to run the tests in the itests subproject. In order to do so you can list the
@@ -482,11 +557,34 @@ mvn -P integration-tests clean install
 
 ===== Selecting the Search Engine for Integration Tests
 
-By default, integration tests target ElasticSearch. To run them against OpenSearch, set the activation property used by the OpenSearch profile (no additional -P flags are required):
+By default, integration tests target ElasticSearch. To run them against OpenSearch, you can use either:
 
+* **Using the build script** (recommended):
++
+[source]
+----
+./build.sh --integration-tests --use-opensearch
+----
++
+Or specify the distribution directly (automatically enables OpenSearch if distribution contains "opensearch"):
++
+[source]
+----
+./build.sh --integration-tests --distribution unomi-distribution-opensearch
+----
++
+* **Using Maven directly**: Set the activation property used by the OpenSearch profile (no additional -P flags are required):
++
 [source]
 ----
 mvn -P integration-tests -Duse.opensearch=true clean install
+----
++
+You can also set the Unomi distribution system property:
++
+[source]
+----
+mvn -P integration-tests -Dunomi.distribution=unomi-distribution-opensearch clean install
 ----
 
 ==== Testing with an example page

--- a/manual/src/main/asciidoc/builtin-action-types.adoc
+++ b/manual/src/main/asciidoc/builtin-action-types.adoc
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+[[_builtin_action_types]]
 === Built-in action types
 
 Unomi comes with quite a lot of built-in action types. Instead of detailing them one by one you will find here an overview of

--- a/manual/src/main/asciidoc/builtin-condition-types.adoc
+++ b/manual/src/main/asciidoc/builtin-condition-types.adoc
@@ -12,6 +12,7 @@
 // limitations under the License.
 //
 
+[[_builtin_condition_types]]
 === Built-in condition types
 
 Apache Unomi comes with an extensive collection of built-in condition types. Instead of detailing them one by one you will
@@ -78,13 +79,13 @@ When implementing a new condition type, you need to provide implementations for 
 <!-- OpenSearch Query Builder -->
 <service interface="org.apache.unomi.persistence.opensearch.ConditionOSQueryBuilder">
     <service-properties>
-        <entry key="queryBuilderId" value="booleanConditionOSQueryBuilder"/>
+        <entry key="queryBuilderId" value="booleanConditionQueryBuilder"/>
     </service-properties>
     <bean class="org.apache.unomi.persistence.opensearch.BooleanConditionOSQueryBuilder"/>
 </service>
 
 <!-- Condition Evaluator (shared between both engines) -->
-<service interface="org.apache.unomi.persistence.spi.conditions.ConditionEvaluator">
+<service interface="org.apache.unomi.persistence.spi.conditions.evaluator.ConditionEvaluator">
     <service-properties>
         <entry key="conditionEvaluatorId" value="booleanConditionEvaluator"/>
     </service-properties>

--- a/manual/src/main/asciidoc/builtin-event-types.adoc
+++ b/manual/src/main/asciidoc/builtin-event-types.adoc
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+[[_builtin_event_types]]
 === Built-in Event types
 
 Apache Unomi comes with built-in event types, which we describe below.

--- a/manual/src/main/asciidoc/condition-evaluation.adoc
+++ b/manual/src/main/asciidoc/condition-evaluation.adoc
@@ -1,0 +1,131 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+=== Condition Evaluation System
+
+The condition evaluation system in Apache Unomi provides flexible and efficient evaluation of conditions across different storage backends.
+
+==== Architecture Overview
+
+=== Condition Evaluation Architecture
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam component {
+  BackgroundColor<<evaluation>> LightBlue
+  BackgroundColor<<query>> LightGreen
+  BackgroundColor<<persistence>> LightYellow
+}
+
+package "Condition Evaluation" {
+  [ConditionDispatcher] <<evaluation>>
+  [ConditionEvaluator] <<evaluation>>
+  [ConditionESQueryBuilder] <<query>>
+  [ConditionOSQueryBuilder] <<query>>
+}
+
+package "Query Building" {
+  interface "QueryBuilder" as QB
+  [ElasticSearchQueryBuilder] <<query>>
+  [OpenSearchQueryBuilder] <<query>>
+}
+
+package "Storage" {
+  [ElasticSearch] <<persistence>>
+  [OpenSearch] <<persistence>>
+}
+
+[ConditionDispatcher] --> [ConditionEvaluator]
+[ConditionDispatcher] --> QB
+
+QB <|.. [ConditionESQueryBuilder]
+QB <|.. [ConditionOSQueryBuilder]
+
+[ConditionESQueryBuilder] --> [ElasticSearchQueryBuilder]
+[ConditionOSQueryBuilder] --> [OpenSearchQueryBuilder]
+
+[ElasticSearchQueryBuilder] --> [ElasticSearch]
+[OpenSearchQueryBuilder] --> [OpenSearch]
+
+note right of [ConditionDispatcher]
+  Routes condition evaluation:
+  1. Direct evaluation
+  2. Query-based evaluation
+end note
+
+note right of QB
+  Abstract query building
+  for different search
+  engine implementations
+end note
+@enduml
+----
+
+==== Key Components
+
+1. *ConditionDispatcher*
+- Routes conditions to appropriate evaluators
+- Determines evaluation strategy (direct vs query-based)
+- Handles caching and optimization
+
+2. *ConditionEvaluator*
+- Performs direct condition evaluation
+- Handles boolean logic and property comparisons
+- Evaluates nested conditions
+
+3. *QueryBuilders*
+- Convert conditions to search engine queries
+- Handle search engine specific syntax
+- Optimize query performance
+
+==== Evaluation Strategies
+
+1. *Direct Evaluation*
+- Used for simple conditions
+- Evaluates against in-memory data
+- No storage queries required
+- Fastest evaluation path
+
+2. *Query-Based Evaluation*
+- Used for complex conditions
+- Converts conditions to storage queries
+- Supports different search engines
+- Handles large data sets efficiently
+
+==== Query Builder Implementation
+
+Query builders provide storage-specific implementations:
+
+1. *ElasticSearch Implementation*
+- Optimized for ES query syntax
+- Handles ES-specific mappings
+- Supports ES versioning
+
+2. *OpenSearch Implementation*
+- Compatible with OS API
+- Maintains OS-specific features
+- Handles OS security model
+
+==== Best Practices
+
+1. *Performance Optimization*
+- Use direct evaluation when possible
+- Leverage caching for frequent queries
+- Consider query complexity impact
+
+2. *Implementation Guidelines*
+- Implement storage-specific query builders
+- Handle version compatibility
+- Consider security implications

--- a/manual/src/main/asciidoc/connectors/connectors.adoc
+++ b/manual/src/main/asciidoc/connectors/connectors.adoc
@@ -15,7 +15,7 @@
 
 Apache Unomi provides the following connectors:
 
-* <<Salesforce Connector,Salesforce CRM connector>>
+* <<_salesforce_connector,Salesforce CRM connector>>
 
 ==== Call for contributors
 

--- a/manual/src/main/asciidoc/connectors/salesforce-connector.adoc
+++ b/manual/src/main/asciidoc/connectors/salesforce-connector.adoc
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+[[_salesforce_connector]]
 === Salesforce Connector
 
 This connectors makes it possible to push and pull data to/from the Salesforce CRM. It can copy information between
@@ -112,7 +113,7 @@ Both URLs are password protected by the Apache Unomi (Karaf) password. You can f
 in the etc/users.properties file.
 
 You can now use the connectors's defined actions in rules to push or pull data to/from the Salesforce CRM. You can
-find more information about rules in the <<Data Model Overview,Data Model>> and the <<Getting started with Unomi,Getting Started>> pages.
+find more information about rules in the <<_data_model_overview,Data Model>> and the <<_getting_started_with_unomi,Getting Started>> pages.
 
 ==== Properties
 

--- a/manual/src/main/asciidoc/data-structures.adoc
+++ b/manual/src/main/asciidoc/data-structures.adoc
@@ -1,0 +1,763 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+==== Core Data Structures Overview
+
+==== Base Types
+
+All major entities in Apache Unomi inherit from two base classes that provide essential functionality:
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam class {
+    BackgroundColor White
+    BorderColor DarkGray
+    ArrowColor DarkGray
+    FontSize 14
+}
+
+abstract class Item {
+    + itemId: String
+    + itemType: String
+    + scope: String
+    + version: Long
+    + systemProperties: Map
+}
+
+abstract class MetadataItem {
+    + metadata: Metadata
+}
+
+class Metadata {
+    + id: String
+    + name: String
+    + description: String
+    + scope: String
+    + tags: Set<String>
+    + enabled: Boolean
+    + hidden: Boolean
+    + readOnly: Boolean
+}
+
+Item <|-- MetadataItem
+MetadataItem *-- "1" Metadata
+
+note right of Item
+  Base class for all Unomi objects
+  providing identification and
+  versioning
+end note
+
+note right of MetadataItem
+  Adds metadata support for
+  naming, description, and
+  operational flags
+end note
+@enduml
+----
+
+==== Core Entities and Their Relationships
+
+This diagram shows the key data structures in Apache Unomi and their relationships:
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam class {
+    BackgroundColor White
+    BorderColor DarkGray
+    ArrowColor DarkGray
+    FontSize 14
+}
+
+' Core entities
+class Profile {
+    + itemId: String
+    + properties: Map
+    + segments: Set<String>
+    + scores: Map<String,Integer>
+    + consents: Map<String,Consent>
+    + systemProperties: Map
+}
+
+class Event {
+    + eventType: String
+    + sessionId: String
+    + profileId: String
+    + timeStamp: Date
+    + properties: Map
+    + persistent: Boolean
+    + attributes: Map
+}
+
+class Session {
+    + profileId: String
+    + properties: Map
+    + timeStamp: Date
+    + lastEventDate: Date
+    + duration: Long
+    + size: Integer
+}
+
+class Segment {
+    + itemId: String
+    + condition: Condition
+}
+
+class Rule {
+    + condition: Condition
+    + actions: List<Action>
+    + priority: Integer
+    + raiseEventOnlyOnce: Boolean
+    + raiseEventOnlyOnceForProfile: Boolean
+    + raiseEventOnlyOnceForSession: Boolean
+}
+
+class Goal {
+    + startEvent: Condition
+    + targetEvent: Condition
+    + campaignId: String
+}
+
+class Campaign {
+    + startDate: Date
+    + endDate: Date
+    + cost: Double
+    + currency: String
+    + primaryGoal: String
+    + timezone: String
+}
+
+class Consent {
+    + scope: String
+    + typeIdentifier: String
+    + status: String
+    + statusDate: Date
+    + revokeDate: Date
+}
+
+' Relationships
+Profile "1" *-- "*" Event : generates >
+Profile "1" *-- "*" Session : has >
+Profile "*" -- "*" Segment : belongs to >
+Profile "*" -- "*" Campaign : participates in >
+Profile "1" *-- "*" Consent : manages >
+
+Event "*" -- "1" Session : part of >
+Event -- Goal : triggers >
+Event "*" -- "1" Profile : associated with >
+
+Campaign "1" *-- "*" Goal : contains >
+Rule "*" -- "*" Event : processes >
+
+note right of Profile
+  Central entity representing a visitor
+  - Properties are extensible
+  - Segments are dynamic
+  - Consents track permissions
+end note
+
+note right of Event
+  Records all interactions
+  - Can be persistent or transient
+  - Links profile and session
+  - Carries properties and context
+end note
+
+note right of Session
+  Time-bounded interaction period
+  - Tracks duration and activity
+  - Links to profile
+  - Maintains state
+end note
+
+note left of Rule
+  Defines automated responses
+  - Priority controls execution order
+  - Can limit event generation
+  - Executes actions on match
+end note
+
+@enduml
+----
+
+==== Key Relationships
+
+* *Profile* is the central entity representing a visitor/customer
+** Properties are fully extensible via Map structure
+** Segments are dynamically evaluated and stored as Set
+** Scores track numeric metrics per profile
+** Consents manage user permissions and preferences
+** System properties store internal data
+
+* *Event* represents any interaction or activity
+** Always associated with both profile and session
+** Can be persistent (stored) or transient
+** Carries properties and context attributes
+** Timestamp tracks occurrence time
+** Can trigger rules and goals
+
+* *Session* represents a time-bounded interaction period
+** Belongs to a single profile
+** Tracks duration and last activity
+** Maintains size counter for events
+** Properties store session-specific state
+
+* *Rule* defines automated behavior
+** Processes events using conditions
+** Executes actions when conditions match
+** Priority controls execution order
+** Can limit event generation:
+*** Once per profile
+*** Once per session
+*** Once globally
+
+* *Segment* groups profiles dynamically
+** Uses conditions to determine membership
+** Profiles can belong to multiple segments
+** Automatically maintained by the system
+
+* *Goal* tracks objective completion
+** Defined by start and target conditions
+** Can be part of a campaign
+** Triggered by specific events
+
+* *Campaign* organizes marketing activities
+** Contains multiple goals
+** Tracks costs and timeframes
+** Associates profiles with marketing efforts
+** Supports timezone-aware scheduling
+
+* *Consent* manages user permissions
+** Scoped to specific areas/features
+** Tracks status and dates
+** Supports revocation
+** Linked to profiles
+
+All these entities inherit from `MetadataItem` which provides:
+- Metadata (name, description, scope, tags)
+- Enabled/disabled status
+- Hidden/visible status
+- Read-only protection
+- Version tracking
+
+==== Detailed Structure Definitions
+
+The following sections provide detailed diagrams for each major component:
+
+==== Condition Structure
+
+Conditions are the fundamental building blocks used across many Unomi components. They evaluate to true/false and can be composed.
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam component {
+  BackgroundColor LightBlue
+  BorderColor DarkBlue
+}
+
+class Condition {
+  + type: String
+  + parameterValues: Map<String,Object>
+}
+
+class BooleanCondition {
+  + operator: String (and/or)
+  + subConditions: List<Condition>
+}
+
+class PropertyCondition {
+  + propertyName: String
+  + comparisonOperator: String
+  + propertyValue: Object
+}
+
+class EventCondition {
+  + eventTypeId: String
+}
+
+class PastEventCondition {
+  + eventType: String
+  + numberOfDays: Integer
+  + minimumCount: Integer
+  + maximumCount: Integer
+}
+
+Condition <|-- BooleanCondition
+Condition <|-- PropertyCondition
+Condition <|-- EventCondition
+Condition <|-- PastEventCondition
+
+note right of Condition
+  Base structure for all conditions.
+  Used in segments, rules, goals, etc.
+end note
+@enduml
+----
+
+==== Segment Structure
+
+Segments group profiles based on conditions. They are dynamic - profiles can enter/exit based on condition evaluation.
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam component {
+  BackgroundColor LightGreen
+  BorderColor DarkGreen
+}
+
+class Segment {
+  + itemId: String
+  + itemType: "segment"
+  + metadata: Metadata
+  + condition: Condition
+}
+
+class Metadata {
+  + id: String
+  + name: String
+  + scope: String
+  + description: String
+  + tags: List<String>
+  + enabled: Boolean
+}
+
+class Profile {
+  + itemId: String
+  + properties: Map
+  + segments: List<String>
+}
+
+Segment --> "1" Condition : uses
+Segment --> "1" Metadata : has
+Profile --> "*" Segment : belongs to
+
+note right of Segment
+  Segments automatically generate rules
+  to maintain profile membership
+end note
+@enduml
+----
+
+==== Rule Structure
+
+Rules define automated actions triggered by conditions.
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam component {
+  BackgroundColor LightYellow
+  BorderColor DarkGoldenRod
+}
+
+class Rule {
+  + itemId: String
+  + itemType: "rule"
+  + metadata: Metadata
+  + condition: Condition
+  + actions: List<Action>
+  + raiseEventOnlyOnce: Boolean
+  + priority: Integer
+}
+
+class Action {
+  + type: String
+  + parameterValues: Map
+}
+
+class Event {
+  + eventType: String
+  + source: Item
+  + target: Item
+  + properties: Map
+}
+
+Rule --> "1" Condition : triggers on
+Rule --> "*" Action : executes
+Rule ..> Event : may raise
+
+note right of Rule
+  Rules execute actions when
+  conditions match incoming events
+end note
+@enduml
+----
+
+==== Goal Structure
+
+Goals track visitor progress toward specific objectives.
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam component {
+  BackgroundColor LightPink
+  BorderColor DarkRed
+}
+
+class Goal {
+  + itemId: String
+  + itemType: "goal"
+  + metadata: Metadata
+  + startEvent: Condition
+  + targetEvent: Condition
+  + campaignId: String
+}
+
+class Campaign {
+  + itemId: String
+  + startDate: Date
+  + endDate: Date
+  + cost: Double
+  + currency: String
+  + primaryGoal: String
+}
+
+class GoalEvent {
+  + eventType: "goal"
+  + source: Event
+  + target: Goal
+}
+
+Goal --> "1" Condition : starts with
+Goal --> "1" Condition : completes with
+Goal --> "0..1" Campaign : part of
+Goal ..> GoalEvent : generates
+
+note right of Goal
+  Goals track progress from
+  start to target conditions
+end note
+@enduml
+----
+
+==== Campaign Structure
+
+Campaigns organize marketing activities with goals, timeframes and costs.
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam component {
+  BackgroundColor LightSalmon
+  BorderColor DarkRed
+}
+
+class Campaign {
+  + itemId: String
+  + itemType: "campaign"
+  + metadata: Metadata
+  + startDate: Date
+  + endDate: Date
+  + entryCondition: Condition
+  + cost: Double
+  + currency: String
+  + primaryGoal: String
+  + timezone: String
+}
+
+class Goal {
+  + itemId: String
+  + campaignId: String
+}
+
+class Profile {
+  + itemId: String
+  + properties: Map
+}
+
+Campaign --> "1" Condition : entry criteria
+Campaign --> "1..*" Goal : contains
+Campaign --> "*" Profile : tracks
+
+note right of Campaign
+  Campaigns organize marketing activities
+  with goals, timeframes and costs
+end note
+@enduml
+----
+
+==== Integration Flow
+
+This diagram shows how these components work together in practice.
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam component {
+  BackgroundColor White
+  BorderColor Black
+}
+
+actor Visitor
+participant "Event Collector" as EC
+participant "Rule Engine" as RE
+database "Profile Store" as PS
+database "Event Store" as ES
+
+Visitor -> EC: Generate Event
+EC -> RE: Process Event
+RE -> PS: Load Profile
+RE -> ES: Query Past Events
+
+group Rule Evaluation
+  RE -> RE: Evaluate Conditions
+  RE -> RE: Execute Actions
+end
+
+group Segment Processing  
+  RE -> PS: Update Profile
+  RE -> PS: Update Segments
+end
+
+group Goal Tracking
+  RE -> RE: Check Goal Progress
+  RE -> PS: Record Goal Completion
+end
+
+group Campaign Metrics
+  RE -> PS: Update Campaign Stats
+end
+
+@enduml
+----
+
+The diagrams above illustrate the key data structures in Apache Unomi and how they work together to enable personalization and marketing automation. Each component builds on the foundational concept of conditions to create increasingly sophisticated targeting and tracking capabilities. 
+
+==== Condition Composition Structure
+
+The following diagram illustrates how conditions can be nested and composed to create complex matching logic:
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam class {
+    BackgroundColor White
+    BorderColor DarkGray
+    ArrowColor DarkGray
+    FontSize 14
+}
+
+abstract class Condition {
+    + type: String
+    + parameterValues: Map<String,Object>
+}
+
+class BooleanCondition {
+    + operator: String (and/or/not)
+    + subConditions: List<Condition>
+}
+
+class PropertyCondition {
+    + propertyName: String
+    + comparisonOperator: String
+    + propertyValue: Object
+}
+
+class EventCondition {
+    + eventTypeId: String
+    + properties: Map<String,Object>
+}
+
+class PastEventCondition {
+    + eventCondition: EventCondition
+    + minimumEventCount: Integer
+    + maximumEventCount: Integer
+    + fromDate: Date
+    + toDate: Date
+    + countCondition: String
+}
+
+class SessionPropertyCondition {
+    + propertyName: String
+    + comparisonOperator: String
+    + propertyValue: Object
+}
+
+class ProfileSegmentCondition {
+    + segments: List<String>
+    + matchType: String (all/some)
+}
+
+Condition <|-- BooleanCondition
+Condition <|-- PropertyCondition
+Condition <|-- EventCondition
+Condition <|-- PastEventCondition
+Condition <|-- SessionPropertyCondition
+Condition <|-- ProfileSegmentCondition
+
+BooleanCondition o-- "*" Condition : contains >
+PastEventCondition o-- "1" EventCondition : uses >
+
+note right of BooleanCondition
+  Combines multiple conditions with
+  logical operators (AND/OR/NOT)
+end note
+
+note right of PastEventCondition
+  Matches events that occurred
+  in a specific time window
+  with count constraints
+end note
+
+@enduml
+----
+
+===== Example Condition Compositions
+
+Here are some examples of how conditions can be composed:
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam object {
+    BackgroundColor White
+    BorderColor DarkGray
+    ArrowColor DarkGray
+}
+
+object "BooleanCondition (AND)" as root {
+    type = "booleanCondition"
+    operator = "and"
+}
+
+object "ProfileSegmentCondition" as seg {
+    type = "profileSegmentCondition"
+    segments = ["premium-customer"]
+}
+
+object "BooleanCondition (OR)" as pastEvents {
+    type = "booleanCondition"
+    operator = "or"
+}
+
+object "PastEventCondition (Purchase)" as pastPurchase {
+    type = "pastEventCondition"
+    minimumEventCount = 2
+    fromDate = "last30days"
+}
+
+object "EventCondition (Purchase)" as purchaseEvent {
+    type = "eventCondition"
+    eventTypeId = "purchase"
+    minAmount = 100
+}
+
+object "PastEventCondition (PageView)" as pastPageView {
+    type = "pastEventCondition"
+    minimumEventCount = 5
+    fromDate = "last7days"
+}
+
+object "EventCondition (PageView)" as pageViewEvent {
+    type = "eventCondition"
+    eventTypeId = "pageView"
+    category = "product"
+}
+
+root *-- seg
+root *-- pastEvents
+
+pastEvents *-- pastPurchase
+pastEvents *-- pastPageView
+
+pastPurchase *-- purchaseEvent
+pastPageView *-- pageViewEvent
+
+note right of root
+  Example: Match premium customers who either:
+  - Made 2+ purchases in last 30 days
+  - Viewed 5+ product pages in last 7 days
+end note
+
+@enduml
+----
+
+===== Past Event Condition Structure
+
+Past event conditions have a special structure that allows for complex temporal matching:
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam object {
+    BackgroundColor White
+    BorderColor DarkGray
+    ArrowColor DarkGray
+}
+
+object "PastEventCondition" as past {
+    type = "pastEventCondition"
+    minimumEventCount = 3
+    maximumEventCount = 10
+    fromDate = "2024-01-01"
+    toDate = "2024-12-31"
+    countCondition = "between"
+}
+
+object "EventCondition" as event {
+    type = "eventCondition"
+    eventTypeId = "login"
+}
+
+object "BooleanCondition (AND)" as props {
+    type = "booleanCondition"
+    operator = "and"
+}
+
+object "PropertyCondition 1" as prop1 {
+    type = "propertyCondition"
+    propertyName = "deviceType"
+    propertyValue = "mobile"
+}
+
+object "PropertyCondition 2" as prop2 {
+    type = "propertyCondition"
+    propertyName = "successful"
+    propertyValue = true
+}
+
+past *-- event
+event *-- props
+props *-- prop1
+props *-- prop2
+
+note right of past
+  Matches profiles with 3-10 successful
+  mobile login events during 2024
+end note
+
+@enduml
+----
+
+These diagrams show how conditions can be:
+1. Nested using BooleanCondition to create complex logical expressions
+2. Combined with PastEventCondition to match historical behavior
+3. Enhanced with property constraints at any level
+4. Used to create sophisticated temporal and behavioral matching rules 

--- a/manual/src/main/asciidoc/event-processing.adoc
+++ b/manual/src/main/asciidoc/event-processing.adoc
@@ -1,0 +1,88 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+==== Event Processing Architecture
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam component {
+  BackgroundColor<<event>> LightBlue
+  BackgroundColor<<rule>> LightGreen
+  BackgroundColor<<action>> LightYellow
+}
+
+package "Event Processing" {
+  [Event Service] <<event>>
+  [Event Listeners] <<event>>
+  [Event Router] <<event>>
+}
+
+package "Rules Engine" {
+  [Rules Service] <<rule>>
+  [Rule Evaluator] <<rule>>
+  [Condition Evaluator] <<rule>>
+}
+
+package "Actions" {
+  [Action Executor] <<action>>
+  [Action Dispatcher] <<action>>
+  [Custom Actions] <<action>>
+}
+
+database "Storage" {
+  [Event Store]
+  [Rule Store]
+  [Profile Store]
+}
+
+[Event Service] --> [Event Router]
+[Event Router] --> [Event Listeners]
+[Event Router] --> [Rules Service]
+
+[Rules Service] --> [Rule Evaluator]
+[Rule Evaluator] --> [Condition Evaluator]
+[Rule Evaluator] --> [Action Dispatcher]
+
+[Action Dispatcher] --> [Action Executor]
+[Action Dispatcher] --> [Custom Actions]
+
+[Event Service] --> [Event Store]
+[Rules Service] --> [Rule Store]
+[Action Executor] --> [Profile Store]
+
+note right of [Event Router]
+  Routes events to:
+  1. Event listeners
+  2. Rule evaluation
+  3. Profile updates
+end note
+
+note right of [Rule Evaluator]
+  1. Evaluates conditions
+  2. Triggers actions
+  3. Updates profiles
+end note
+
+note right of [Action Dispatcher]
+  Dispatches actions to:
+  1. Built-in executors
+  2. Custom executors
+  3. External systems
+end note
+
+@enduml
+----
+
+===== Overview 

--- a/manual/src/main/asciidoc/foreword.adoc
+++ b/manual/src/main/asciidoc/foreword.adoc
@@ -1,0 +1,26 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[_foreword]]
+== Foreword
+
+This documentation provides a comprehensive guide to Apache Unomi 3.x, a powerful and flexible Customer Data Platform (CDP) that enables organizations to collect, manage, and leverage customer data for personalization and marketing automation.
+
+Apache Unomi is built on open standards and provides a robust foundation for building customer-centric applications. Whether you're implementing personalization, running marketing campaigns, or building customer profiles, this documentation will help you understand and effectively use Apache Unomi's capabilities.
+
+This guide covers everything from getting started with your first installation to advanced topics like plugin development, migration strategies, and integration patterns. We recommend starting with the "Discover Unomi" section if you're new to the platform, and then exploring the specific topics that match your needs.
+
+The Apache Unomi community is committed to providing comprehensive, accurate, and up-to-date documentation. We welcome feedback and contributions to help improve this documentation for all users.
+
+Happy reading!

--- a/manual/src/main/asciidoc/graphql-examples.adoc
+++ b/manual/src/main/asciidoc/graphql-examples.adoc
@@ -175,7 +175,7 @@ To make this query work you need to supply authorization token in the `HTTP head
 }
 ----
 
-The above header adds `Basic` authorization scheme with base64 encoded `karaf:karaf` value to the request.
+NOTE: When using curl, you can use the `--user` option instead of manually encoding credentials. For example, `--user karaf:karaf` automatically handles Base64 encoding for Basic authentication.
 
 The result will now show the list of profiles:
 
@@ -249,5 +249,5 @@ The response will show the result of the operation:
 
 ==== Where to go from here
 
-* You can find more <<Useful Apache Unomi URLs,useful Apache Unomi URLs>> that can be used in the same way as the above examples.
+* You can find more <<_useful_apache_unomi_urls,useful Apache Unomi URLs>> that can be used in the same way as the above examples.
 * Read https://graphql.org/learn/[GraphQL documentation] to learn more about GraphQL syntax.

--- a/manual/src/main/asciidoc/jsonSchema/extend-an-existing-schema.adoc
+++ b/manual/src/main/asciidoc/jsonSchema/extend-an-existing-schema.adoc
@@ -12,6 +12,7 @@
 // limitations under the License.
 //
 
+[[_extend_an_existing_schema]]
 === Extend an existing schema
 
 ==== When a extension is needed?

--- a/manual/src/main/asciidoc/jsonSchema/introduction.adoc
+++ b/manual/src/main/asciidoc/jsonSchema/introduction.adoc
@@ -271,7 +271,7 @@ Each schema where the *target* value is set to *events*, will be used to validat
 The others are simply used as part of JSON schema or can be used in additional JSON schemas.
 
 It’s possible to add JSON schemas to validate your own event by using the API, the explanations to manage JSON schema through the API are
-in the <<Create / update a JSON schema to validate an event, Create / update a JSON schema to validate an event>> section.
+in the <<_create_update_json_schema,Create / update a JSON schema to validate an event>> section.
 
 Contrary to the predefined schemas, the schemas added through the API will be persisted in Elasticsearch in the jsonSchema index.
 Schemas persisted in Elasticsearch do not require a restart of the platform to reflect changes.

--- a/manual/src/main/asciidoc/migrations/migrate-1.4-to-1.5.adoc
+++ b/manual/src/main/asciidoc/migrations/migrate-1.4-to-1.5.adoc
@@ -12,7 +12,9 @@
 // limitations under the License.
 //
 
-==== Data model and ElasticSearch 7
+==== Migration from Apache Unomi 1.4 to 1.5
+
+===== Data model and ElasticSearch 7
 
 Since Apache Unomi version 1.5.0 we decided to upgrade the supported ElasticSearch version to the 7.4.2.
 
@@ -22,8 +24,7 @@ Previously every items was stored inside the same ElasticSearch index but this i
 
 Since Apache Unomi version 1.5.0 every type of items (see section: link:#_items[Items]) is now stored in a dedicated separated index.
 
-
-==== API changes
+===== API changes
 
 To be able to handle the multiple indices the Persistence API implementation
 (https://github.com/apache/unomi/blob/9f1bab437fd93826dc54d318ed00d3b2e3161437/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java[ElasticSearchPersistenceServiceImpl])
@@ -49,7 +50,7 @@ Because of this changes the geonames DB index name is now respecting the index n
 Previously named: `geonames` is now using the index name `context-geonameentry`
 (see: link:#_installing_geonames_database[Documentation about geonames extension]).
 
-==== Migration steps
+===== Migration steps
 
 In order to migrate the data from ElasticSearch 5 to 7, Unomi provides a migration tool that is directly integrated.
 

--- a/manual/src/main/asciidoc/migrations/migrate-1.6-to-2.0.adoc
+++ b/manual/src/main/asciidoc/migrations/migrate-1.6-to-2.0.adoc
@@ -29,7 +29,7 @@ Doing so will display any errors when processing events (such as JSON Schema val
 
 ==== Data Model changes
 
-There has been changes to Unomi Data model, please make sure to review those in the <<_whats_new_in_apache_unomi_2_0,What's new in Unomi 2>> section of the user manual.
+There has been changes to Unomi Data model, please make sure to review those in the <<_whats_new,What's new>> section of the user manual.
 
 ==== Create JSON schemas
 
@@ -52,7 +52,7 @@ Once the debug logs are active, you will see detailed error messages if your eve
 
 Note that it is currently not possible to modify or surcharge an existing system-deployed JSON schema via the REST API. It is however possible to deploy new schemas and manage them through the REST API on the `/cxs/jsonSchema` endpoint.
 If you are currently using custom properties on an Apache Unomi-provided event type,
-you will need to either change to use a new custom eventType and create the corresponding schema or to create a Unomi schema extension. You can find more details in the <<JSON schemas,JSON Schema>> section of this documentation.
+you will need to either change to use a new custom eventType and create the corresponding schema or to create a Unomi schema extension. You can find more details in the <<_json_schemas,JSON Schema>> section of this documentation.
 
 You can use, as a source of inspiration for creating new schemas, Apache Unomi 2.0 schema located at:
  https://github.com/apache/unomi/tree/master/extensions/json-schema/services/src/main/resources/META-INF/cxs/schemas[extensions/json-schema/services/src/main/resources/META-INF/cxs/schemas].

--- a/manual/src/main/asciidoc/migrations/migrate-elasticsearch-to-opensearch.adoc
+++ b/manual/src/main/asciidoc/migrations/migrate-elasticsearch-to-opensearch.adoc
@@ -12,7 +12,8 @@
 // limitations under the License.
 //
 
-= Migrating from Elasticsearch to OpenSearch
+[[_migrating_from_elasticsearch_to_opensearch]]
+==== Migrating from Elasticsearch to OpenSearch
 :toc: macro
 :toclevels: 4
 :toc-title: Table of contents
@@ -20,11 +21,11 @@
 
 toc::[]
 
-== Overview
+===== Overview
 
 This guide describes how to migrate your Apache Unomi data from Elasticsearch to OpenSearch. The migration process involves using the OpenSearch Replication Tool, which is designed to handle large-scale migrations efficiently while maintaining data consistency.
 
-== Prerequisites
+===== Prerequisites
 
 Before starting the migration, ensure you have:
 
@@ -34,13 +35,13 @@ Before starting the migration, ensure you have:
 * Java 11 or later installed
 * Network connectivity between source and target clusters
 
-== Migration Options
+===== Migration Options
 
-=== Option 1: OpenSearch Replication Tool (Recommended)
+====== Option 1: OpenSearch Replication Tool (Recommended)
 
 The OpenSearch Replication Tool is the recommended approach for production environments, especially for large datasets.
 
-==== Installation
+====== Installation
 
 [source,bash]
 ----
@@ -49,7 +50,7 @@ cd opensearch-migrations/replication-tool
 ./gradlew build
 ----
 
-==== Configuration
+====== Configuration
 
 Create a configuration file `config.yml`:
 
@@ -72,7 +73,7 @@ indices:
   - name: "session-*"         # Unomi session indices
 ----
 
-==== Running the Migration
+====== Running the Migration
 
 [source,bash]
 ----
@@ -81,11 +82,11 @@ indices:
 
 The tool provides progress updates and ensures data consistency during the migration.
 
-=== Option 2: Logstash Pipeline
+====== Option 2: Logstash Pipeline
 
 For smaller deployments or when more control over the migration process is needed, you can use Logstash.
 
-==== Logstash Configuration
+====== Logstash Configuration
 
 Create a file named `logstash-migration.conf`:
 
@@ -114,14 +115,14 @@ output {
 }
 ----
 
-==== Running Logstash Migration
+====== Running Logstash Migration
 
 [source,bash]
 ----
 logstash -f logstash-migration.conf
 ----
 
-== Post-Migration Steps
+===== Post-Migration Steps
 
 1. Verify Data Integrity
 +
@@ -158,9 +159,9 @@ org.apache.unomi.opensearch.password=admin
 ./bin/start
 ----
 
-== Troubleshooting
+===== Troubleshooting
 
-=== Common Issues
+====== Common Issues
 
 1. Connection Timeouts
 * Increase the timeout settings in your configuration
@@ -174,7 +175,7 @@ org.apache.unomi.opensearch.password=admin
 * Verify index patterns in configuration
 * Check source cluster health
 
-=== Monitoring Progress
+====== Monitoring Progress
 
 The OpenSearch Replication Tool provides progress information during migration:
 
@@ -183,7 +184,7 @@ The OpenSearch Replication Tool provides progress information during migration:
 * Current transfer rate
 * Estimated completion time
 
-== Best Practices
+===== Best Practices
 
 1. *Testing*
 * Always test the migration process in a non-production environment first
@@ -203,7 +204,7 @@ The OpenSearch Replication Tool provides progress information during migration:
 * Verify index mappings and settings
 * Test Unomi functionality with migrated data
 
-== Support
+===== Support
 
 For additional support:
 

--- a/manual/src/main/asciidoc/past-event-conditions.adoc
+++ b/manual/src/main/asciidoc/past-event-conditions.adoc
@@ -1,0 +1,1828 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+=== Past Event Conditions in Apache Unomi
+:toc: macro
+:toclevels: 4
+:toc-title: Table of contents
+:doctype: article
+:source-highlighter: highlightjs
+:sectlinks:
+:sectanchors:
+
+toc::[]
+
+==== Introduction
+
+Past event conditions are a powerful feature in Apache Unomi that allows both segments and rules to be defined based on events that occurred within a specific time window. This document explains how past event conditions work, their different usage patterns, and performance implications.
+
+[plantuml]
+----
+@startuml
+skinparam activityBackgroundColor LightBlue
+skinparam activityBorderColor DarkBlue
+skinparam arrowColor DarkBlue
+
+|Visitor|
+start
+:Visit Website;
+
+|Unomi|
+:Track Page Views;
+:Monitor Product Views;
+:Track Search Terms;
+:Record Cart Actions;
+
+|Personalization|
+if (Viewed 3+ products in category?) then (yes)
+  :Show Category Recommendations;
+else (no)
+  :Show Generic Content;
+endif
+
+if (Abandoned Cart?) then (yes)
+  :Trigger Recovery Email;
+else (no)
+  :Continue Normal Flow;
+endif
+
+|Visitor|
+stop
+@enduml
+----
+
+.Example: Product Interest Segment
+[source,json]
+----
+{
+  "metadata": {
+    "id": "electronics_enthusiast",
+    "name": "Electronics Category Interest"
+  },
+  "condition": {
+    "type": "pastEventCondition",
+    "parameterValues": {
+      "eventType": "view",
+      "numberOfDays": 30,
+      "minimumCount": 3,
+      "propertyConditions": {
+        "type": "propertyCondition",
+        "parameterValues": {
+          "propertyName": "target.properties.category",
+          "comparisonOperator": "equals",
+          "propertyValue": "electronics"
+        }
+      }
+    }
+  }
+}
+----
+
+Common website scenarios include:
+
+1. *Shopping Cart Abandonment*
+   * Track cart additions and checkout starts
+   * Identify abandoned carts after time threshold
+   * Trigger recovery campaigns
+
+2. *Content Engagement*
+   * Monitor article views and time spent
+   * Track topic interests
+   * Personalize content recommendations
+
+[source,json]
+----
+{
+  "type": "pastEventCondition",
+  "parameterValues": {
+    "eventType": "articleView",
+    "numberOfDays": 30,
+    "minimumCount": 5,
+    "propertyConditions": {
+      "type": "propertyCondition",
+      "parameterValues": {
+        "propertyName": "topic",
+        "comparisonOperator": "equals",
+        "propertyValue": "technology"
+      }
+    }
+  }
+}
+----
+
+=== Mobile Application Engagement
+
+[plantuml]
+----
+@startuml
+skinparam activityBackgroundColor LightGreen
+skinparam activityBorderColor DarkGreen
+skinparam arrowColor DarkGreen
+
+|User|
+start
+:Open App;
+
+|Unomi|
+:Track Session Start;
+:Monitor Feature Usage;
+:Record In-App Events;
+
+|Engagement|
+if (Inactive for 7 days?) then (yes)
+  :Send Re-engagement Push;
+else (no)
+  if (Used Feature 3x?) then (yes)
+    :Show Advanced Tips;
+  else (no)
+    :Show Basic Tutorial;
+  endif
+endif
+
+|User|
+stop
+@enduml
+----
+
+Common mobile scenarios include:
+
+1. *User Activation*
+   * Track feature discovery and usage
+   * Identify activation milestones
+   * Guide user onboarding
+
+2. *Retention Campaigns*
+   * Monitor app opens and session frequency
+   * Detect usage patterns
+   * Trigger re-engagement actions
+
+[source,json]
+----
+{
+  "type": "pastEventCondition",
+  "parameterValues": {
+    "eventType": "featureUsed",
+    "numberOfDays": 7,
+    "minimumCount": 3,
+    "propertyConditions": {
+      "type": "propertyCondition",
+      "parameterValues": {
+        "propertyName": "featureId",
+        "comparisonOperator": "equals",
+        "propertyValue": "core_feature"
+      }
+    }
+  }
+}
+----
+
+[source,json]
+----
+{
+  "type": "pastEventCondition",
+  "parameterValues": {
+    "eventType": "appOpen",
+    "numberOfDays": 7,
+    "maximumCount": 0,
+    "operator": "eventsNotOccurred"
+  }
+}
+----
+
+=== Customer Data Platform (CDP) Integration
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam component {
+  BackgroundColor<<source>> LightYellow
+  BackgroundColor<<processing>> LightBlue
+  BackgroundColor<<action>> LightGreen
+}
+
+package "Data Sources" {
+  [Website Events] as web <<source>>
+  [Mobile Events] as mobile <<source>>
+  [CRM Data] as crm <<source>>
+  [Support Tickets] as support <<source>>
+}
+
+package "Unomi Processing" {
+  [Event Collection] as collect <<processing>>
+  [Past Event Analysis] as analysis <<processing>>
+  [Segment Evaluation] as segments <<processing>>
+}
+
+package "Activation" {
+  [Email Campaigns] as email <<action>>
+  [Ad Targeting] as ads <<action>>
+  [Support Prioritization] as priority <<action>>
+}
+
+web --> collect
+mobile --> collect
+crm --> collect
+support --> collect
+
+collect --> analysis
+analysis --> segments
+segments --> email
+segments --> ads
+segments --> priority
+@enduml
+----
+
+Common CDP scenarios include:
+
+1. *Cross-Channel Customer Journey*
+   * Track interactions across touchpoints
+   * Build unified customer view
+   * Trigger omnichannel campaigns
+
+2. *Customer Support Optimization*
+   * Monitor support interactions
+   * Track issue resolution
+   * Identify high-value customers
+
+[source,json]
+----
+{
+  "type": "booleanCondition",
+  "parameterValues": {
+    "operator": "and",
+    "subConditions": [
+      {
+        "type": "pastEventCondition",
+        "parameterValues": {
+          "eventType": "websiteView",
+          "numberOfDays": 30,
+          "minimumCount": 1
+        }
+      },
+      {
+        "type": "pastEventCondition",
+        "parameterValues": {
+          "eventType": "mobileAppOpen",
+          "numberOfDays": 30,
+          "minimumCount": 1
+        }
+      }
+    ]
+  }
+}
+----
+
+[source,json]
+----
+{
+  "type": "pastEventCondition",
+  "parameterValues": {
+    "eventType": "supportTicket",
+    "numberOfDays": 90,
+    "minimumCount": 3,
+    "propertyConditions": {
+      "type": "propertyCondition",
+      "parameterValues": {
+        "propertyName": "priority",
+        "comparisonOperator": "equals",
+        "propertyValue": "high"
+      }
+    }
+  }
+}
+----
+
+=== B2B Use Cases
+
+[plantuml]
+----
+@startuml
+skinparam activityBackgroundColor LightPurple
+skinparam activityBorderColor DarkPurple
+skinparam arrowColor DarkPurple
+
+|Account|
+start
+:Multiple Users;
+
+|Unomi|
+:Track User Actions;
+:Aggregate Account Activity;
+:Monitor Product Usage;
+
+|Engagement|
+if (Trial Period Active?) then (yes)
+  if (Key Features Used?) then (yes)
+    :Show Upgrade Offer;
+  else (no)
+    :Send Usage Tips;
+  endif
+else (no)
+  if (Usage Declining?) then (yes)
+    :Trigger CSM Review;
+  endif
+endif
+
+|Account|
+stop
+@enduml
+----
+
+Common B2B scenarios include:
+
+1. *Account Health Monitoring*
+   * Track usage across account users
+   * Monitor feature adoption
+   * Predict churn risk
+
+2. *Product Adoption Tracking*
+   * Monitor feature usage frequency
+   * Track user onboarding progress
+   * Identify power users
+
+[source,json]
+----
+{
+  "type": "pastEventCondition",
+  "parameterValues": {
+    "eventType": "login",
+    "numberOfDays": 30,
+    "maximumCount": 5,
+    "propertyConditions": {
+      "type": "propertyCondition",
+      "parameterValues": {
+        "propertyName": "accountId",
+        "comparisonOperator": "exists"
+      }
+    }
+  }
+}
+----
+
+[source,json]
+----
+{
+  "type": "pastEventCondition",
+  "parameterValues": {
+    "eventType": "featureUsed",
+    "numberOfDays": 30,
+    "minimumCount": 10,
+    "propertyConditions": {
+      "type": "propertyCondition",
+      "parameterValues": {
+        "propertyName": "featureTier",
+        "comparisonOperator": "equals",
+        "propertyValue": "premium"
+      }
+    }
+  }
+}
+----
+
+== Architecture Overview
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam component {
+  BackgroundColor<<cached>> LightGreen
+  BackgroundColor<<uncached>> LightYellow
+}
+
+package "Past Event System" {
+  [SetEventOccurenceCountAction] as action
+  [PastEventConditionEvaluator] as evaluator
+  [PastEventConditionESQueryBuilder] as queryBuilder
+  [SegmentServiceImpl] as segmentService
+}
+
+database "Elasticsearch" {
+  [Events] as events
+  [Profiles] as profiles
+}
+
+cloud "Cache" {
+  [Profile Event Counts] as counts <<cached>>
+}
+
+[Segments] <<cached>> as segments
+[Rules] as rules
+[Auto-Generated Rules] as autoRules
+
+segments --> evaluator
+rules --> evaluator
+evaluator --> queryBuilder
+queryBuilder --> events
+action --> profiles
+action --> counts
+segmentService --> autoRules
+
+note right of counts
+  Cached counts are stored
+  in profile properties
+end note
+
+note right of evaluator
+  Two evaluation strategies:
+  1. Property-based (cached)
+  2. Direct query (uncached)
+end note
+@enduml
+----
+
+=== Query Strategy Selection
+
+[plantuml]
+----
+@startuml
+start
+:Past Event Condition;
+
+if (Has Generated Property Key?) then (yes)
+  :Use Property-Based Query;
+  :Check Profile Properties;
+  if (Count Found?) then (yes)
+    :Use Cached Count;
+  else (no)
+    :Calculate Initial Count;
+    :Store in Profile;
+  endif
+else (no)
+  :Use Direct Event Query;
+  :Query Event Store;
+  :Aggregate Results;
+endif
+
+:Return Result;
+stop
+@enduml
+----
+
+==== Performance Implications
+
+1. *Property-Based Evaluation*
+- Uses cached counts from profile properties
+- Minimal query overhead
+- Suitable for high-frequency conditions
+- Recommended for segments
+
+2. *Direct Query Evaluation*
+- Queries event store directly
+- Higher latency and resource usage
+- No caching mechanism
+- Use with caution in rules
+
+== Event Processing Flow
+
+[plantuml]
+----
+@startuml
+skinparam activityBackgroundColor LightBlue
+skinparam activityBorderColor DarkBlue
+skinparam arrowColor DarkBlue
+
+start
+:Event Received;
+
+if (Past Event Condition in Segment?) then (yes)
+  :Generate Property Key;
+  :Find Auto-Generated Rule;
+  :Update Profile Count;
+  :Store in Profile Properties;
+else (no)
+  :Direct Event Query;
+  :Aggregate Results;
+endif
+
+:Evaluate Condition;
+
+if (Condition Met?) then (yes)
+  :Execute Actions;
+else (no)
+  :Skip Actions;
+endif
+
+stop
+@enduml
+----
+
+== Segment vs Direct Rule Comparison
+
+[plantuml]
+----
+@startuml
+skinparam componentStyle uml2
+skinparam component {
+  BackgroundColor<<efficient>> LightGreen
+  BackgroundColor<<inefficient>> LightPink
+}
+
+package "Segment Approach" <<efficient>> {
+  [Past Event Condition] as segmentCondition
+  [Auto-Generated Rule] as autoRule
+  [Cached Profile Count] as profileCount
+}
+
+package "Direct Rule Approach" <<inefficient>> {
+  [Past Event Condition] as ruleCondition
+  [Direct Event Query] as directQuery
+  [Query Results] as queryResults
+}
+
+database "Event Store" as eventStore
+
+segmentCondition --> autoRule
+autoRule --> profileCount
+profileCount --> [Segment Evaluation]
+
+ruleCondition --> directQuery
+directQuery --> eventStore
+eventStore --> queryResults
+queryResults --> [Rule Evaluation]
+
+note right of profileCount
+  Efficient:
+  - Cached counts
+  - Real-time updates
+  - Low latency
+end note
+
+note right of queryResults
+  Less Efficient:
+  - Direct queries
+  - No caching
+  - Higher latency
+end note
+@enduml
+----
+
+== Cache Update Process
+
+[plantuml]
+----
+@startuml
+participant "Event Service" as event
+participant "SetEventOccurenceCountAction" as action
+participant "Profile Service" as profile
+database "Event Store" as store
+database "Profile Store" as profileStore
+
+event -> action: New Event
+activate action
+
+action -> store: Query Existing Events
+store --> action: Event Count
+
+action -> profile: Get Profile
+profile --> action: Profile Data
+
+action -> action: Calculate New Count
+action -> profile: Update Past Events Property
+
+profile -> profileStore: Save Profile
+profileStore --> profile: Saved
+
+action -> event: Profile Updated Event
+deactivate action
+@enduml
+----
+
+== Query Strategy Selection
+
+[plantuml]
+----
+@startuml
+start
+:Past Event Condition;
+
+if (Has Generated Property Key?) then (yes)
+  :Use Property-Based Query;
+  :Check Profile Properties;
+  if (Count Found?) then (yes)
+    :Use Cached Count;
+  else (no)
+    :Calculate Initial Count;
+    :Store in Profile;
+  endif
+else (no)
+  :Use Direct Event Query;
+  :Query Event Store;
+  :Aggregate Results;
+endif
+
+:Return Result;
+stop
+@enduml
+----
+
+== Usage Patterns
+
+=== In Segments
+
+When used in segments, past event conditions automatically generate optimization rules that maintain cached event counts on profiles. This is the recommended approach for optimal performance.
+
+.Example: Segment with Past Event Condition
+[source,json]
+----
+{
+  "metadata": {
+    "id": "activeUsers",
+    "name": "Active Users",
+    "scope": "systemscope"
+  },
+  "condition": {
+    "type": "pastEventCondition",
+    "parameterValues": {
+      "eventType": "view",
+      "numberOfDays": 30,
+      "minimumCount": 10
+    }
+  }
+}
+----
+
+When this segment is created:
+1. The system generates a unique property key for the condition
+2. An auto-generated rule is created to maintain event counts
+3. Initial profile counts are calculated and stored
+4. Subsequent events update the cached counts in real-time
+
+=== In Rules
+
+Past event conditions can also be used directly in rules, but with important performance considerations:
+
+.Example: Rule with Past Event Condition
+[source,json]
+----
+{
+  "metadata": {
+    "id": "directPastEventRule",
+    "name": "Direct Past Event Rule"
+  },
+  "condition": {
+    "type": "pastEventCondition",
+    "parameterValues": {
+      "eventType": "purchase",
+      "numberOfDays": 7,
+      "minimumCount": 1
+    }
+  },
+  "actions": [
+    {
+      "type": "sendEventAction",
+      "parameterValues": {
+        "eventType": "directRuleTriggered"
+      }
+    }
+  ]
+}
+----
+
+*Performance Implications*:
+1. No automatic optimization rules are generated
+2. Each evaluation requires a direct query to the event store
+3. No caching of event counts occurs
+4. Higher latency and resource usage
+5. Not recommended for high-frequency conditions
+
+== Auto-Generated Rules
+
+The system automatically generates rules for past event conditions through `SegmentServiceImpl`:
+
+1. *Rule Creation*
+   * Generated when segments with past event conditions are created/updated
+   * Uses `evaluateProfileSegments.json` template
+   * Includes `EvaluateProfileSegmentsAction` for segment membership updates
+
+2. *Rule Structure*
+[source,json]
+----
+{
+    "metadata": {
+        "id": "evaluateProfileSegments",
+        "name": "Evaluate segments",
+        "description": "Evaluate segments when a profile is modified",
+        "readOnly": true
+    },
+    "condition": {
+        "type": "profileUpdatedEventCondition"
+    },
+    "actions": [
+        {
+            "type": "evaluateProfileSegmentsAction"
+        }
+    ]
+}
+----
++
+3. *Profile Storage Format*
+[source,json]
+----
+{
+  "properties": {
+    "pastEvents": {
+      "past_event_count_abc123_30d_v1": {
+        "count": 15,
+        "lastUpdated": "2024-03-15T10:30:00Z"
+      }
+    }
+  }
+}
+----
+
+== Core Components
+
+The past event condition system consists of four main components:
+
+1. `SetEventOccurenceCountAction` - Handles real-time event processing and updates profile event counts
+2. `PastEventConditionEvaluator` - Manages condition evaluation with optimized caching
+3. `PastEventConditionESQueryBuilder` - Constructs optimized Elasticsearch queries
+4. `SegmentServiceImpl` - Manages segments and auto-generated rules
+
+== Condition Parameters
+
+Past event conditions support the following parameters as defined in `pastEventCondition.json`:
+
+1. *Time Window Parameters*
+   * `numberOfDays` (integer) - Rolling window of N days from current time
+   * `fromDate` (date) - Explicit start date for the time window
+   * `toDate` (date) - Explicit end date for the time window
+
+2. *Count Parameters*
+   * `minimumEventCount` (integer) - Minimum number of events required
+   * `maximumEventCount` (integer) - Maximum number of events allowed
+   * `operator` (string) - Either "eventsOccurred" or "eventsNotOccurred"
+
+3. *Event Filter*
+   * `eventCondition` (Condition) - The condition defining which events to count
+
+[IMPORTANT]
+====
+The `eventCondition` parameter can *only* accept conditions that are specifically tagged with `eventCondition`. These are conditions specifically designed to match events. It is NOT allowed to use any other type of condition, including `booleanCondition`, even if that condition contains valid event conditions.
+
+If you need to combine multiple event conditions, you have two options:
+
+1. Use multiple `pastEventCondition`s at a higher level and combine them with a `booleanCondition` (as shown in previous examples).
+
+2. Define a custom condition type that uses a `booleanCondition` in its `parentCondition`. This is a valid pattern because the condition type itself will be tagged with `eventCondition`. Example:
+
+[source,json]
+----
+{
+  "metadata": {
+    "id": "pageViewEventCondition",
+    "name": "pageViewEventCondition",
+    "systemTags": [
+      "eventCondition",  // This tag makes it valid for use in pastEventCondition
+      "event",
+      "condition"
+    ]
+  },
+  "parentCondition": {
+    "type": "booleanCondition",  // Valid here because it's part of condition type definition
+    "parameterValues": {
+      "subConditions": [
+        {
+          "type": "eventTypeCondition",
+          "parameterValues": {
+            "eventTypeId": "view"
+          }
+        },
+        {
+          "type": "eventPropertyCondition",
+          "parameterValues": {
+            "propertyName": "target.properties.pageInfo.pagePath",
+            "propertyValue": "parameter::pagePath",
+            "comparisonOperator": "equals"
+          }
+        }
+      ],
+      "operator": "and"
+    }
+  },
+  "parameters": [
+    {
+      "id": "pagePath",
+      "type": "string",
+      "multivalued": false
+    }
+  ]
+}
+----
+
+This pattern works because the condition type system is hierarchical - a condition type can define a `parentCondition` that will be evaluated as part of the condition evaluation. The restriction on using `booleanCondition` applies only to direct usage in the `eventCondition` parameter, not to the internal structure of properly tagged condition types.
+====
+
+== Event Processing System
+
+=== Real-Time Event Processing
+
+When an event occurs in Unomi, the `SetEventOccurenceCountAction` processes it in real-time through the following steps:
+
+1. Extracts the past event condition from the action parameters
+2. Builds a compound condition for event matching that includes:
+   * The original event condition
+   * Time window constraints
+   * Profile filters
+3. Queries existing matching events using optimized Elasticsearch queries
+4. Updates the profile's past event count in system properties
+5. Triggers profile update events if configured
+
+The action is defined in `setEventOccurenceCountAction.json` with the following metadata:
+[source,json]
+----
+{
+  "metadata": {
+    "id": "setEventOccurenceCountAction",
+    "systemTags": [
+      "profileTags",
+      "demographic"
+    ]
+  }
+}
+----
+
+=== Time Window Processing
+
+The `SetEventOccurenceCountAction` implements time window processing using the following logic:
+
+[source,java]
+----
+private boolean inTimeRange(LocalDateTime eventTime, Integer numberOfDays, 
+                          LocalDateTime fromDate, LocalDateTime toDate) {
+    boolean inTimeRange = true;
+
+    if (numberOfDays != null) {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+        if (eventTime.isAfter(now)) {
+            inTimeRange = false;
+        }
+        long daysDiff = Duration.between(eventTime, now).toDays();
+        if (daysDiff > numberOfDays) {
+            inTimeRange = false;
+        }
+    }
+    if (fromDate != null && fromDate.isAfter(eventTime)) {
+        inTimeRange = false;
+    }
+    if (toDate != null && toDate.isBefore(eventTime)) {
+        inTimeRange = false;
+    }
+
+    return inTimeRange;
+}
+----
+
+=== Profile Storage Format
+
+Past event counts are stored efficiently in the profile's system properties under a `pastEvents` list. Each entry contains:
+
+* `key` - A generated unique identifier for the condition using MD5 hashing
+* `count` - The number of matching events for that condition
+
+The update process is handled by:
+
+[source,java]
+----
+private boolean updatePastEvents(Event event, String generatedPropertyKey, long count) {
+    List<Map<String, Object>> existingPastEvents = 
+        (List<Map<String, Object>>) event.getProfile().getSystemProperties().get("pastEvents");
+    if (existingPastEvents == null) {
+        existingPastEvents = new ArrayList<>();
+        event.getProfile().getSystemProperties().put("pastEvents", existingPastEvents);
+    }
+
+    // Update or add count
+    for (Map<String, Object> pastEvent : existingPastEvents) {
+        if (generatedPropertyKey.equals(pastEvent.get("key"))) {
+            if (pastEvent.containsKey("count") && pastEvent.get("count").equals(count)) {
+                return false;
+            }
+            pastEvent.put("count", count);
+            return true;
+        }
+    }
+
+    Map<String, Object> newPastEvent = new HashMap<>();
+    newPastEvent.put("key", generatedPropertyKey);
+    newPastEvent.put("count", count);
+    existingPastEvents.add(newPastEvent);
+    return true;
+}
+----
+
+=== Evaluation Process
+
+The evaluation process involves multiple components working together to efficiently evaluate past event conditions:
+
+1. *Condition Evaluator* (`PastEventConditionEvaluator`)
+   * Primary evaluation logic for past event conditions
+   * Two-phase evaluation strategy:
+     ** First checks profile properties for cached counts using `generatedPropertyKey`
+     ** Falls back to direct event queries only if cached data is unavailable
+   * Count validation logic:
+     ** For `eventsOccurred`: Verifies count is between `minimumEventCount` and `maximumEventCount`
+     ** For `eventsNotOccurred`: Verifies count is exactly 0
+
+2. *Query Builder* (`PastEventConditionESQueryBuilder`)
+   * Responsible for constructing optimized Elasticsearch queries
+   * Supports two query strategies:
+     ** Property-based queries: Uses cached counts from profile properties
+     ** Event-based queries: Aggregates events directly when needed
+   * Partitioned processing support:
+     ** Configurable through `pastEventsDisablePartitions`
+     ** Uses `aggregateQueryBucketSize` for partition sizing
+     ** Handles large datasets efficiently
+
+3. *Action Executor* (`ActionExecutorDispatcherImpl`)
+   * Manages the execution of past event condition actions
+   * Features:
+     ** Contextual parameter resolution for dynamic values
+     ** Performance metrics collection for monitoring
+     ** Script execution support for complex logic
+     ** Error handling and logging
+   * Execution flow:
+     . Resolves action parameters using context
+     . Validates action configuration
+     . Executes action with performance tracking
+     . Handles results and updates profiles
+   * Implementation details:
+[source,java]
+----
+public boolean eval(Condition condition, Item item, Map<String, Object> context, 
+                   ConditionEvaluatorDispatcher dispatcher) {
+    final Map<String, Object> parameters = condition.getParameterValues();
+    long count;
+
+    // Try to get count from profile properties first
+    if (parameters.containsKey("generatedPropertyKey")) {
+        String key = (String) parameters.get("generatedPropertyKey");
+        Profile profile = (Profile) item;
+        List<Map<String, Object>> pastEvents = 
+            (ArrayList<Map<String, Object>>) profile.getSystemProperties().get("pastEvents");
+        if (pastEvents != null) {
+            Number l = (Number) pastEvents
+                    .stream()
+                    .filter(pastEvent -> pastEvent.get("key").equals(key))
+                    .findFirst()
+                    .map(pastEvent -> pastEvent.get("count")).orElse(0L);
+            count = l.longValue();
+        } else {
+            count = 0;
+        }
+    } else {
+        // Legacy fallback: direct event query
+        count = persistenceService.queryCount(
+            pastEventConditionPersistenceQueryBuilder.getEventCondition(
+                condition, context, item.getItemId(), definitionsService, scriptExecutor
+            ), 
+            Event.ITEM_TYPE
+        );
+    }
+
+    // Evaluate count against condition parameters
+    boolean eventsOccurred = pastEventConditionPersistenceQueryBuilder
+        .getStrategyFromOperator((String) condition.getParameter("operator"));
+    if (eventsOccurred) {
+        int minimumEventCount = parameters.get("minimumEventCount") == null ? 
+            0 : (Integer) parameters.get("minimumEventCount");
+        int maximumEventCount = parameters.get("maximumEventCount") == null ? 
+            Integer.MAX_VALUE : (Integer) parameters.get("maximumEventCount");
+        return count > 0 && (count >= minimumEventCount && count <= maximumEventCount);
+    } else {
+        return count == 0;
+    }
+}
+----
+
+== Rule Generation
+
+=== Auto-Generated Rules
+
+The system automatically generates rules for past event conditions through `SegmentServiceImpl`:
+
+1. *Rule Creation*
+   * Generated when segments with past event conditions are created/updated
+   * Uses `evaluateProfileSegments.json` template
+   * Includes `EvaluateProfileSegmentsAction` for segment membership updates
+
+2. *Rule Structure*
+[source,json]
+----
+{
+    "metadata": {
+        "id": "evaluateProfileSegments",
+        "name": "Evaluate segments",
+        "description": "Evaluate segments when a profile is modified",
+        "readOnly": true
+    },
+    "condition": {
+        "type": "profileUpdatedEventCondition"
+    },
+    "actions": [
+        {
+            "type": "evaluateProfileSegmentsAction"
+        }
+    ]
+}
+----
+
+=== Performance Configuration
+
+Key configuration parameters from `SegmentServiceImpl`:
+
+[source]
+----
+# Maximum number of IDs to return in a single query
+maximumIdsQueryCount = 5000
+
+# Size of each partition for aggregation queries
+aggregateQueryBucketSize = 5000
+
+# Whether to disable partitioned processing
+pastEventsDisablePartitions = false
+
+# Segment update batch size
+segmentUpdateBatchSize = 1000
+
+# Maximum retries for profile segment updates
+maxRetriesForUpdateProfileSegment = 3
+
+# Delay between retries (seconds)
+secondsDelayForRetryUpdateProfileSegment = 1
+
+# Whether to send profile update events
+sendProfileUpdateEventForSegmentUpdate = true
+----
+
+== Best Practices
+
+=== Implementation Guidelines
+
+1. *Time Window Selection*
+   * Use `numberOfDays` for rolling windows
+   * Use explicit dates for fixed periods
+   * Consider data retention policies
+   * Account for timezone handling (UTC)
+
+2. *Performance Optimization*
+   * Enable partitioning for large datasets
+   * Configure appropriate batch sizes
+   * Monitor memory usage
+   * Use property-based evaluation when possible
+
+3. *Error Handling*
+   * Configure appropriate retries
+   * Monitor failed updates
+   * Implement proper logging
+   * Plan for recovery scenarios
+
+=== Example Configurations
+
+1. *Rolling Window*
+[source,json]
+----
+{
+  "type": "pastEventCondition",
+  "parameterValues": {
+    "eventCondition": {
+      "type": "eventTypeCondition",
+      "parameterValues": {
+        "eventTypeId": "purchase"
+      }
+    },
+    "numberOfDays": 30
+  }
+}
+----
++
+2. *Date Range*
+[source,json]
+----
+{
+  "type": "pastEventCondition",
+  "parameterValues": {
+    "eventCondition": {
+      "type": "eventTypeCondition",
+      "parameterValues": {
+        "eventTypeId": "campaign-click"
+      }
+    },
+    "fromDate": "2024-01-01T00:00:00Z",
+    "toDate": "2024-12-31T23:59:59Z"
+  }
+}
+----
+
+== Common Use Cases and Examples
+
+=== Basic Past Event Condition
+
+.Example: Count page views in the last 7 days
+[source,json]
+----
+{
+  "type": "pastEventCondition",
+  "parameterValues": {
+    "eventType": "view",
+    "numberOfDays": 7,
+    "minimumCount": 5,
+    "maximumCount": null
+  }
+}
+----
+
+=== Time-Based Conditions
+
+.Example: Count purchases between specific dates
+[source,json]
+----
+{
+  "type": "pastEventCondition",
+  "parameterValues": {
+    "eventType": "purchase",
+    "fromDate": "2024-01-01T00:00:00Z",
+    "toDate": "2024-03-31T23:59:59Z",
+    "minimumCount": 1
+  }
+}
+----
+
+=== Complex Event Conditions
+
+.Example: Count specific product category views with property constraints
+[source,json]
+----
+{
+  "type": "pastEventCondition",
+  "parameterValues": {
+    "eventType": "view",
+    "numberOfDays": 30,
+    "minimumCount": 3,
+    "propertyConditions": {
+      "type": "booleanCondition",
+      "parameterValues": {
+        "operator": "and",
+        "subConditions": [
+          {
+            "type": "propertyCondition",
+            "parameterValues": {
+              "propertyName": "target.properties.category",
+              "comparisonOperator": "equals",
+              "propertyValue": "electronics"
+            }
+          },
+          {
+            "type": "propertyCondition",
+            "parameterValues": {
+              "propertyName": "target.properties.price",
+              "comparisonOperator": "greaterThan",
+              "propertyValue": 100
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+----
+
+=== Segment Definition
+
+.Example: Segment for active users based on past events
+[source,json]
+----
+{
+  "metadata": {
+    "id": "activeUsers",
+    "name": "Active Users",
+    "scope": "systemscope"
+  },
+  "condition": {
+    "type": "booleanCondition",
+    "parameterValues": {
+      "operator": "and",
+      "subConditions": [
+        {
+          "type": "pastEventCondition",
+          "parameterValues": {
+            "eventType": "view",
+            "numberOfDays": 30,
+            "minimumCount": 10
+          }
+        },
+        {
+          "type": "pastEventCondition",
+          "parameterValues": {
+            "eventType": "purchase",
+            "numberOfDays": 90,
+            "minimumCount": 1
+          }
+        }
+      ]
+    }
+  }
+}
+----
+
+=== Auto-Generated Rule
+
+.Example: Auto-generated rule for past event counting
+[source,json]
+----
+{
+  "metadata": {
+    "id": "auto_past_event_count_rule_12345",
+    "name": "Past Event Count Rule for Segment activeUsers",
+    "hidden": true
+  },
+  "condition": {
+    "type": "eventTypeCondition",
+    "parameterValues": {
+      "eventTypeId": "view"
+    }
+  },
+  "actions": [
+    {
+      "type": "setEventOccurenceCountAction",
+      "parameterValues": {
+        "pastEventCondition": {
+          "eventType": "view",
+          "numberOfDays": 30
+        }
+      }
+    }
+  ]
+}
+----
+
+=== Property Storage Format
+
+.Example: Profile property storage format for past event counts
+[source,json]
+----
+{
+  "properties": {
+    "pastEvents": {
+      "past_event_count_abc123_30d_v1": {
+        "count": 15,
+        "lastUpdated": "2024-03-15T10:30:00Z"
+      },
+      "past_event_count_def456_90d_v1": {
+        "count": 3,
+        "lastUpdated": "2024-03-15T10:30:00Z"
+      }
+    }
+  }
+}
+----
+
+=== Integration Examples
+
+==== REST API Usage
+
+.Example: Query past event counts via REST API
+[source,bash]
+----
+curl -X POST http://localhost:8181/cxs/profiles/query \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "condition": {
+      "type": "pastEventCondition",
+      "parameterValues": {
+        "eventType": "view",
+        "numberOfDays": 7,
+        "minimumCount": 5
+      }
+    }
+  }'
+----
+
+==== Batch Update Configuration
+
+.Example: Configure batch updates for past event counts
+[source,properties]
+----
+# Batch processing configuration
+segment.pastEventCondition.batchSize=1000
+segment.pastEventCondition.threadsCount=4
+segment.pastEventCondition.timeoutInSeconds=3600
+
+# Monitoring configuration
+segment.pastEventCondition.monitoringEnabled=true
+segment.pastEventCondition.alertThreshold=100000
+----
+
+== Troubleshooting
+
+=== Common Issues
+
+1. *Performance Problems*
+   * Partition Size Issues
+     ** Symptom: Slow query performance or high memory usage
+     ** Check `aggregateQueryBucketSize` configuration (default: 5000)
+     ** Monitor Elasticsearch heap usage during queries
+     ** Consider enabling partitioned processing for large datasets
+   
+   * Query Optimization
+     ** Verify proper index settings for event timestamps
+     ** Check if property-based queries are being used when possible
+     ** Monitor query execution times through metrics
+     ** Analyze Elasticsearch query patterns
+
+2. *Incorrect Counts*
+   * Time Window Configuration
+     ** Verify UTC timezone handling in date calculations
+     ** Check `numberOfDays` calculation logic
+     ** Validate `fromDate`/`toDate` format (ISO-8601)
+   
+   * Event Processing
+     ** Verify events are being properly persisted
+     ** Check event type matching in conditions
+     ** Validate profile ID associations
+     ** Monitor event indexing status
+
+   * Profile Updates
+     ** Verify `pastEvents` property structure
+     ** Check property key generation
+     ** Monitor profile update events
+     ** Validate segment evaluation timing
+
+=== Debugging Tips
+
+1. *Query Verification*
+   * Elasticsearch Query Analysis
+     ** Use Elasticsearch _explain API to analyze queries
+     ** Monitor query performance through metrics
+     ** Check query routing and shard distribution
+     ** Verify index mappings for event fields
+
+2. *Cache Validation*
+   * Property Storage
+     ** Verify `pastEvents` list structure in profiles
+     ** Check property key consistency
+     ** Monitor cache hit/miss ratios
+     ** Validate property update timestamps
+
+   * Profile Updates
+     ** Monitor profile update events
+     ** Check segment evaluation triggers
+     ** Verify rule execution flow
+     ** Validate condition evaluation results
+
+== Integration Points
+
+=== Event Flow
+
+The complete event processing flow for past event conditions:
+
+1. *Event Reception*
+   * Event arrives through REST API or other channels
+   * Event is validated and enriched
+   * Profile association is verified
+   * Event type is matched against conditions
+
+2. *Real-time Processing*
+   * `SetEventOccurenceCountAction` is triggered
+   * Event conditions are evaluated
+   * Time windows are calculated
+   * Counts are updated in profile
+
+3. *Profile Update*
+   * Profile properties are updated
+   * Cache entries are invalidated if needed
+   * Update events are triggered if configured
+   * Optimistic locking handles concurrent updates
+
+4. *Segment Evaluation*
+   * Profile segments are re-evaluated
+   * New segment memberships are calculated
+   * Profile is updated with new segments
+   * Related rules are triggered
+
+=== Segment Evaluation Flow
+
+The detailed segment evaluation process:
+
+1. *Condition Evaluation*
+   * Past event conditions are extracted
+   * Property-based evaluation is attempted first
+   * Falls back to event queries if needed
+   * Results are cached when possible
+
+2. *Query Building*
+   * Appropriate query strategy is selected
+   * Time constraints are applied
+   * Partitioning is configured if enabled
+   * Optimizations are applied based on context
+
+3. *Result Aggregation*
+   * Event counts are aggregated
+   * Results are partitioned if needed
+   * Memory usage is optimized
+   * Results are validated
+
+4. *Profile Update*
+   * Profile properties are updated atomically
+   * Segment memberships are recalculated
+   * Update events are triggered
+   * Changes are persisted to storage
+
+== Security Considerations
+
+=== Data Access Controls
+
+1. *Profile Data Protection*
+   * Event data access is controlled through permissions
+   * Profile properties are protected by scope definitions
+   * Sensitive data is filtered from event properties
+   * Access to past event counts follows profile permissions
+
+2. *Query Security*
+   * Elasticsearch queries are sanitized
+   * Input parameters are validated
+   * Time ranges are bounded
+   * Resource limits are enforced
+
+=== Resource Protection
+
+1. *Query Limits*
+   * Maximum time window restrictions
+   * Aggregation bucket size limits
+   * Query timeout configurations
+   * Memory usage thresholds
+
+2. *Rate Limiting*
+   * Profile update frequency limits
+   * Event processing rate controls
+   * Segment evaluation throttling
+   * Cache invalidation controls
+
+=== Data Integrity
+
+1. *Event Data*
+   * Event timestamps are validated
+   * Event type verification
+   * Profile association validation
+   * Property value sanitization
+
+2. *Profile Updates*
+   * Optimistic locking for concurrent updates
+   * Transaction boundaries
+   * Update validation
+   * Rollback procedures
+
+=== Audit Trail
+
+1. *Event Processing*
+   * Event processing logs
+   * Profile update tracking
+   * Segment evaluation history
+   * Rule execution records
+
+2. *Error Handling*
+   * Failed update logging
+   * Security violation tracking
+   * Resource limit violations
+   * Data integrity issues
+
+== Configuration Parameters
+
+=== Core Settings
+
+[source,properties]
+----
+# Segment Service Configuration
+segment.pastEventCondition.aggregateQueryBucketSize=5000
+segment.pastEventCondition.maxRetriesForUpdateProfileSegment=3
+segment.pastEventCondition.updateBatchSize=1000
+
+# Event Processing
+event.pastCondition.maxTimeWindow=365
+event.pastCondition.defaultTimeUnit=day
+
+# Query Optimization
+query.pastEvent.usePropertyBasedEvaluation=true
+query.pastEvent.enablePartitioning=true
+query.pastEvent.partitionSize=10000
+----
+
+=== Performance Tuning
+
+[source,properties]
+----
+# Cache Configuration
+cache.pastEventCount.timeToLiveInSeconds=3600
+cache.pastEventCount.maxEntries=10000
+
+# Query Timeouts
+query.pastEvent.timeout=30
+query.pastEvent.scrollTimeout=60
+query.pastEvent.scrollSize=1000
+
+# Batch Processing
+batch.pastEventUpdate.threadPoolSize=4
+batch.pastEventUpdate.queueSize=1000
+----
+
+=== Monitoring Configuration
+
+[source,properties]
+----
+# Metrics Collection
+metrics.pastEventCondition.enabled=true
+metrics.pastEventCondition.detailed=false
+
+# Logging
+logging.pastEventCondition.level=INFO
+logging.pastEventCondition.detailed=false
+
+# Alerts
+alerts.pastEventCondition.slowQueryThreshold=5000
+alerts.pastEventCondition.errorThreshold=100
+----
+
+== Best Practices
+
+=== Performance Optimization
+
+1. *Query Optimization*
+   * Use property-based evaluation when possible
+   * Enable partitioning for large datasets
+   * Configure appropriate cache sizes
+   * Monitor and tune query timeouts
+
+2. *Resource Management*
+   * Configure appropriate batch sizes
+   * Set reasonable time windows
+   * Monitor memory usage
+   * Use partitioned processing
+
+=== Maintenance
+
+1. *Regular Tasks*
+   * Monitor cache hit rates
+   * Review query performance
+   * Check error logs
+   * Validate configuration
+
+2. *Troubleshooting*
+   * Use detailed logging when needed
+   * Monitor metrics
+   * Review audit trails
+   * Check resource usage
+
+=== Scaling Considerations
+
+1. *Horizontal Scaling*
+   * Configure cluster settings
+   * Balance load across nodes
+   * Monitor node health
+   * Optimize resource allocation
+
+2. *Vertical Scaling*
+   * Tune JVM settings
+   * Configure memory limits
+   * Optimize thread pools
+   * Monitor CPU usage
+
+== Evaluation Strategies
+
+The system uses different evaluation strategies depending on how the past event condition is used:
+
+=== Property-Based Evaluation
+
+Used when a past event condition is part of a segment:
+
+1. *Evaluation Process*
+   * Checks for cached count in profile's `pastEvents` property
+   * Uses the generated property key to locate the count
+   * Compares count against condition parameters
+   * No direct event store query needed
+
+.Example Code Flow:
+[source,java]
+----
+if (parameters.containsKey("generatedPropertyKey")) {
+    String key = (String) parameters.get("generatedPropertyKey");
+    Profile profile = (Profile) item;
+    List<Map<String, Object>> pastEvents = 
+        (ArrayList<Map<String, Object>>) profile.getSystemProperties().get("pastEvents");
+    if (pastEvents != null) {
+        Number count = (Number) pastEvents
+                .stream()
+                .filter(pastEvent -> pastEvent.get("key").equals(key))
+                .findFirst()
+                .map(pastEvent -> pastEvent.get("count")).orElse(0L);
+        // Evaluate count against condition parameters
+    }
+}
+----
+
+=== Direct Event Query Evaluation
+
+Used when a past event condition is used directly in a rule:
+
+1. *Evaluation Process*
+   * Constructs Elasticsearch query for matching events
+   * Queries event store directly
+   * Aggregates results
+   * No caching occurs
+
+.Example Query Flow:
+[source,java]
+----
+// Direct event store query (less efficient)
+count = persistenceService.queryCount(
+    pastEventConditionPersistenceQueryBuilder.getEventCondition(
+        condition, context, item.getItemId(), definitionsService, scriptExecutor
+    ), 
+    Event.ITEM_TYPE
+);
+----
+
+== Performance Considerations
+
+=== Segment vs Direct Rule Usage
+
+1. *Segment Usage (Recommended)*
+   * Cached event counts in profile properties
+   * Real-time updates through auto-generated rules
+   * Minimal query overhead during evaluation
+   * Efficient for high-frequency conditions
+   * Suitable for large-scale segment memberships
+
+2. *Direct Rule Usage (Use with Caution)*
+   * No caching mechanism
+   * Direct event store queries on each evaluation
+   * Higher latency and resource usage
+   * Can impact system performance
+   * Suitable only for low-frequency rules
+
+=== Query Optimization
+
+1. *Property-Based Queries*
+   * Used when `generatedPropertyKey` is available
+   * Fast profile property lookups
+   * Minimal resource usage
+   * Example:
+[source,java]
+----
+if (generatedPropertyKey != null) {
+    // Use property-based query (efficient)
+    return dispatcher.buildFilter(
+        getProfileConditionForCounter(
+            generatedPropertyKey, 
+            minimumEventCount, 
+            maximumEventCount, 
+            eventsOccurred
+        ), 
+        context
+    );
+}
+----
++
+2. *Event-Based Queries*
+   * Used for direct rule conditions
+   * Requires event store access
+   * Higher resource usage
+   * Example:
+[source,java]
+----
+// Fall back to event-based query (less efficient)
+Condition eventCondition = getEventCondition(condition, context, null);
+Set<String> ids = getProfileIdsMatchingEventCount(
+    eventCondition, minimumEventCount, maximumEventCount
+);
+----
+
+=== Resource Usage
+
+1. *Memory Impact*
+   * Segment usage: Minimal (only stores count in profile)
+   * Direct rule usage: Higher (query results in memory)
+
+2. *CPU Impact*
+   * Segment usage: Low (simple property lookup)
+   * Direct rule usage: Higher (query execution and aggregation)
+
+3. *Storage Impact*
+   * Segment usage: Small profile property overhead
+   * Direct rule usage: No additional storage
+
+=== Best Practices for Performance
+
+1. *Use Segments When Possible*
+   * Prefer segments over direct rule usage
+   * Let the system generate optimization rules
+   * Benefit from built-in caching
+
+2. *Optimize Time Windows*
+   * Use reasonable time windows
+   * Consider data retention policies
+   * Balance accuracy vs performance
+
+3. *Query Optimization*
+   * Enable partitioning for large datasets
+   * Configure appropriate batch sizes
+   * Monitor query performance
+
+4. *Cache Management*
+   * Monitor cache hit rates
+   * Configure appropriate cache sizes
+   * Regular cache maintenance
+
+=== Resolution Steps
+
+1. *Initial Analysis*
+   * Verify configuration
+   * Check query patterns
+   * Analyze resource usage
+   * Review error logs
+
+2. *Detailed Investigation*
+   * Analyze query execution plans
+   * Review cache statistics
+   * Check system metrics
+   * Examine log patterns
+
+3. *Solution Implementation*
+   * Apply configuration changes
+   * Optimize queries
+   * Adjust cache settings
+   * Update monitoring rules
+
+4. *Validation*
+   * Verify improvements
+   * Monitor performance
+   * Check error rates
+   * Document changes
+
+== Maintenance and Monitoring
+
+=== Regular Maintenance Tasks
+
+1. *Event Count Recalculation*
+   * Periodic recalculation of past event counts
+   * Updates stale or incorrect counts
+   * Example:
+[source,java]
+----
+// Recalculate past event conditions
+segmentService.recalculatePastEventConditions();
+----
++
+2. *Cache Management*
+   * Monitor cache hit rates
+   * Clean up expired entries
+   * Optimize cache sizes
++
+3. *Performance Monitoring*
+   * Track query execution times
+   * Monitor resource usage
+   * Identify bottlenecks
+
+=== Monitoring Metrics
+
+1. *Query Performance*
+   * Average query execution time
+   * Query count by type (property vs direct)
+   * Cache hit/miss ratios
+
+2. *Resource Usage*
+   * Memory consumption
+   * CPU utilization
+   * Storage growth
+
+=== Troubleshooting
+
+1. *Common Issues*
+   * Slow query performance
+   * High memory usage
+   * Incorrect event counts
+   * Cache inconsistencies
+
+2. *Diagnostic Tools*
+   * Elasticsearch query analysis
+   * Performance metrics
+   * Log analysis
+   * Cache statistics
+
+3. *Resolution Steps*
+   * Verify configuration
+   * Check query patterns
+   * Analyze resource usage
+   * Review error logs

--- a/manual/src/main/asciidoc/patches.adoc
+++ b/manual/src/main/asciidoc/patches.adoc
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+[[_migration_patches]]
 === Migration patches
 
 You may provide patches on any predefined items by simply adding a JSON file in :

--- a/manual/src/main/asciidoc/samples/login-sample.adoc
+++ b/manual/src/main/asciidoc/samples/login-sample.adoc
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+[[_login_sample]]
 === Login sample
 
 This samples is an example of what is involved in integrated a login with Apache Unomi.

--- a/manual/src/main/asciidoc/samples/samples.adoc
+++ b/manual/src/main/asciidoc/samples/samples.adoc
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+[[_samples]]
 === Samples
 
 Apache Unomi provides the following samples:
 
-* <<Twitter sample,Twitter integration>>
-* <<Login sample,Login integration>>
+* <<_twitter_sample,Twitter integration>>
+* <<_login_sample,Login integration>>

--- a/manual/src/main/asciidoc/useful-unomi-urls.adoc
+++ b/manual/src/main/asciidoc/useful-unomi-urls.adoc
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+[[_useful_apache_unomi_urls]]
 === Useful Apache Unomi URLs
 
 In this section we will list some useful URLs that can be used to quickly access parts of Apache Unomi that can help

--- a/manual/src/main/asciidoc/web-tracker.adoc
+++ b/manual/src/main/asciidoc/web-tracker.adoc
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+[[_unomi_web_tracker_reference]]
 === Unomi Web Tracker reference
 
 In this section of the documentation, more details are provided about the web tracker provided by Unomi.
@@ -54,7 +55,7 @@ The first step is to declare a JSON schema for your custom event type. Here's an
 }
 ----
 
-The above example comes from a built-in event type that is already declared in Unomi but that illustrates the structure of a JSON schema. It is not however the objective of this section of the documentation to go into the details of how to declare a JSON schema, instead, we recommend you go to the <<_json_schemas_2,corresponding section>> of the documentation.
+The above example comes from a built-in event type that is already declared in Unomi but that illustrates the structure of a JSON schema. It is not however the objective of this section of the documentation to go into the details of how to declare a JSON schema, instead, we recommend you go to the <<_json_schemas,corresponding section>> of the documentation.
 
 ===== Sending event from tracker
 


### PR DESCRIPTION
## Summary
- Integrate AsciiDoctor diagram tooling in `manual/pom.xml` (asciidoctor-diagram + PlantUML) and wire GraphViz (`graphvizdot` / `GRAPHVIZ_DOT`).
- Update CI workflows to install GraphViz and add a docs workflow that builds and publishes manual artifacts.
- Add and update AsciiDoc documentation chapters (including foreword, data structures, event processing, condition evaluation, and past-event conditions).

## Test plan
- [ ] Run `cd manual && mvn -U -ntp clean install`
- [ ] Confirm docs CI workflow triggers on `manual/**` and workflow changes
- [ ] Verify generated HTML/PDF artifacts are produced in CI