### PR TITLE
Exclude .local-notes from git and RAT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ rest/.miredot-offline.json
 itests/src/main
 dependency_tree.txt
 .mvn/.develocity/develocity-workspace-id
+/.local-notes/

--- a/pom.xml
+++ b/pom.xml
@@ -641,6 +641,8 @@
                                 <exclude>**/*.js.map</exclude>
                                 <!-- Exclude dependency tree generated files -->
                                 <exclude>**/dependency_tree.txt</exclude>
+                                <!-- local developer notes (not part of the release) -->
+                                <exclude>**/.local-notes/**</exclude>
                             </excludes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
## Summary
- Add `/.local-notes/` to `.gitignore` (local developer notes, not release artifacts).
- Exclude `**/.local-notes/**` from the default `rat` profile so `mvn install` is not blocked when that directory exists locally.

## Why
Stack-extraction tracker and similar files live under `.local-notes/` without Apache license headers. RAT fails with “Too many files with unapproved license” when the directory is present in the working tree.

## Test plan
- [x] `mvn -Prat org.apache.rat:apache-rat-plugin:check`
- [ ] Build with `.local-notes/` present locally — no RAT failure

No functional or integration-test changes. After merge, sync the Git Town stack to pick up this commit.