### PR TITLE
UNOMI-937: Diagnostic fixes that missed the merge window

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,16 +19,15 @@
 ################################################################################
 
 set -e  # Exit on error
-trap 'handle_error $? $LINENO' ERR
+# Truncate $BASH_COMMAND in the trap (where it correctly reflects the failing
+# command) to avoid ARG_MAX limits after a failed mvn invocation.
+trap 'handle_error $? $LINENO "${BASH_COMMAND:0:200}"' ERR
 
 # Error handling function
 handle_error() {
     local exit_code=$1
     local line_no=$2
-    # Read BASH_COMMAND inside the function rather than passing it through the
-    # trap to avoid ARG_MAX limits after a failed mvn invocation; truncate to
-    # keep the output readable.
-    local failed_cmd="${BASH_COMMAND:0:200}"
+    local failed_cmd=$3
 
     cat << "EOF"
      _____ ____  ____   ___  ____

--- a/build.sh
+++ b/build.sh
@@ -19,13 +19,16 @@
 ################################################################################
 
 set -e  # Exit on error
-# Keep trap arguments small: passing full $BASH_COMMAND can exceed ARG_MAX after a failed mvn invocation.
 trap 'handle_error $? $LINENO' ERR
 
 # Error handling function
 handle_error() {
     local exit_code=$1
     local line_no=$2
+    # Read BASH_COMMAND inside the function rather than passing it through the
+    # trap to avoid ARG_MAX limits after a failed mvn invocation; truncate to
+    # keep the output readable.
+    local failed_cmd="${BASH_COMMAND:0:200}"
 
     cat << "EOF"
      _____ ____  ____   ___  ____
@@ -36,6 +39,7 @@ handle_error() {
 
 EOF
     echo "Error occurred in:"
+    echo "  Command: $failed_cmd"
     echo "  Line: $line_no"
     echo "  Exit code: $exit_code"
     exit $exit_code

--- a/itests/src/test/java/org/apache/unomi/itests/graphql/GraphQLListIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/graphql/GraphQLListIT.java
@@ -21,9 +21,13 @@ import org.apache.unomi.api.Profile;
 import org.apache.unomi.lists.UserList;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.Objects;
 
 public class GraphQLListIT extends BaseGraphQLIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GraphQLListIT.class);
 
     @Test
     public void testCRUD() throws Exception {
@@ -82,6 +86,7 @@ public class GraphQLListIT extends BaseGraphQLIT {
                         try (CloseableHttpResponse response = post("graphql/list/find-lists.json")) {
                             return ResponseContext.parse(response.getEntity());
                         } catch (Exception e) {
+                            LOGGER.warn("find-lists poll attempt failed: {}", e.getMessage());
                             return null;
                         }
                     },

--- a/setenv.sh
+++ b/setenv.sh
@@ -17,12 +17,15 @@
 #    limitations under the License.
 #
 ################################################################################
-# Quiet evaluate: avoid capturing Maven download lines into the environment (breaks CI with ARG_MAX).
-export UNOMI_VERSION="$(mvn -B -q -DforceStdout help:evaluate -Dexpression=project.version -DinteractiveMode=false 2>/dev/null)"
+_mvn_err=$(mktemp)
+export UNOMI_VERSION="$(mvn -B -q -DforceStdout help:evaluate -Dexpression=project.version -DinteractiveMode=false 2>"$_mvn_err")"
 if [ -z "$UNOMI_VERSION" ]; then
     echo "Failed to detect project version from Maven" >&2
+    cat "$_mvn_err" >&2
+    rm -f "$_mvn_err"
     exit 1
 fi
+rm -f "$_mvn_err"
 echo "Detected project version=$UNOMI_VERSION"
 export KARAF_VERSION=4.4.8
 # Uncomment the following line if you need Apache Unomi to start automatically at the first start


### PR DESCRIPTION
## Summary

Two small diagnostic improvements committed to the local `UNOMI-937-itests-hardening-ci` branch after the PR was merged on GitHub, so they never landed in master.

- **`GraphQLListIT.java`**: Add `LOGGER.warn(e.getMessage())` inside the `keepTrying` poll supplier so failed HTTP attempts are visible in CI logs instead of timing out silently.
- **`build.sh`**: Restore the failing command in `handle_error` output by reading `$BASH_COMMAND` inside the function (avoids ARG_MAX) and printing the first 200 chars.
- **`setenv.sh`**: Capture Maven stderr to a temp file instead of `2>/dev/null` so version detection failures print the actual error.

These were committed in response to Copilot review comments on #764 but were not pushed before the branch was merged and deleted.