### PR TITLE
UNOMI-881: Add service and extension unit tests (part 2/2)

### DIFF
--- a/extensions/groovy-actions/services/src/test/java/org/apache/unomi/groovy/actions/services/impl/GroovyActionsServiceImplTest.java
+++ b/extensions/groovy-actions/services/src/test/java/org/apache/unomi/groovy/actions/services/impl/GroovyActionsServiceImplTest.java
@@ -1,0 +1,516 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.groovy.actions.services.impl;
+
+import groovy.lang.Script;
+import org.apache.unomi.api.Event;
+import org.apache.unomi.api.ExecutionContext;
+import org.apache.unomi.api.Parameter;
+import org.apache.unomi.api.actions.Action;
+import org.apache.unomi.api.actions.ActionType;
+import org.apache.unomi.api.services.DefinitionsService;
+import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.api.services.ExecutionContextManager;
+import org.apache.unomi.api.services.SchedulerService;
+import org.apache.unomi.api.services.cache.MultiTypeCacheService;
+import org.apache.unomi.api.tenants.TenantService;
+import org.apache.unomi.groovy.actions.GroovyActionDispatcher;
+import org.apache.unomi.persistence.spi.PersistenceService;
+import org.apache.unomi.persistence.spi.conditions.evaluator.ConditionEvaluatorDispatcher;
+import org.apache.unomi.services.TestHelper;
+import org.apache.unomi.services.common.security.KarafSecurityService;
+import org.apache.unomi.services.impl.InMemoryPersistenceServiceImpl;
+import org.apache.unomi.services.impl.TestConditionEvaluators;
+import org.apache.unomi.services.impl.TestTenantService;
+import org.apache.unomi.services.impl.cache.MultiTypeCacheServiceImpl;
+import org.apache.unomi.tracing.api.TracerService;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.wiring.BundleWiring;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the GroovyActionsServiceImpl class.
+ */
+public class GroovyActionsServiceImplTest {
+
+    private GroovyActionsServiceImpl groovyActionsService;
+    private TenantService tenantService;
+    private PersistenceService persistenceService;
+    private BundleContext bundleContext;
+    private ExecutionContextManager contextManager;
+    private SchedulerService schedulerService;
+    private MultiTypeCacheService cacheService;
+    private KarafSecurityService securityService;
+    private TracerService tracerService;
+    private DefinitionsService definitionsService;
+    private ExecutionContext executionContext;
+
+    private static final String TENANT_1 = "tenant1";
+    private static final String SYSTEM_TENANT = "system";
+
+    @Before
+    public void setUp() throws Exception {
+        tenantService = new TestTenantService();
+        securityService = TestHelper.createSecurityService();
+        securityService.setCurrentSubject(securityService.createSubject(TENANT_1, true));
+        contextManager = TestHelper.createExecutionContextManager(securityService);
+        tracerService = TestHelper.createTracerService();
+        // Create tenants
+        contextManager.executeAsSystem(() -> {
+            tenantService.createTenant(SYSTEM_TENANT, Collections.singletonMap("description", "System tenant"));
+            tenantService.createTenant(TENANT_1, Collections.singletonMap("description", "Tenant 1"));
+            return null;
+        });
+
+        // Set up condition evaluator dispatcher
+        ConditionEvaluatorDispatcher conditionEvaluatorDispatcher = TestConditionEvaluators.createDispatcher();
+
+        // Set up persistence service
+        persistenceService = new InMemoryPersistenceServiceImpl(contextManager, conditionEvaluatorDispatcher);
+
+
+        // Set up bundle context with predefined data
+        bundleContext = mock(BundleContext.class);
+        Bundle systemBundle = mock(Bundle.class);
+        when(systemBundle.getBundleId()).thenReturn(0L);
+        when(systemBundle.getSymbolicName()).thenReturn("org.apache.unomi.predefined");
+        when(systemBundle.getBundleContext()).thenReturn(bundleContext);
+        BundleWiring bundleWiring = mock(BundleWiring.class);
+        when(bundleWiring.getClassLoader()).thenReturn(getClass().getClassLoader());
+        when(systemBundle.adapt(BundleWiring.class)).thenReturn(bundleWiring);
+        when(bundleContext.getBundle()).thenReturn(systemBundle);
+        when(bundleContext.getBundles()).thenReturn(new Bundle[] { systemBundle });
+        when(bundleContext.getBundle().getHeaders()).thenReturn(new Hashtable<>());
+        URL baseScriptURL = getClass().getResource("/META-INF/base/BaseScript.groovy");
+        when(bundleContext.getBundle().getEntry("META-INF/base/BaseScript.groovy")).thenReturn(baseScriptURL);
+
+        // Create predefined schemas
+        URL schemasUrl = getClass().getResource("/META-INF/cxs/schemas/predefined-schemas.json");
+        when(bundleContext.getBundle().findEntries("META-INF/cxs/schemas", "*.json", true))
+                .thenReturn(Collections.enumeration(Arrays.asList(schemasUrl)));
+
+        schedulerService = TestHelper.createSchedulerService("groovy-actions-service-scheduler-node", persistenceService, contextManager, bundleContext, null, -1, true, true);
+
+        cacheService = new MultiTypeCacheServiceImpl();
+
+        definitionsService = TestHelper.createDefinitionService(persistenceService, bundleContext, schedulerService, cacheService, contextManager, tenantService);
+
+        // Set up Groovy actions service with spy to mock internal methods
+        groovyActionsService = new GroovyActionsServiceImpl();
+
+        // Set dependencies
+        groovyActionsService.setPersistenceService(persistenceService);
+        groovyActionsService.setTenantService(tenantService);
+        groovyActionsService.setContextManager(contextManager);
+        groovyActionsService.setSchedulerService(schedulerService);
+        groovyActionsService.setCacheService(cacheService);
+        groovyActionsService.setDefinitionsService(definitionsService);
+        groovyActionsService.setBundleContext(bundleContext);
+
+        // Create a mock config for the activate method
+        GroovyActionsServiceImpl.GroovyActionsServiceConfig config = mock(GroovyActionsServiceImpl.GroovyActionsServiceConfig.class);
+        when(config.services_groovy_actions_refresh_interval()).thenReturn(1000);
+
+        groovyActionsService.activate(config, bundleContext);
+    }
+
+    @Test
+    public void testSaveGroovyAction() {
+        // Prepare test data
+        String actionName = "testSaveAction";
+
+        // Load the Groovy script from the resource file
+        String groovyScript;
+        try {
+            URL resourceUrl = getClass().getResource("/META-INF/cxs/actions/testSaveAction.groovy");
+            if (resourceUrl == null) {
+                fail("Could not find test Groovy action file");
+            }
+            groovyScript = new String(Files.readAllBytes(
+                    Paths.get(resourceUrl.toURI())));
+        } catch (Exception e) {
+            fail("Failed to load Groovy action from resource file: " + e.getMessage());
+            return;
+        }
+
+        // Execute save action in tenant context
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            groovyActionsService.save(actionName, groovyScript);
+
+            assertNotNull(definitionsService.getActionType(actionName));
+        });
+    }
+
+    @Test
+    public void testRemoveGroovyAction() {
+        // First save an action
+        String actionName = "testRemoveAction";
+
+        // Load the Groovy script from the resource file
+        String groovyScript;
+        try {
+            URL resourceUrl = getClass().getResource("/META-INF/cxs/actions/testRemoveAction.groovy");
+            if (resourceUrl == null) {
+                fail("Could not find test Groovy action file for removal test");
+            }
+            groovyScript = new String(Files.readAllBytes(
+                    Paths.get(resourceUrl.toURI())));
+        } catch (Exception e) {
+            fail("Failed to load Groovy action from resource file: " + e.getMessage());
+            return;
+        }
+
+        // Execute save and then remove action in tenant context
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            // First save the action
+            groovyActionsService.save(actionName, groovyScript);
+            assertNotNull("Action should be saved before removal test", definitionsService.getActionType(actionName));
+
+            // Then remove it
+            groovyActionsService.remove(actionName);
+            assertNull("Action should be removed after removal test", definitionsService.getActionType(actionName));
+        });
+    }
+
+    @Test
+    public void testExecuteGroovyAction() {
+        // Prepare test data
+        String actionName = "testExecuteAction";
+
+        // Load the Groovy script from the resource file
+        String groovyScript;
+        try {
+            URL resourceUrl = getClass().getResource("/META-INF/cxs/actions/testExecuteAction.groovy");
+            if (resourceUrl == null) {
+                fail("Could not find test Groovy action file for execution test");
+            }
+            groovyScript = new String(Files.readAllBytes(
+                    Paths.get(resourceUrl.toURI())));
+        } catch (Exception e) {
+            fail("Failed to load Groovy action from resource file: " + e.getMessage());
+            return;
+        }
+
+        // First save the Groovy action
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            groovyActionsService.save(actionName, groovyScript);
+
+            // Verify action type is saved properly
+            ActionType actionType = definitionsService.getActionType(actionName);
+            assertNotNull("Action type should be registered", actionType);
+            assertEquals("Action should have 2 parameters", 2, actionType.getParameters().size());
+
+            // Create a GroovyActionDispatcher to execute the action directly
+            GroovyActionDispatcher groovyDispatcher = new GroovyActionDispatcher();
+            groovyDispatcher.setTracerService(tracerService);
+            groovyDispatcher.setGroovyActionsService(groovyActionsService);
+
+            // Create an event
+            Event event = new Event();
+            event.setEventType("test");
+            event.setScope("testScope");
+
+            try {
+                // Test 1: SESSION_UPDATED return value
+                Action action1 = new Action();
+                action1.setActionTypeId(actionName);
+                action1.setParameter("returnType", "SESSION_UPDATED");
+                action1.setParameter("shouldFail", false);
+
+                int result1 = groovyDispatcher.execute(action1, event, actionName);
+                assertEquals("Action should return SESSION_UPDATED", EventService.SESSION_UPDATED, result1);
+
+                // Test 2: NO_CHANGE return value
+                Action action2 = new Action();
+                action2.setActionTypeId(actionName);
+                action2.setParameter("returnType", "NO_CHANGE");
+                action2.setParameter("shouldFail", false);
+
+                int result2 = groovyDispatcher.execute(action2, event, actionName);
+                assertEquals("Action should return NO_CHANGE", EventService.NO_CHANGE, result2);
+
+                // Test 3: ERROR return value
+                Action action3 = new Action();
+                action3.setActionTypeId(actionName);
+                action3.setParameter("returnType", "SESSION_UPDATED");
+                action3.setParameter("shouldFail", true);
+
+                int result3 = groovyDispatcher.execute(action3, event, actionName);
+                assertEquals("Action should return ERROR", EventService.ERROR, result3);
+            } catch (Exception e) {
+                fail("Failed to execute Groovy action: " + e.getMessage());
+            }
+        });
+    }
+
+    @Test
+    public void testCompiledScript() {
+        // Test that we can get a compiled script
+        String actionName = "testCompiledScript";
+        String script = "return 'Hello, World!'";
+
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            groovyActionsService.save(actionName, script);
+
+            Class<? extends groovy.lang.Script> scriptClass = groovyActionsService.getCompiledScript(actionName);
+            assertNotNull("Compiled script should not be null", scriptClass);
+
+            // Test that we can create an instance and execute it
+            try {
+                Script scriptInstance = scriptClass.getDeclaredConstructor().newInstance();
+                Object result = scriptInstance.run();
+                assertEquals("Script result should match", "Hello, World!", result);
+            } catch (Exception e) {
+                fail("Should be able to execute compiled script: " + e.getMessage());
+            }
+
+            // Clean up
+            groovyActionsService.remove(actionName);
+        });
+    }
+
+    @Test
+    public void testLoadPredefinedGroovyActions() {
+        // We'll use the existing service instance instead of creating a new one
+        // Set up the bundle to find our test Groovy actions
+        URL action1Url = getClass().getResource("/META-INF/cxs/actions/testSaveAction.groovy");
+        URL action2Url = getClass().getResource("/META-INF/cxs/actions/testExecuteAction.groovy");
+
+        // Mock the bundle context to return our test actions
+        when(bundleContext.getBundle().findEntries("META-INF/cxs/actions", "*.groovy", true))
+            .thenReturn(Collections.enumeration(Arrays.asList(action1Url, action2Url)));
+
+        // Reset the service to force loading of predefined items
+        groovyActionsService.preDestroy();
+
+        // Re-activate the service with the existing bundle context
+        GroovyActionsServiceImpl.GroovyActionsServiceConfig config = mock(GroovyActionsServiceImpl.GroovyActionsServiceConfig.class);
+        when(config.services_groovy_actions_refresh_interval()).thenReturn(1000);
+        groovyActionsService.activate(config, bundleContext);
+
+        // Verify that the actions were loaded in the system tenant
+        contextManager.executeAsSystem(() -> {
+            // Test action types were registered properly
+            ActionType saveActionType = definitionsService.getActionType("testSaveAction");
+            assertNotNull("testSaveAction should be registered", saveActionType);
+
+            ActionType executeActionType = definitionsService.getActionType("testExecuteAction");
+            assertNotNull("testExecuteAction should be registered", executeActionType);
+            return null;
+        });
+
+        // Verify we can get the compiled script for the loaded actions
+        contextManager.executeAsSystem(() -> {
+            assertNotNull("Should have compiled script for testSaveAction in system tenant",
+                        groovyActionsService.getCompiledScript("testSaveAction"));
+            return null;
+        });
+    }
+
+    @Test
+    public void testDetailedActionAnnotation() {
+        // Create a Groovy script with a detailed action annotation
+        String actionName = "testDetailedAction";
+        String groovyScript =
+            "import org.apache.unomi.api.services.EventService\n" +
+            "import org.apache.unomi.groovy.actions.annotations.Action\n" +
+            "import org.apache.unomi.groovy.actions.annotations.Parameter\n\n" +
+            "@Action(\n" +
+            "    id = \"testDetailedAction\",\n" +
+            "    name = \"Test Detailed Action\",\n" +
+            "    description = \"A detailed action for testing annotations\",\n" +
+            "    actionExecutor = \"groovy:testDetailedAction\",\n" +
+            "    systemTags = [\"test\", \"groovy\"],\n" +
+            "    hidden = true,\n" +
+            "    parameters = [\n" +
+            "        @Parameter(id = \"stringParam\", type = \"string\", multivalued = false),\n" +
+            "        @Parameter(id = \"intParam\", type = \"integer\", multivalued = true),\n" +
+            "        @Parameter(id = \"boolParam\", type = \"boolean\", multivalued = false)\n" +
+            "    ]\n" +
+            ")\n" +
+            "def execute() {\n" +
+            "    logger.info(\"Executing detailed test action\")\n" +
+            "    return EventService.NO_CHANGE\n" +
+            "}";
+
+        // Save the action
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            groovyActionsService.save(actionName, groovyScript);
+
+            // Verify action type is created with all the details
+            ActionType actionType = definitionsService.getActionType(actionName);
+            assertNotNull("Action type should be created", actionType);
+
+            // Check metadata
+            assertEquals("Action name should match", "Test Detailed Action", actionType.getMetadata().getName());
+            assertEquals("Action description should match", "A detailed action for testing annotations",
+                        actionType.getMetadata().getDescription());
+            assertEquals("Action executor should match", "groovy:testDetailedAction",
+                        actionType.getActionExecutor());
+            assertTrue("Action should be hidden", actionType.getMetadata().isHidden());
+
+            // Check system tags
+            Set<String> systemTags = actionType.getMetadata().getSystemTags();
+            assertTrue("Should have 'test' system tag", systemTags.contains("test"));
+            assertTrue("Should have 'groovy' system tag", systemTags.contains("groovy"));
+
+            // Check parameters
+            assertEquals("Should have 3 parameters", 3, actionType.getParameters().size());
+
+            // Check parameters by id
+            Map<String, Parameter> paramsById = new HashMap<>();
+            for (Parameter param : actionType.getParameters()) {
+                paramsById.put(param.getId(), param);
+            }
+
+            assertTrue("Should have stringParam", paramsById.containsKey("stringParam"));
+            Parameter stringParam = paramsById.get("stringParam");
+            assertEquals("String parameter type should match", "string", stringParam.getType());
+            assertFalse("String parameter should not be multivalued", stringParam.isMultivalued());
+
+            assertTrue("Should have intParam", paramsById.containsKey("intParam"));
+            Parameter intParam = paramsById.get("intParam");
+            assertEquals("Integer parameter type should match", "integer", intParam.getType());
+            assertTrue("Integer parameter should be multivalued", intParam.isMultivalued());
+
+            assertTrue("Should have boolParam", paramsById.containsKey("boolParam"));
+            Parameter boolParam = paramsById.get("boolParam");
+            assertEquals("Boolean parameter type should match", "boolean", boolParam.getType());
+            assertFalse("Boolean parameter should not be multivalued", boolParam.isMultivalued());
+
+            // Clean up
+            groovyActionsService.remove(actionName);
+            assertNull("Action should be removed", definitionsService.getActionType(actionName));
+        });
+    }
+
+    @Test
+    public void testMultiTenantIsolation() {
+        // Create a second tenant for testing isolation
+        final String TENANT_2 = "tenant2";
+
+        contextManager.executeAsSystem(() -> {
+            tenantService.createTenant(TENANT_2, Collections.singletonMap("description", "Tenant 2"));
+            return null;
+        });
+
+        // Create a simple action
+        String actionName = "isolatedAction";
+        String tenant1Script =
+            "import org.apache.unomi.api.services.EventService\n" +
+            "import org.apache.unomi.groovy.actions.annotations.Action\n\n" +
+            "@Action(id = \"isolatedAction\", actionExecutor = \"groovy:isolatedAction\")\n" +
+            "def execute() {\n" +
+            "    return EventService.NO_CHANGE\n" +
+            "}";
+
+        String tenant2Script =
+            "import org.apache.unomi.api.services.EventService\n" +
+            "import org.apache.unomi.groovy.actions.annotations.Action\n\n" +
+            "@Action(id = \"isolatedAction\", actionExecutor = \"groovy:isolatedAction\")\n" +
+            "def execute() {\n" +
+            "    return EventService.SESSION_UPDATED\n" +
+            "}";
+
+        try {
+            // Save actions for each tenant
+            contextManager.executeAsTenant(TENANT_1, () -> {
+                groovyActionsService.save(actionName, tenant1Script);
+                assertNotNull("Action should be registered for tenant1",
+                             groovyActionsService.getCompiledScript(actionName));
+            });
+
+            contextManager.executeAsTenant(TENANT_2, () -> {
+                groovyActionsService.save(actionName, tenant2Script);
+                assertNotNull("Action should be registered for tenant2",
+                             groovyActionsService.getCompiledScript(actionName));
+            });
+
+            // Create a dispatcher to test execution
+            GroovyActionDispatcher dispatcher = new GroovyActionDispatcher();
+            dispatcher.setTracerService(tracerService);
+            dispatcher.setGroovyActionsService(groovyActionsService);
+
+            Event event = new Event();
+            Action action = new Action();
+            action.setActionTypeId(actionName);
+
+            // Test execution in tenant1
+            final int[] tenant1Result = new int[1];
+            contextManager.executeAsTenant(TENANT_1, () -> {
+                try {
+                    tenant1Result[0] = dispatcher.execute(action, event, actionName);
+                } catch (Exception e) {
+                    fail("Failed to execute action in tenant1: " + e.getMessage());
+                }
+            });
+
+            // Test execution in tenant2
+            final int[] tenant2Result = new int[1];
+            contextManager.executeAsTenant(TENANT_2, () -> {
+                try {
+                    tenant2Result[0] = dispatcher.execute(action, event, actionName);
+                } catch (Exception e) {
+                    fail("Failed to execute action in tenant2: " + e.getMessage());
+                }
+            });
+
+            // Verify different results
+            assertEquals("Tenant1 action should return NO_CHANGE", EventService.NO_CHANGE, tenant1Result[0]);
+            assertEquals("Tenant2 action should return SESSION_UPDATED", EventService.SESSION_UPDATED, tenant2Result[0]);
+
+            // Check tenant isolation - remove tenant1's action
+            contextManager.executeAsTenant(TENANT_1, () -> {
+                // Remove tenant1's action
+                groovyActionsService.remove(actionName);
+
+                // Verify tenant1's action is gone
+                assertNull("Tenant1's action should be removed",
+                          groovyActionsService.getCompiledScript(actionName));
+            });
+
+            // Verify tenant2's action is still available
+            contextManager.executeAsTenant(TENANT_2, () -> {
+                // Tenant2's action should still be available
+                assertNotNull("Tenant2's action should still be available",
+                           groovyActionsService.getCompiledScript(actionName));
+
+                // Cleanup
+                groovyActionsService.remove(actionName);
+            });
+
+        } finally {
+            // Clean up tenant2
+            contextManager.executeAsSystem(() -> {
+                tenantService.deleteTenant(TENANT_2);
+                return null;
+            });
+        }
+    }
+}
+

--- a/extensions/groovy-actions/services/src/test/java/org/apache/unomi/groovy/actions/services/impl/GroovyActionsServiceImplTest.java
+++ b/extensions/groovy-actions/services/src/test/java/org/apache/unomi/groovy/actions/services/impl/GroovyActionsServiceImplTest.java
@@ -38,6 +38,7 @@ import org.apache.unomi.services.impl.TestConditionEvaluators;
 import org.apache.unomi.services.impl.TestTenantService;
 import org.apache.unomi.services.impl.cache.MultiTypeCacheServiceImpl;
 import org.apache.unomi.tracing.api.TracerService;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
@@ -45,7 +46,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.wiring.BundleWiring;
 
 import java.net.URL;
-import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.*;
 
@@ -139,24 +140,29 @@ public class GroovyActionsServiceImplTest {
         groovyActionsService.activate(config, bundleContext);
     }
 
+    @After
+    public void tearDown() {
+        if (groovyActionsService != null) {
+            groovyActionsService.preDestroy();
+        }
+        if (schedulerService instanceof org.apache.unomi.services.impl.scheduler.SchedulerServiceImpl) {
+            ((org.apache.unomi.services.impl.scheduler.SchedulerServiceImpl) schedulerService).preDestroy();
+        }
+    }
+
+    private String loadGroovyScript(String resourcePath, String missingMessage) throws Exception {
+        URL resourceUrl = getClass().getResource(resourcePath);
+        assertNotNull(missingMessage, resourceUrl);
+        return java.nio.file.Files.readString(Paths.get(resourceUrl.toURI()), StandardCharsets.UTF_8);
+    }
+
     @Test
-    public void testSaveGroovyAction() {
+    public void testSaveGroovyAction() throws Exception {
         // Prepare test data
         String actionName = "testSaveAction";
-
-        // Load the Groovy script from the resource file
-        String groovyScript;
-        try {
-            URL resourceUrl = getClass().getResource("/META-INF/cxs/actions/testSaveAction.groovy");
-            if (resourceUrl == null) {
-                fail("Could not find test Groovy action file");
-            }
-            groovyScript = new String(Files.readAllBytes(
-                    Paths.get(resourceUrl.toURI())));
-        } catch (Exception e) {
-            fail("Failed to load Groovy action from resource file: " + e.getMessage());
-            return;
-        }
+        String groovyScript = loadGroovyScript(
+            "/META-INF/cxs/actions/testSaveAction.groovy",
+            "Could not find test Groovy action file");
 
         // Execute save action in tenant context
         contextManager.executeAsTenant(TENANT_1, () -> {
@@ -167,23 +173,12 @@ public class GroovyActionsServiceImplTest {
     }
 
     @Test
-    public void testRemoveGroovyAction() {
+    public void testRemoveGroovyAction() throws Exception {
         // First save an action
         String actionName = "testRemoveAction";
-
-        // Load the Groovy script from the resource file
-        String groovyScript;
-        try {
-            URL resourceUrl = getClass().getResource("/META-INF/cxs/actions/testRemoveAction.groovy");
-            if (resourceUrl == null) {
-                fail("Could not find test Groovy action file for removal test");
-            }
-            groovyScript = new String(Files.readAllBytes(
-                    Paths.get(resourceUrl.toURI())));
-        } catch (Exception e) {
-            fail("Failed to load Groovy action from resource file: " + e.getMessage());
-            return;
-        }
+        String groovyScript = loadGroovyScript(
+            "/META-INF/cxs/actions/testRemoveAction.groovy",
+            "Could not find test Groovy action file for removal test");
 
         // Execute save and then remove action in tenant context
         contextManager.executeAsTenant(TENANT_1, () -> {
@@ -198,23 +193,12 @@ public class GroovyActionsServiceImplTest {
     }
 
     @Test
-    public void testExecuteGroovyAction() {
+    public void testExecuteGroovyAction() throws Exception {
         // Prepare test data
         String actionName = "testExecuteAction";
-
-        // Load the Groovy script from the resource file
-        String groovyScript;
-        try {
-            URL resourceUrl = getClass().getResource("/META-INF/cxs/actions/testExecuteAction.groovy");
-            if (resourceUrl == null) {
-                fail("Could not find test Groovy action file for execution test");
-            }
-            groovyScript = new String(Files.readAllBytes(
-                    Paths.get(resourceUrl.toURI())));
-        } catch (Exception e) {
-            fail("Failed to load Groovy action from resource file: " + e.getMessage());
-            return;
-        }
+        String groovyScript = loadGroovyScript(
+            "/META-INF/cxs/actions/testExecuteAction.groovy",
+            "Could not find test Groovy action file for execution test");
 
         // First save the Groovy action
         contextManager.executeAsTenant(TENANT_1, () -> {
@@ -263,7 +247,7 @@ public class GroovyActionsServiceImplTest {
                 int result3 = groovyDispatcher.execute(action3, event, actionName);
                 assertEquals("Action should return ERROR", EventService.ERROR, result3);
             } catch (Exception e) {
-                fail("Failed to execute Groovy action: " + e.getMessage());
+                throw new AssertionError("Failed to execute Groovy action", e);
             }
         });
     }
@@ -286,7 +270,7 @@ public class GroovyActionsServiceImplTest {
                 Object result = scriptInstance.run();
                 assertEquals("Script result should match", "Hello, World!", result);
             } catch (Exception e) {
-                fail("Should be able to execute compiled script: " + e.getMessage());
+                throw new AssertionError("Should be able to execute compiled script", e);
             }
 
             // Clean up
@@ -466,7 +450,7 @@ public class GroovyActionsServiceImplTest {
                 try {
                     tenant1Result[0] = dispatcher.execute(action, event, actionName);
                 } catch (Exception e) {
-                    fail("Failed to execute action in tenant1: " + e.getMessage());
+                    throw new AssertionError("Failed to execute action in tenant1", e);
                 }
             });
 
@@ -476,7 +460,7 @@ public class GroovyActionsServiceImplTest {
                 try {
                     tenant2Result[0] = dispatcher.execute(action, event, actionName);
                 } catch (Exception e) {
-                    fail("Failed to execute action in tenant2: " + e.getMessage());
+                    throw new AssertionError("Failed to execute action in tenant2", e);
                 }
             });
 
@@ -513,4 +497,3 @@ public class GroovyActionsServiceImplTest {
         }
     }
 }
-

--- a/extensions/groovy-actions/services/src/test/resources/META-INF/base/BaseScript.groovy
+++ b/extensions/groovy-actions/services/src/test/resources/META-INF/base/BaseScript.groovy
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Base script class extended by all Groovy action scripts.
+ * Provides common utility functions for Groovy actions.
+ */
+abstract class BaseScript extends Script {
+    
+    /**
+     * Example utility function that could be used by Groovy actions
+     */
+    def utilityFunction(String value) {
+        return "processed: " + value
+    }
+    
+    /**
+     * Helper method to log debug messages
+     */
+    def debug(String message) {
+        logger.debug(message)
+    }
+    
+    /**
+     * Helper method to log info messages
+     */
+    def info(String message) {
+        logger.info(message)
+    }
+} 

--- a/extensions/groovy-actions/services/src/test/resources/META-INF/cxs/actions/predefined-actions.json
+++ b/extensions/groovy-actions/services/src/test/resources/META-INF/cxs/actions/predefined-actions.json
@@ -1,0 +1,8 @@
+{
+  "actions": [
+    {
+      "name": "predefinedAction",
+      "script": "import org.apache.unomi.groovy.actions.annotations.Action\n@Action(id = \"predefinedAction\", name = \"Predefined Action\")\ndef execute() {\n  logger.info(\"Executing predefined action\")\n  return true\n}"
+    }
+  ]
+} 

--- a/extensions/groovy-actions/services/src/test/resources/META-INF/cxs/actions/testAction.groovy
+++ b/extensions/groovy-actions/services/src/test/resources/META-INF/cxs/actions/testAction.groovy
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.unomi.groovy.actions.annotations.Action
+import org.apache.unomi.groovy.actions.annotations.Parameter
+
+/**
+ * Test Groovy action for unit tests
+ */
+@Action(
+    id = "testAction",
+    name = "Test Action",
+    description = "A test action for unit testing",
+    parameters = [
+        @Parameter(id = "param1", type = "string"),
+        @Parameter(id = "param2", type = "integer")
+    ]
+)
+def execute() {
+    logger.info("Executing test action")
+    
+    // Use base script utility function
+    def processedText = utilityFunction("test")
+    logger.debug("Processed text: ${processedText}")
+    
+    return true
+} 

--- a/extensions/groovy-actions/services/src/test/resources/META-INF/cxs/actions/testExecuteAction.groovy
+++ b/extensions/groovy-actions/services/src/test/resources/META-INF/cxs/actions/testExecuteAction.groovy
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.unomi.api.services.EventService
+import org.apache.unomi.groovy.actions.annotations.Action
+import org.apache.unomi.groovy.actions.annotations.Parameter
+
+/**
+ * Test Groovy action that accepts parameters and returns EventService constants
+ */
+@Action(
+    id = "testExecuteAction", 
+    name = "Test Execute Action", 
+    description = "Action for testing execution with parameters",
+    actionExecutor = "groovy:testExecuteAction",
+    parameters = [
+        @Parameter(id = "returnType", type = "string", multivalued = false),
+        @Parameter(id = "shouldFail", type = "boolean", multivalued = false)
+    ]
+)
+def execute() {
+    // Access parameters from the action object
+    def returnType = action.getParameterValues().get("returnType")
+    def shouldFail = action.getParameterValues().get("shouldFail")
+    
+    // Log received parameters
+    logger.info("Executing action with parameters: returnType=${returnType}, shouldFail=${shouldFail}")
+    
+    // Check the should fail parameter
+    if (shouldFail) {
+        logger.error("Action execution failed as requested by shouldFail parameter")
+        return EventService.ERROR
+    }
+    
+    // Return based on the returnType parameter
+    switch (returnType) {
+        case "SESSION_UPDATED":
+            return EventService.SESSION_UPDATED
+        case "NO_CHANGE":
+            return EventService.NO_CHANGE
+        default:
+            logger.warn("Unknown returnType: ${returnType}, defaulting to NO_CHANGE")
+            return EventService.NO_CHANGE
+    }
+} 

--- a/extensions/groovy-actions/services/src/test/resources/META-INF/cxs/actions/testRemoveAction.groovy
+++ b/extensions/groovy-actions/services/src/test/resources/META-INF/cxs/actions/testRemoveAction.groovy
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.unomi.api.services.EventService
+import org.apache.unomi.groovy.actions.annotations.Action
+import org.apache.unomi.groovy.actions.annotations.Parameter
+
+/**
+ * Test Groovy action for the testRemoveGroovyAction unit test
+ */
+@Action(
+    id = "testRemoveAction", 
+    name = "Test Remove Action", 
+    description = "Action for testing remove functionality",
+    actionExecutor = "groovy:testRemoveAction",
+    parameters = []
+)
+def execute() {
+    logger.info("Executing remove test action")
+    return EventService.NO_CHANGE
+} 

--- a/extensions/groovy-actions/services/src/test/resources/META-INF/cxs/actions/testSaveAction.groovy
+++ b/extensions/groovy-actions/services/src/test/resources/META-INF/cxs/actions/testSaveAction.groovy
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.unomi.api.services.EventService
+import org.apache.unomi.groovy.actions.annotations.Action
+import org.apache.unomi.groovy.actions.annotations.Parameter
+
+/**
+ * Test Groovy action for the testSaveGroovyAction unit test
+ */
+@Action(
+    id = "testSaveAction", 
+    name = "Test Save Action", 
+    description = "Action for testing save functionality",
+    actionExecutor = "groovy:testSaveAction",
+    parameters = []
+)
+def execute() {
+    logger.info("Executing test action")
+    return EventService.NO_CHANGE
+} 

--- a/extensions/json-schema/services/src/test/java/org/apache/unomi/schema/impl/SchemaServiceImplTest.java
+++ b/extensions/json-schema/services/src/test/java/org/apache/unomi/schema/impl/SchemaServiceImplTest.java
@@ -29,6 +29,7 @@ import org.apache.unomi.services.common.security.KarafSecurityService;
 import org.apache.unomi.services.impl.*;
 import org.apache.unomi.services.impl.cache.MultiTypeCacheServiceImpl;
 import org.apache.unomi.tracing.api.TracerService;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
@@ -106,6 +107,16 @@ public class SchemaServiceImplTest {
         schemaService.setBundleContext(bundleContext);
         schemaService.setCacheService(cacheService);
         schemaService.postConstruct();
+    }
+
+    @After
+    public void tearDown() {
+        if (schemaService != null) {
+            schemaService.preDestroy();
+        }
+        if (schedulerService instanceof org.apache.unomi.services.impl.scheduler.SchedulerServiceImpl) {
+            ((org.apache.unomi.services.impl.scheduler.SchedulerServiceImpl) schedulerService).preDestroy();
+        }
     }
 
     @Test
@@ -1189,13 +1200,9 @@ public class SchemaServiceImplTest {
                 // Test events - should not have errors (valid test event)
                 assertFalse("Should not have errors for test event type", validationResults.containsKey("test"));
 
-                // Unknown event type - should have errors
-                assertTrue("Should have errors for unknown event type",
-                    validationResults.containsKey("unknown") || validationResults.containsKey("error"));
-
-                // Missing eventType event - should produce an error (may be under 'error' key)
-                assertTrue("Should have generic error for missing eventType",
-                    validationResults.containsKey("error"));
+                assertEquals("Batch validation should report the invalid known type, the unknown event type and the missing eventType error",
+                    new HashSet<>(Arrays.asList("test_event", "unknown", "error")),
+                    validationResults.keySet());
 
                 return null;
             } catch (ValidationException e) {
@@ -1211,17 +1218,14 @@ public class SchemaServiceImplTest {
 
                 Map<String, Set<ValidationError>> validationResults = schemaService.validateEvents(invalidJson);
 
-                // Should return a generic error with key "error"
                 assertNotNull("Validation results should not be null", validationResults);
-                assertTrue("Should have generic error key", validationResults.containsKey("error"));
+                assertEquals("Non-array input should be reported under the generic error key",
+                    Collections.singleton("error"), validationResults.keySet());
                 assertFalse("Error set should not be empty", validationResults.get("error").isEmpty());
 
                 return null;
             } catch (ValidationException e) {
-                // This is expected for implementation that throws exceptions
-                // If the implementation returns error map instead, this catch block won't execute
-                assertNotNull("Exception should have a message", e.getMessage());
-                return null;
+                throw new AssertionError("validateEvents should normalize malformed JSON input to the generic error bucket", e);
             }
         });
 

--- a/extensions/json-schema/services/src/test/java/org/apache/unomi/schema/impl/SchemaServiceImplTest.java
+++ b/extensions/json-schema/services/src/test/java/org/apache/unomi/schema/impl/SchemaServiceImplTest.java
@@ -1,0 +1,1255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.schema.impl;
+
+import org.apache.unomi.api.services.ExecutionContextManager;
+import org.apache.unomi.api.services.SchedulerService;
+import org.apache.unomi.api.services.cache.MultiTypeCacheService;
+import org.apache.unomi.persistence.spi.PersistenceService;
+import org.apache.unomi.persistence.spi.conditions.evaluator.ConditionEvaluatorDispatcher;
+import org.apache.unomi.schema.api.JsonSchemaWrapper;
+import org.apache.unomi.schema.api.ValidationException;
+import org.apache.unomi.schema.api.ValidationError;
+import org.apache.unomi.services.TestHelper;
+import org.apache.unomi.services.common.security.KarafSecurityService;
+import org.apache.unomi.services.impl.*;
+import org.apache.unomi.services.impl.cache.MultiTypeCacheServiceImpl;
+import org.apache.unomi.tracing.api.TracerService;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.apache.commons.io.IOUtils;
+
+import java.net.URL;
+import java.util.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SchemaServiceImplTest {
+
+    private SchemaServiceImpl schemaService;
+    private TestTenantService tenantService;
+    private PersistenceService persistenceService;
+    private TestBundleContext bundleContext;
+    private KarafSecurityService securityService;
+    private ExecutionContextManager contextManager;
+    private TracerService tracerService;
+    private SchedulerService schedulerService;
+    private MultiTypeCacheService cacheService;
+    private static final String TENANT_1 = "tenant1";
+    private static final String SYSTEM_TENANT = "system";
+
+    @Before
+    public void setUp() {
+        tenantService = new TestTenantService();
+        securityService = TestHelper.createSecurityService();
+        securityService.setCurrentSubject(securityService.createSubject(TENANT_1, true));
+        contextManager = TestHelper.createExecutionContextManager(securityService);
+        tracerService = TestHelper.createTracerService();
+        // Create tenants
+        contextManager.executeAsSystem(() -> {
+            tenantService.createTenant(SYSTEM_TENANT, Collections.singletonMap("description", "System tenant"));
+            tenantService.createTenant(TENANT_1, Collections.singletonMap("description", "Tenant 1"));
+            return null;
+        });
+
+        // Set up condition evaluator dispatcher
+        ConditionEvaluatorDispatcher conditionEvaluatorDispatcher = TestConditionEvaluators.createDispatcher();
+
+        // Set up persistence service
+        persistenceService = new InMemoryPersistenceServiceImpl(contextManager, conditionEvaluatorDispatcher);
+
+        // Set up bundle context with predefined data
+        bundleContext = new TestBundleContext();
+        Bundle systemBundle = mock(Bundle.class);
+        when(systemBundle.getBundleId()).thenReturn(0L);
+        when(systemBundle.getSymbolicName()).thenReturn("org.apache.unomi.predefined");
+        when(systemBundle.getBundleContext()).thenReturn(bundleContext);
+
+        bundleContext.addBundle(systemBundle);
+
+        // Create predefined schemas
+        URL schemasUrl = getClass().getResource("/META-INF/cxs/schemas/predefined-schemas.json");
+        when(bundleContext.getBundle().findEntries("META-INF/cxs/schemas", "*.json", true))
+                .thenReturn(Collections.enumeration(Arrays.asList(schemasUrl)));
+
+        schedulerService = TestHelper.createSchedulerService("schema-scheduler-node", persistenceService, contextManager, bundleContext, null, -1, true, true);
+
+        cacheService = new MultiTypeCacheServiceImpl();
+
+        // Set up schema service
+        schemaService = new SchemaServiceImpl();
+        schemaService.setPersistenceService(persistenceService);
+        schemaService.setTenantService(tenantService);
+        schemaService.setContextManager(contextManager);
+        schemaService.setTracerService(tracerService);
+        schemaService.setSchedulerService(schedulerService);
+        schemaService.setBundleContext(bundleContext);
+        schemaService.setCacheService(cacheService);
+        schemaService.postConstruct();
+    }
+
+    @Test
+    public void testPredefinedSchemas() {
+        // The schema listener in setup should have already loaded the predefined schemas
+        schemaService.refreshJSONSchemas();
+
+        // Test from system context
+        contextManager.executeAsSystem(() -> {
+            JsonSchemaWrapper result = schemaService.getSchema("https://unomi.apache.org/schemas/json/events/test");
+
+            // Verify predefined schema exists
+            assertNotNull(result);
+            assertEquals(SYSTEM_TENANT, result.getTenantId());
+            assertEquals("test", result.getName());
+            assertEquals("events", result.getTarget());
+
+            // Also verify schema can be found through target lookup
+            List<JsonSchemaWrapper> eventSchemas = schemaService.getSchemasByTarget("events");
+            assertFalse("Should have at least one event schema", eventSchemas.isEmpty());
+            boolean foundTestSchema = eventSchemas.stream()
+                    .anyMatch(schema -> "test".equals(schema.getName()) &&
+                              "https://unomi.apache.org/schemas/json/events/test".equals(schema.getItemId()));
+            assertTrue("Predefined test schema should be found in events target", foundTestSchema);
+            return null;
+        });
+
+        // Test access from another tenant
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            JsonSchemaWrapper result = schemaService.getSchema("https://unomi.apache.org/schemas/json/events/test");
+
+            // Non-system tenant should still have access to system schemas
+            assertNotNull("Tenant should see predefined schemas", result);
+            assertEquals("Predefined schema should be from system tenant", SYSTEM_TENANT, result.getTenantId());
+            assertEquals("test", result.getName());
+            return null;
+        });
+    }
+
+    @Test
+    public void testSchemaInheritance_CurrentTenant() {
+        // Setup - Create a schema in tenant1
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                String schema = loadFromResource("/META-INF/cxs/schemas/tenant-specific-schema.json");
+                schemaService.saveSchema(schema);
+
+                // Test - Get from same tenant
+                schemaService.refreshJSONSchemas();
+                JsonSchemaWrapper result = schemaService.getSchema("https://unomi.apache.org/schemas/json/tenant-specific-schema");
+
+                // Verify - Should get tenant schema
+                assertNotNull("Should find schema in current tenant", result);
+                assertEquals("Schema should be from tenant1", TENANT_1, result.getTenantId());
+                assertEquals("tenant-test", result.getName());
+
+                // Create another tenant to test isolation
+                contextManager.executeAsSystem(() -> {
+                    tenantService.createTenant("tenant-test-isolation", Collections.singletonMap("description", "Isolation Test Tenant"));
+                    return null;
+                });
+
+                // Switch to the other tenant and verify tenant isolation
+                contextManager.executeAsTenant("tenant-test-isolation", () -> {
+                    // This should NOT find the tenant1 schema - schemas aren't shared between tenants
+                    JsonSchemaWrapper isolatedResult = schemaService.getSchema("https://unomi.apache.org/schemas/json/tenant-specific-schema");
+                    assertNull("Other tenant should not see tenant1 schema", isolatedResult);
+                    return null;
+                });
+
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void testSchemaInheritance_SystemTenant() throws IOException {
+        // Setup
+        contextManager.executeAsSystem(() -> {
+            try {
+                String systemSchema = loadFromResource("/META-INF/cxs/schemas/system-inheritance-schema.json");
+                schemaService.saveSchema(systemSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Switch to tenant1 and test
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            schemaService.refreshJSONSchemas();
+
+            // Test
+            JsonSchemaWrapper result = schemaService.getSchema("https://unomi.apache.org/schemas/json/test/system-inheritance-schema");
+
+            // Verify
+            assertNotNull(result);
+            assertEquals(SYSTEM_TENANT, result.getTenantId());
+            assertEquals("test", result.getName());
+            return null;
+        });
+    }
+
+    @Test
+    public void testSchemaInheritance_TenantOverride() {
+        // Setup system schema
+        contextManager.executeAsSystem(() -> {
+            try {
+                String systemSchema = loadFromResource("/META-INF/cxs/schemas/system-override-schema.json");
+                schemaService.saveSchema(systemSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Setup tenant schema and test
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                String tenantSchema = loadFromResource("/META-INF/cxs/schemas/tenant-override-schema.json");
+                schemaService.saveSchema(tenantSchema);
+
+                // Test
+                schemaService.refreshJSONSchemas();
+                JsonSchemaWrapper result = schemaService.getSchema("https://unomi.apache.org/schemas/json/test/override-schema");
+
+                // Verify
+                assertNotNull(result);
+                assertEquals(TENANT_1, result.getTenantId());
+                assertEquals("tenant-version", result.getName());
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void testSchemaInheritance_MergeResults() throws IOException {
+        // Setup system schemas
+        contextManager.executeAsSystem(() -> {
+            try {
+                String systemOnlySchema = loadFromResource("/META-INF/cxs/schemas/merge-system-only.json");
+                schemaService.saveSchema(systemOnlySchema);
+
+                String systemOverrideSchema = loadFromResource("/META-INF/cxs/schemas/merge-shared-schema-system.json");
+                schemaService.saveSchema(systemOverrideSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas to load system schemas
+        schemaService.refreshJSONSchemas();
+
+        // Add tenant schemas in a separate step
+        try {
+            // Execute in tenant context
+            contextManager.executeAsTenant(TENANT_1, () -> {
+                try {
+                    String tenantOnlySchema = loadFromResource("/META-INF/cxs/schemas/merge-tenant-only.json");
+                    schemaService.saveSchema(tenantOnlySchema);
+
+                    String tenantOverrideSchema = loadFromResource("/META-INF/cxs/schemas/merge-shared-schema-tenant.json");
+                    schemaService.saveSchema(tenantOverrideSchema);
+                    return null;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            // Refresh schemas again to load tenant schemas
+            schemaService.refreshJSONSchemas();
+
+            // Test - still in tenant context
+            contextManager.executeAsTenant(TENANT_1, () -> {
+                Set<String> allSchemaIds = schemaService.getInstalledJsonSchemaIds();
+
+                // Verify
+                assertNotNull(allSchemaIds);
+                Map<String, JsonSchemaWrapper> schemaMap = new HashMap<>();
+                for (String schemaId : allSchemaIds) {
+                    JsonSchemaWrapper schema = schemaService.getSchema(schemaId);
+                    schemaMap.put(schema.getItemId(), schema);
+                }
+
+                // Verify system-only schema
+                JsonSchemaWrapper systemOnly = schemaMap.get("https://unomi.apache.org/schemas/json/test/system-only");
+                assertNotNull(systemOnly);
+                assertEquals(SYSTEM_TENANT, systemOnly.getTenantId());
+                assertEquals("system-only", systemOnly.getName());
+
+                // Verify tenant-only schema
+                JsonSchemaWrapper tenantOnly = schemaMap.get("https://unomi.apache.org/schemas/json/test/tenant-only");
+                assertNotNull(tenantOnly);
+                assertEquals(TENANT_1, tenantOnly.getTenantId());
+                assertEquals("tenant-only", tenantOnly.getName());
+
+                // Verify overridden schema
+                JsonSchemaWrapper overridden = schemaMap.get("https://unomi.apache.org/schemas/json/test/shared-schema");
+                assertNotNull(overridden);
+                assertEquals(TENANT_1, overridden.getTenantId());
+                assertEquals("tenant-version", overridden.getName());
+                return null;
+            });
+        } catch (Exception e) {
+            throw new RuntimeException("Error testing schema inheritance", e);
+        }
+    }
+
+    @Test
+    public void testSchemaValidation_SystemTenant() throws IOException {
+        // Setup system schema
+        contextManager.executeAsSystem(() -> {
+            try {
+                String schema = loadFromResource("/META-INF/cxs/schemas/validation-schema.json");
+                schemaService.saveSchema(schema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Test from tenant context
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            schemaService.refreshJSONSchemas();
+            JsonSchemaWrapper result = schemaService.getSchema("https://unomi.apache.org/schemas/json/test/test-validation");
+
+            // Verify schema validation works
+            assertNotNull(result);
+            assertEquals(SYSTEM_TENANT, result.getTenantId());
+            assertTrue(result.getSchema().contains("\"required\": [\"name\"]"));
+            return null;
+        });
+    }
+
+    @Test
+    public void testSchemaByTarget_SystemTenant() throws IOException {
+        // Setup system schema with target
+        contextManager.executeAsSystem(() -> {
+            try {
+                String systemSchema = loadFromResource("/META-INF/cxs/schemas/test-scope-schema.json");
+                schemaService.saveSchema(systemSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Test from tenant context
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            schemaService.refreshJSONSchemas();
+            List<JsonSchemaWrapper> scopedSchemas = schemaService.getSchemasByTarget("test-scope");
+
+            // Verify
+            assertNotNull(scopedSchemas);
+            assertFalse(scopedSchemas.isEmpty());
+            JsonSchemaWrapper result = scopedSchemas.get(0);
+            assertEquals(SYSTEM_TENANT, result.getTenantId());
+            assertEquals("system", result.getName());
+            return null;
+        });
+    }
+
+    @Test
+    public void testTenantSpecificSchema_Validation() throws IOException {
+        String schemaId = "https://unomi.apache.org/schemas/json/test/dual-tenant-schema-tenant1";
+        String systemSchemaId = "https://unomi.apache.org/schemas/json/test/dual-tenant-schema-system";
+
+        // Tenant 1 schema - requires a "name" field
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                String tenant1Schema = loadFromResource("/META-INF/cxs/schemas/tenant1-schema.json");
+                schemaService.saveSchema(tenant1Schema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // System tenant schema - requires an "id" field (different validation rules)
+        contextManager.executeAsSystem(() -> {
+            try {
+                String systemSchema = loadFromResource("/META-INF/cxs/schemas/system-schema.json");
+                schemaService.saveSchema(systemSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas to load both
+        schemaService.refreshJSONSchemas();
+
+        // Test validation with Tenant 1
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            // Data with name (valid for tenant1) but no id (invalid for system)
+            String validForTenant1 = "{ \"name\": \"testName\" }";
+            // Data with id (valid for system) but no name (invalid for tenant1)
+            String validForSystem = "{ \"id\": \"testId\" }";
+
+            // Should validate against tenant1's schema (requiring name)
+            assertTrue(schemaService.isValid(validForTenant1, schemaId));
+            assertFalse(schemaService.isValid(validForSystem, schemaId));
+            return null;
+        });
+
+        // Test validation with System tenant
+        contextManager.executeAsSystem(() -> {
+            // Data with name (valid for tenant1) but no id (invalid for system)
+            String validForTenant1 = "{ \"name\": \"testName\" }";
+            // Data with id (valid for system) but no name (invalid for tenant1)
+            String validForSystem = "{ \"id\": \"testId\" }";
+
+            // Should validate against system's schema (requiring id)
+            assertFalse(schemaService.isValid(validForTenant1, systemSchemaId));
+            assertTrue(schemaService.isValid(validForSystem, systemSchemaId));
+            return null;
+        });
+    }
+
+    @Test
+    public void testTenantSpecificSchema_CrossTenantValidation() throws IOException {
+        String eventName = "test_event";
+
+        // System tenant schema - requires "systemField"
+        contextManager.executeAsSystem(() -> {
+            try {
+                String systemSchema = loadFromResource("/META-INF/cxs/schemas/system-event-schema.json");
+                schemaService.saveSchema(systemSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Tenant 1 schema - requires "tenantField"
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                String tenantSchema = loadFromResource("/META-INF/cxs/schemas/tenant-event-schema.json");
+                schemaService.saveSchema(tenantSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas
+        schemaService.refreshJSONSchemas();
+
+        // Test validation of events in each tenant
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            // Event valid for tenant 1, invalid for system
+            String event1 = "{ \"eventType\": \"" + eventName + "\", \"tenantField\": \"value\" }";
+            // Event valid for system, invalid for tenant 1
+            String event2 = "{ \"eventType\": \"" + eventName + "\", \"systemField\": \"value\" }";
+
+            // Should validate against tenant1's schema
+            assertTrue(schemaService.isEventValid(event1));
+            assertFalse(schemaService.isEventValid(event2));
+            return null;
+        });
+
+        contextManager.executeAsSystem(() -> {
+            // Event valid for tenant 1, invalid for system
+            String event1 = "{ \"eventType\": \"" + eventName + "\", \"tenantField\": \"value\" }";
+            // Event valid for system, invalid for tenant 1
+            String event2 = "{ \"eventType\": \"" + eventName + "\", \"systemField\": \"value\" }";
+
+            // Should validate against system's schema
+            assertFalse(schemaService.isEventValid(event1));
+            assertTrue(schemaService.isEventValid(event2));
+            return null;
+        });
+    }
+
+    @Test
+    public void testDynamicSchemaUpdates() throws IOException {
+        String schemaId = "https://unomi.apache.org/schemas/json/test/dynamic-schema";
+
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                String initialSchema = loadFromResource("/META-INF/cxs/schemas/initial-schema.json");
+                schemaService.saveSchema(initialSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas
+        schemaService.refreshJSONSchemas();
+
+        // Test initial validation
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            String validInitial = "{ \"initialField\": \"value\" }";
+            String invalidInitial = "{ \"updatedField\": \"value\" }";
+
+            assertTrue(schemaService.isValid(validInitial, schemaId));
+            assertFalse(schemaService.isValid(invalidInitial, schemaId));
+            return null;
+        });
+
+        // Update schema in tenant 1
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                String updatedSchema = loadFromResource("/META-INF/cxs/schemas/updated-schema.json");
+                schemaService.saveSchema(updatedSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas to pick up changes
+        schemaService.refreshJSONSchemas();
+
+        // Test validation with updated schema
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            String validInitial = "{ \"initialField\": \"value\" }";
+            String validUpdated = "{ \"updatedField\": \"value\" }";
+
+            // Now the requirements have changed
+            assertFalse(schemaService.isValid(validInitial, schemaId));
+            assertTrue(schemaService.isValid(validUpdated, schemaId));
+            return null;
+        });
+    }
+
+    @Test
+    public void testGetSchemaForEventType_TenantIsolation() throws IOException, ValidationException {
+        String eventName = "test_event";
+
+        // Create two event schemas with the same name but different validation rules in different tenants
+
+        // System tenant schema
+        contextManager.executeAsSystem(() -> {
+            try {
+                String systemSchema = loadFromResource("/META-INF/cxs/schemas/system-event-schema.json");
+                schemaService.saveSchema(systemSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Tenant 1 schema
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                String tenantSchema = loadFromResource("/META-INF/cxs/schemas/tenant-event-schema.json");
+                schemaService.saveSchema(tenantSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas to load both
+        schemaService.refreshJSONSchemas();
+
+        // 1. Test from Tenant 1 context - should get tenant-specific schema
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                JsonSchemaWrapper schema = schemaService.getSchemaForEventType(eventName);
+                assertNotNull(schema);
+                assertEquals(TENANT_1, schema.getTenantId());
+                assertEquals("https://unomi.apache.org/schemas/json/events/tenant-event-schema", schema.getItemId());
+                return null;
+            } catch (ValidationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // 2. Test from System tenant context - should get system schema
+        contextManager.executeAsSystem(() -> {
+            try {
+                JsonSchemaWrapper schema = schemaService.getSchemaForEventType(eventName);
+                assertNotNull(schema);
+                assertEquals(SYSTEM_TENANT, schema.getTenantId());
+                assertEquals("https://unomi.apache.org/schemas/json/events/system-event-schema", schema.getItemId());
+                return null;
+            } catch (ValidationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // 3. Create another tenant without this schema and verify it falls back to system tenant
+        final String TENANT_2 = "tenant2";
+        contextManager.executeAsSystem(() -> {
+            tenantService.createTenant(TENANT_2, Collections.singletonMap("description", "Tenant 2"));
+            return null;
+        });
+
+        contextManager.executeAsTenant(TENANT_2, () -> {
+            try {
+                JsonSchemaWrapper schema = schemaService.getSchemaForEventType(eventName);
+                assertNotNull(schema);
+                assertEquals(SYSTEM_TENANT, schema.getTenantId());
+                assertEquals("https://unomi.apache.org/schemas/json/events/system-event-schema", schema.getItemId());
+                return null;
+            } catch (ValidationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // 4. Test with non-existent event type - should throw exception
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                schemaService.getSchemaForEventType("non-existent-event");
+                fail("Should have thrown ValidationException for non-existent event type");
+                return null;
+            } catch (ValidationException e) {
+                // Expected behavior
+                assertTrue(e.getMessage().contains("Schema not found for event type"));
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void testGetSchemasByTarget_TenantIsolation() throws IOException {
+        String targetName = "test-target";
+
+        // System tenant schemas with the target
+        contextManager.executeAsSystem(() -> {
+            try {
+                String systemSchema1 = loadFromResource("/META-INF/cxs/schemas/target-schema1.json");
+                String systemSchema2 = loadFromResource("/META-INF/cxs/schemas/target-schema2.json");
+                schemaService.saveSchema(systemSchema1);
+                schemaService.saveSchema(systemSchema2);
+
+                // Create a schema with different target (should not be returned)
+                String differentTargetSchema = loadFromResource("/META-INF/cxs/schemas/target-schema5.json");
+                schemaService.saveSchema(differentTargetSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Tenant 1 schemas with the target
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                String tenantSchema1 = loadFromResource("/META-INF/cxs/schemas/target-schema3.json");
+                String tenantSchema2 = loadFromResource("/META-INF/cxs/schemas/target-schema4.json");
+                schemaService.saveSchema(tenantSchema1);
+                schemaService.saveSchema(tenantSchema2);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Create another tenant with schemas with the same target
+        final String TENANT_2 = "tenant2";
+        contextManager.executeAsSystem(() -> {
+            tenantService.createTenant(TENANT_2, Collections.singletonMap("description", "Tenant 2"));
+            return null;
+        });
+
+        contextManager.executeAsTenant(TENANT_2, () -> {
+            try {
+                String tenant2Schema = loadFromResource("/META-INF/cxs/schemas/target-schema6.json");
+                schemaService.saveSchema(tenant2Schema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas
+        schemaService.refreshJSONSchemas();
+
+        // 1. Test from Tenant 1 context - should get tenant1 schemas + system schemas
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            List<JsonSchemaWrapper> schemas = schemaService.getSchemasByTarget(targetName);
+
+            // Should have 4 schemas: 2 from tenant1 + 2 from system
+            assertEquals(4, schemas.size());
+
+            // Count schemas by tenant
+            long tenant1Count = schemas.stream()
+                    .filter(schema -> TENANT_1.equals(schema.getTenantId()))
+                    .count();
+            long systemCount = schemas.stream()
+                    .filter(schema -> SYSTEM_TENANT.equals(schema.getTenantId()))
+                    .count();
+            long tenant2Count = schemas.stream()
+                    .filter(schema -> TENANT_2.equals(schema.getTenantId()))
+                    .count();
+
+            assertEquals(2, tenant1Count);
+            assertEquals(2, systemCount);
+            assertEquals(0, tenant2Count); // Should not have any schemas from tenant2
+            return null;
+        });
+
+        // 2. Test from System tenant context - should get only system schemas
+        contextManager.executeAsSystem(() -> {
+            List<JsonSchemaWrapper> schemas = schemaService.getSchemasByTarget(targetName);
+
+            // Should have only 2 schemas from system tenant
+            assertEquals(2, schemas.size());
+
+            // All schemas should be from system tenant
+            for (JsonSchemaWrapper schema : schemas) {
+                assertEquals(SYSTEM_TENANT, schema.getTenantId());
+            }
+            return null;
+        });
+
+        // 3. Test from Tenant 2 context - should get tenant2 schemas + system schemas
+        contextManager.executeAsTenant(TENANT_2, () -> {
+            List<JsonSchemaWrapper> schemas = schemaService.getSchemasByTarget(targetName);
+
+            // Should have 3 schemas: 1 from tenant2 + 2 from system
+            assertEquals(3, schemas.size());
+
+            // Count schemas by tenant
+            long tenant1Count = schemas.stream()
+                    .filter(schema -> TENANT_1.equals(schema.getTenantId()))
+                    .count();
+            long systemCount = schemas.stream()
+                    .filter(schema -> SYSTEM_TENANT.equals(schema.getTenantId()))
+                    .count();
+            long tenant2Count = schemas.stream()
+                    .filter(schema -> TENANT_2.equals(schema.getTenantId()))
+                    .count();
+
+            assertEquals(0, tenant1Count); // Should not have any schemas from tenant1
+            assertEquals(2, systemCount);
+            assertEquals(1, tenant2Count);
+            return null;
+        });
+
+        // 4. Test with non-existent target - should return empty list
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            List<JsonSchemaWrapper> schemas = schemaService.getSchemasByTarget("non-existent-target");
+            assertNotNull(schemas);
+            assertTrue(schemas.isEmpty());
+            return null;
+        });
+    }
+
+    @Test
+    public void testSchemaExtension_MergingMechanism() throws IOException, ValidationException {
+        // Create a base view event schema in system tenant (similar to the doc example)
+        String baseSchemaId = "https://unomi.apache.org/schemas/json/events/view/properties/1-0-0";
+        String extension1Id = "https://vendor.test.com/schemas/json/events/dummy/extension/1-0-0";
+        String extension2Id = "https://apache.org/schemas/json/events/system/extension/1-0-0";
+
+        // 1. Create base view event schema in system tenant
+        contextManager.executeAsSystem(() -> {
+            try {
+                // Load base schema
+                String baseSchema1 = loadFromResource("/META-INF/cxs/schemas/view-event-schema.json");
+                schemaService.saveSchema(baseSchema1);
+
+                // Load system tenant extension
+                String systemExtSchema = loadFromResource("/META-INF/cxs/schemas/system-extension.json");
+                schemaService.saveSchema(systemExtSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // 2. Create tenant extension
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                // Load tenant extension schema
+                String tenant1ExtSchema = loadFromResource("/META-INF/cxs/schemas/tenant1-extension.json");
+                schemaService.saveSchema(tenant1ExtSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas to load all schemas
+        schemaService.refreshJSONSchemas();
+
+        // 3. Test the dynamic merging functionality during validation
+
+        // From Tenant 1 Context - should apply both tenant and system extensions
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                // Test data validation with extensions
+
+                // Data with only base schema properties - should fail (missing required properties from extensions)
+                String baseOnlyData = "{ \"source\": \"web\", \"url\": \"https://example.org\" }";
+
+                // Data with all required properties - should pass validation
+                String fullData = "{ \"source\": \"web\", \"url\": \"https://example.org\", \"myNewProp\": \"value\", \"systemProp\": \"value\" }";
+
+                // Validate directly using the schema - this should trigger dynamic merging
+                boolean baseOnlyValid = schemaService.isValid(baseOnlyData, baseSchemaId);
+                boolean fullDataValid = schemaService.isValid(fullData, baseSchemaId);
+
+                assertFalse("Data with only base properties should fail validation", baseOnlyValid);
+                assertTrue("Data with all extension properties should pass validation", fullDataValid);
+
+                // Validate directly against the extensions to ensure they're applied separately
+                boolean missingTenantProp = schemaService.isValid(
+                    "{ \"source\": \"web\", \"url\": \"https://example.org\", \"systemProp\": \"value\" }",
+                    baseSchemaId);
+                boolean missingSystemProp = schemaService.isValid(
+                    "{ \"source\": \"web\", \"url\": \"https://example.org\", \"myNewProp\": \"value\" }",
+                    baseSchemaId);
+
+                assertFalse("Should fail without tenant extension property", missingTenantProp);
+                assertFalse("Should fail without system extension property", missingSystemProp);
+
+                return null;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // From System Context - should only apply system extension
+        contextManager.executeAsSystem(() -> {
+            try {
+                // Data with only base schema properties - should fail (missing system extension property)
+                String baseOnlyData = "{ \"source\": \"web\", \"url\": \"https://example.org\" }";
+
+                // Data with base + system extension properties - should pass
+                String withSystemData = "{ \"source\": \"web\", \"url\": \"https://example.org\", \"systemProp\": \"value\" }";
+
+                // Data with tenant extension property - should be ignored in system context
+                String withTenantData = "{ \"source\": \"web\", \"url\": \"https://example.org\", \"systemProp\": \"value\", \"myNewProp\": \"value\" }";
+
+                // Validate directly using the schema - this should trigger dynamic merging
+                boolean baseOnlyValid = schemaService.isValid(baseOnlyData, baseSchemaId);
+                boolean withSystemValid = schemaService.isValid(withSystemData, baseSchemaId);
+                boolean withTenantValid = schemaService.isValid(withTenantData, baseSchemaId);
+
+                assertFalse("Data with only base properties should fail validation", baseOnlyValid);
+                assertTrue("Data with system properties should pass validation", withSystemValid);
+                assertTrue("Data with tenant property should pass validation in system context", withTenantValid);
+
+                return null;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // 4. Test from a fresh tenant that doesn't have its own extensions
+        final String TENANT_2 = "tenant2";
+        contextManager.executeAsSystem(() -> {
+            tenantService.createTenant(TENANT_2, Collections.singletonMap("description", "Tenant 2"));
+            return null;
+        });
+
+        // New tenant should inherit system extensions but not tenant1 extensions
+        contextManager.executeAsTenant(TENANT_2, () -> {
+            try {
+                // Data with only base schema properties - should fail (missing system extension property)
+                String baseOnlyData = "{ \"source\": \"web\", \"url\": \"https://example.org\" }";
+
+                // Data with base + system extension properties - should pass
+                String withSystemData = "{ \"source\": \"web\", \"url\": \"https://example.org\", \"systemProp\": \"value\" }";
+
+                // Data with tenant1 extension property - should be ignored (not tenant2's extension)
+                String withTenantData = "{ \"source\": \"web\", \"url\": \"https://example.org\", \"systemProp\": \"value\", \"myNewProp\": \"value\" }";
+
+                // Validate directly using the schema - this should trigger dynamic merging
+                boolean baseOnlyValid = schemaService.isValid(baseOnlyData, baseSchemaId);
+                boolean withSystemValid = schemaService.isValid(withSystemData, baseSchemaId);
+                boolean withTenantValid = schemaService.isValid(withTenantData, baseSchemaId);
+
+                assertFalse("Data with only base properties should fail validation", baseOnlyValid);
+                assertTrue("Data with system properties should pass validation", withSystemValid);
+                assertTrue("Data with other tenant's property should pass validation (ignored)", withTenantValid);
+
+                return null;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // 5. Verify we can add a tenant-specific extension to tenant2 and it will be applied
+        contextManager.executeAsTenant(TENANT_2, () -> {
+            try {
+                // Load tenant2 extension schema from file
+                String tenant2ExtSchema = loadFromResource("/META-INF/cxs/schemas/tenant2-extension.json");
+                schemaService.saveSchema(tenant2ExtSchema);
+
+                // Refresh schemas
+                schemaService.refreshJSONSchemas();
+
+                // Now tenant2 should require tenant2Prop in addition to systemProp
+
+                // Data with just system property - should now fail (missing tenant2 property)
+                String withSystemOnly = "{ \"source\": \"web\", \"url\": \"https://example.org\", \"systemProp\": \"value\" }";
+
+                // Data with system + tenant2 properties - should pass
+                String withTenant2Prop = "{ \"source\": \"web\", \"url\": \"https://example.org\", \"systemProp\": \"value\", \"tenant2Prop\": \"value\" }";
+
+                boolean systemOnlyValid = schemaService.isValid(withSystemOnly, baseSchemaId);
+                boolean withTenant2Valid = schemaService.isValid(withTenant2Prop, baseSchemaId);
+
+                assertFalse("Should now fail without tenant2 extension property", systemOnlyValid);
+                assertTrue("Should pass with tenant2 extension property", withTenant2Valid);
+
+                return null;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void testGetSchema_TenantIsolation() {
+        // Create schemas with the same ID in different tenants to test proper isolation
+        String schemaId = "https://unomi.apache.org/schemas/json/test/shared-id-schema";
+
+        // Create system tenant schema
+        contextManager.executeAsSystem(() -> {
+            try {
+                String systemSchema = loadFromResource("/META-INF/cxs/schemas/schema1.json");
+                schemaService.saveSchema(systemSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Create tenant1 schema with same ID
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                String tenantSchema = loadFromResource("/META-INF/cxs/schemas/schema2.json");
+                schemaService.saveSchema(tenantSchema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Create tenant2 without this schema
+        final String TENANT_2 = "tenant2-getschema-test";
+        contextManager.executeAsSystem(() -> {
+            tenantService.createTenant(TENANT_2, Collections.singletonMap("description", "Tenant 2"));
+            return null;
+        });
+
+        // Refresh schemas
+        schemaService.refreshJSONSchemas();
+
+        // 1. Test from System context - should get system schema
+        contextManager.executeAsSystem(() -> {
+            JsonSchemaWrapper result = schemaService.getSchema(schemaId);
+            assertNotNull("System should find the schema", result);
+            assertEquals("System should get its own schema", SYSTEM_TENANT, result.getTenantId());
+            assertEquals("system-version", result.getName());
+            return null;
+        });
+
+        // 2. Test from Tenant1 context - should get tenant schema (overriding system)
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            JsonSchemaWrapper result = schemaService.getSchema(schemaId);
+            assertNotNull("Tenant1 should find the schema", result);
+            assertEquals("Tenant1 should get its own schema", TENANT_1, result.getTenantId());
+            assertEquals("tenant1-version", result.getName());
+            return null;
+        });
+
+        // 3. Test from Tenant2 context - should get system schema (fallback)
+        contextManager.executeAsTenant(TENANT_2, () -> {
+            JsonSchemaWrapper result = schemaService.getSchema(schemaId);
+            assertNotNull("Tenant2 should find the schema", result);
+            assertEquals("Tenant2 should get system schema", SYSTEM_TENANT, result.getTenantId());
+            assertEquals("system-version", result.getName());
+            return null;
+        });
+
+        // 4. Test non-existent schema
+        String nonExistentId = "https://unomi.apache.org/schemas/json/non-existent";
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            JsonSchemaWrapper result = schemaService.getSchema(nonExistentId);
+            assertNull("Should not find non-existent schema", result);
+            return null;
+        });
+    }
+
+    @Test
+    public void testDeleteSchema() throws IOException {
+        // Create a schema in the system tenant
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                String schema = loadFromResource("/META-INF/cxs/schemas/tenant1-schema.json");
+                schemaService.saveSchema(schema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas to load the new schema
+        schemaService.refreshJSONSchemas();
+
+        // 1. Verify schema exists before deletion
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            String schemaId = "https://unomi.apache.org/schemas/json/test/dual-tenant-schema-tenant1";
+            JsonSchemaWrapper schema = schemaService.getSchema(schemaId);
+            assertNotNull("Schema should exist before deletion", schema);
+            assertEquals("Schema ID should match", schemaId, schema.getItemId());
+            assertEquals("Schema should be from tenant1 tenant", TENANT_1, schema.getTenantId());
+
+            // 2. Delete the schema
+            boolean deleted = schemaService.deleteSchema(schemaId);
+            assertTrue("Schema deletion should succeed", deleted);
+
+            // 3. Verify schema no longer exists after deletion
+            JsonSchemaWrapper deletedSchema = schemaService.getSchema(schemaId);
+            assertNull("Schema should not exist after deletion", deletedSchema);
+
+            return null;
+        });
+
+        // 5. Test tenant isolation for delete operation
+        String tenantSchemaId = "https://unomi.apache.org/schemas/json/tenant-specific-schema";
+
+        // Create a tenant-specific schema
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                String schema = loadFromResource("/META-INF/cxs/schemas/tenant-specific-schema.json");
+                schemaService.saveSchema(schema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas
+        schemaService.refreshJSONSchemas();
+
+        // Try to delete tenant schema from system context - should fail
+        contextManager.executeAsSystem(() -> {
+            JsonSchemaWrapper tenantSchema = schemaService.getSchema(tenantSchemaId);
+            assertNull("System tenant should not see tenant-specific schema", tenantSchema);
+
+            schemaService.deleteSchema(tenantSchemaId);
+            return null;
+        });
+
+        // Verify tenant schema still exists from tenant context
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            JsonSchemaWrapper tenantSchema = schemaService.getSchema(tenantSchemaId);
+            assertNotNull("Tenant schema should still exist", tenantSchema);
+            assertEquals("Tenant schema should be from tenant1", TENANT_1, tenantSchema.getTenantId());
+            return null;
+        });
+    }
+
+    @Test
+    public void testIsEventValid_AutoDetect() throws IOException {
+        // Setup - create an event schema in the system tenant
+        contextManager.executeAsSystem(() -> {
+            try {
+                String schema = loadFromResource("/META-INF/cxs/schemas/autodetect-system-event-schema.json");
+                schemaService.saveSchema(schema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas to load the new schema
+        schemaService.refreshJSONSchemas();
+
+        // Test the isEventValid method that auto-detects event type
+        contextManager.executeAsSystem(() -> {
+            // Valid event with eventType field
+            String validEvent = "{ \"eventType\": \"system\", \"scope\": \"test\", \"properties\": { \"systemProperty\": \"value\" } }";
+            boolean isValid = schemaService.isEventValid(validEvent);
+            assertTrue("Valid event should pass validation", isValid);
+
+            // Invalid event missing required property
+            String invalidEvent = "{ \"eventType\": \"system\", \"scope\": \"test\", \"properties\": {} }";
+            boolean isInvalid = schemaService.isEventValid(invalidEvent);
+            assertFalse("Event missing required property should fail validation", isInvalid);
+
+            // Event with unknown eventType
+            String unknownTypeEvent = "{ \"eventType\": \"unknown\", \"scope\": \"test\" }";
+            boolean isUnknownValid = schemaService.isEventValid(unknownTypeEvent);
+            assertFalse("Event with unknown type should fail validation", isUnknownValid);
+
+            // Malformed JSON
+            String malformedEvent = "{ \"eventType\": \"system\", \"scope\": \"test\", \"properties\": { \"missing\": ";
+            boolean isMalformedValid = schemaService.isEventValid(malformedEvent);
+            assertFalse("Malformed JSON should fail validation", isMalformedValid);
+
+            // Missing eventType field
+            String missingTypeEvent = "{ \"scope\": \"test\", \"properties\": { \"systemProperty\": \"value\" } }";
+            boolean isMissingTypeValid = schemaService.isEventValid(missingTypeEvent);
+            assertFalse("Event missing eventType field should fail validation", isMissingTypeValid);
+
+            return null;
+        });
+
+        // Test tenant isolation - create tenant-specific event schema
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            try {
+                String schema = loadFromResource("/META-INF/cxs/schemas/autodetect-tenant-event-schema.json");
+                schemaService.saveSchema(schema);
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas
+        schemaService.refreshJSONSchemas();
+
+        // Test from tenant context
+        contextManager.executeAsTenant(TENANT_1, () -> {
+            // Valid event for tenant schema
+            String validTenantEvent = "{ \"eventType\": \"tenant\", \"scope\": \"test\", \"properties\": { \"tenantProperty\": \"value\" } }";
+            boolean isValid = schemaService.isEventValid(validTenantEvent);
+            assertTrue("Valid tenant event should pass validation", isValid);
+
+            // System event should also be visible from tenant context
+            String validSystemEvent = "{ \"eventType\": \"system\", \"scope\": \"test\", \"properties\": { \"systemProperty\": \"value\" } }";
+            boolean isSystemValid = schemaService.isEventValid(validSystemEvent);
+            assertTrue("System event should pass validation from tenant context", isSystemValid);
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testValidateEvents_BatchValidation() throws IOException, ValidationException {
+        // Setup - create event schemas in the system tenant
+        contextManager.executeAsSystem(() -> {
+            try {
+                // System event schema
+                String systemSchema = loadFromResource("/META-INF/cxs/schemas/system-event-schema.json");
+                schemaService.saveSchema(systemSchema);
+
+                // Predefined test schema (from predefined-schemas.json)
+                // This is loaded during setup from the mocked bundle.findEntries
+
+                return null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Refresh schemas to load the new schemas
+        schemaService.refreshJSONSchemas();
+
+        // Test batch validation with multiple events
+        contextManager.executeAsSystem(() -> {
+            try {
+                // Prepare batch of events with different validation outcomes
+                String events = "["
+                    + "{ \"eventType\": \"test_event\", \"systemField\": \"test\" },"                                            // valid system event
+                    + "{ \"eventType\": \"test_event\" },"                                                                       // invalid system event (missing required property)
+                    + "{ \"eventType\": \"test\", \"scope\": \"scope\", \"properties\": {} },"                                   // valid test event
+                    + "{ \"eventType\": \"unknown\", \"scope\": \"test\" },"                                                     // unknown event type
+                    + "{ \"scope\": \"test\", \"properties\": { \"systemProperty\": \"value\" } }"                               // missing eventType
+                    + "]";
+
+                // Validate batch of events
+                Map<String, Set<ValidationError>> validationResults = schemaService.validateEvents(events);
+
+                // Assertions
+                assertNotNull("Validation results should not be null", validationResults);
+
+                // Check which event types have validation errors
+                // The map should contain errors for 'system' (invalid event) and 'unknown' (unknown type)
+                // And possibly 'error' for the event missing eventType field
+
+                // System events - should have errors because one event is invalid
+                assertTrue("Should have errors for system event type", validationResults.containsKey("test_event"));
+                assertFalse("System event type should have validation errors", validationResults.get("test_event").isEmpty());
+
+                // Test events - should not have errors (valid test event)
+                assertFalse("Should not have errors for test event type", validationResults.containsKey("test"));
+
+                // Unknown event type - should have errors
+                assertTrue("Should have errors for unknown event type",
+                    validationResults.containsKey("unknown") || validationResults.containsKey("error"));
+
+                // Missing eventType event - should produce an error (may be under 'error' key)
+                assertTrue("Should have generic error for missing eventType",
+                    validationResults.containsKey("error"));
+
+                return null;
+            } catch (ValidationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Test malformed JSON array
+        contextManager.executeAsSystem(() -> {
+            try {
+                // Not a valid JSON array
+                String invalidJson = "{ \"not\": \"an array\" }";
+
+                Map<String, Set<ValidationError>> validationResults = schemaService.validateEvents(invalidJson);
+
+                // Should return a generic error with key "error"
+                assertNotNull("Validation results should not be null", validationResults);
+                assertTrue("Should have generic error key", validationResults.containsKey("error"));
+                assertFalse("Error set should not be empty", validationResults.get("error").isEmpty());
+
+                return null;
+            } catch (ValidationException e) {
+                // This is expected for implementation that throws exceptions
+                // If the implementation returns error map instead, this catch block won't execute
+                assertNotNull("Exception should have a message", e.getMessage());
+                return null;
+            }
+        });
+
+        // Test with empty array
+        contextManager.executeAsSystem(() -> {
+            try {
+                String emptyArray = "[]";
+
+                Map<String, Set<ValidationError>> validationResults = schemaService.validateEvents(emptyArray);
+
+                // Should return empty map
+                assertNotNull("Validation results should not be null", validationResults);
+                assertTrue("Should have no validation results for empty array", validationResults.isEmpty());
+
+                return null;
+            } catch (ValidationException e) {
+                fail("Should not throw exception for empty array: " + e.getMessage());
+                return null;
+            }
+        });
+    }
+
+    private String loadFromResource(String resourcePath) throws IOException {
+        try (InputStream is = getClass().getResourceAsStream(resourcePath)) {
+            if (is == null) {
+                throw new IOException("Resource not found: " + resourcePath);
+            }
+            return IOUtils.toString(is, StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/autodetect-system-event-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/autodetect-system-event-schema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/events/autodetect-system-event-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "system",
+    "target": "events"
+  },
+  "type": "object",
+  "properties": {
+    "eventType": {
+      "type": "string"
+    },
+    "scope": {
+      "type": "string"
+    },
+    "properties" : {
+      "type" : "object",
+      "properties" : {
+        "systemProperty" : {
+          "type" : "string"
+        }
+      },
+      "required" : ["systemProperty"]
+    }
+  },
+  "required": ["eventType", "scope"]
+}

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/autodetect-tenant-event-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/autodetect-tenant-event-schema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/events/autodetect-tenant-event-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "tenant",
+    "target": "events"
+  },
+  "type": "object",
+  "properties": {
+    "eventType": {
+      "type": "string"
+    },
+    "scope": {
+      "type": "string"
+    },
+    "properties" : {
+      "type" : "object",
+      "properties" : {
+        "tenantProperty" : {
+          "type" : "string"
+        }
+      },
+      "required" : ["tenantProperty"]
+    }
+  },
+  "required": ["eventType", "scope"]
+}

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/initial-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/initial-schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/dynamic-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "dynamic",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "initialField": {
+      "type": "string"
+    }
+  },
+  "required": ["initialField"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/merge-shared-schema-system.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/merge-shared-schema-system.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/shared-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "system-version",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "sharedProp": {
+      "type": "string"
+    }
+  },
+  "required": ["sharedProp"]
+}

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/merge-shared-schema-tenant.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/merge-shared-schema-tenant.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/shared-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "tenant-version",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "tenantSharedProp": {
+      "type": "string"
+    }
+  },
+  "required": ["tenantSharedProp"]
+}

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/merge-system-only.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/merge-system-only.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/system-only",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "system-only",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "systemOnlyProp": {
+      "type": "string"
+    }
+  },
+  "required": ["systemOnlyProp"]
+}

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/merge-tenant-only.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/merge-tenant-only.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/tenant-only",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "tenant-only",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "tenantOnlyProp": {
+      "type": "string"
+    }
+  },
+  "required": ["tenantOnlyProp"]
+}

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/predefined-schemas.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/predefined-schemas.json
@@ -1,0 +1,23 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/events/test",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "test",
+    "target": "events"
+  },
+  "type": "object",
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "const": "test"
+    },
+    "scope": {
+      "type": "string"
+    },
+    "properties": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "required": ["eventType", "scope"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/schema1.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/schema1.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/shared-id-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "system-version",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "systemVersion": {
+      "type": "string"
+    }
+  },
+  "required": ["systemVersion"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/schema2.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/schema2.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/shared-id-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "tenant1-version",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "tenantVersion": {
+      "type": "string"
+    }
+  },
+  "required": ["tenantVersion"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/system-event-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/system-event-schema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/events/system-event-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "test_event",
+    "target": "events"
+  },
+  "type": "object",
+  "properties": {
+    "eventType": {
+      "type": "string"
+    },
+    "systemField": {
+      "type": "string"
+    }
+  },
+  "required": ["eventType", "systemField"]
+}

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/system-extension.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/system-extension.json
@@ -1,0 +1,19 @@
+{
+  "$id": "https://apache.org/schemas/json/events/system/extension/1-0-0",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "vendor": "org.apache.unomi",
+    "name": "systemExtension",
+    "format": "jsonschema",
+    "extends": "https://unomi.apache.org/schemas/json/events/view/properties/1-0-0",
+    "version": "1-0-0"
+  },
+  "title": "SystemEventExtension",
+  "type": "object",
+  "properties": {
+    "systemProp": {
+      "type": "string"
+    }
+  },
+  "required": ["systemProp"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/system-inheritance-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/system-inheritance-schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/system-inheritance-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "test",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "systemProperty": {
+      "type": "string"
+    }
+  },
+  "required": ["systemProperty"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/system-override-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/system-override-schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/override-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "system-version",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "systemProperty": {
+      "type": "string"
+    }
+  },
+  "required": ["systemProperty"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/system-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/system-schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/dual-tenant-schema-system",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "system-schema",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    }
+  },
+  "required": ["id"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/target-schema1.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/target-schema1.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/target/system-schema-1",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "system1",
+    "target": "test-target"
+  },
+  "type": "object",
+  "properties": {
+    "system1Property": {
+      "type": "string"
+    }
+  },
+  "required": ["system1Property"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/target-schema2.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/target-schema2.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/target/system-schema-2",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "system2",
+    "target": "test-target"
+  },
+  "type": "object",
+  "properties": {
+    "system2Property": {
+      "type": "string"
+    }
+  },
+  "required": ["system2Property"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/target-schema3.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/target-schema3.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/target/tenant-schema-1",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "tenant1",
+    "target": "test-target"
+  },
+  "type": "object",
+  "properties": {
+    "tenant1Property": {
+      "type": "string"
+    }
+  },
+  "required": ["tenant1Property"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/target-schema4.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/target-schema4.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/target/tenant-schema-2",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "tenant2",
+    "target": "test-target"
+  },
+  "type": "object",
+  "properties": {
+    "tenant2Property": {
+      "type": "string"
+    }
+  },
+  "required": ["tenant2Property"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/target-schema5.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/target-schema5.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/target/system-diff-target",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "system-other",
+    "target": "different-target"
+  },
+  "type": "object",
+  "properties": {
+    "differentProperty": {
+      "type": "string"
+    }
+  },
+  "required": ["differentProperty"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/target-schema6.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/target-schema6.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/target/tenant2-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "other-tenant",
+    "target": "test-target"
+  },
+  "type": "object",
+  "properties": {
+    "otherTenantProperty": {
+      "type": "string"
+    }
+  },
+  "required": ["otherTenantProperty"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/tenant-event-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/tenant-event-schema.json
@@ -1,0 +1,18 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/events/tenant-event-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "test_event",
+    "target": "events"
+  },
+  "type": "object",
+  "properties": {
+    "eventType": {
+      "type": "string"
+    },
+    "tenantField": {
+      "type": "string"
+    }
+  },
+  "required": ["eventType", "tenantField"]
+}

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/tenant-override-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/tenant-override-schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/override-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "tenant-version",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "tenantProperty": {
+      "type": "string"
+    }
+  },
+  "required": ["tenantProperty"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/tenant-specific-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/tenant-specific-schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/tenant-specific-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "tenant-test",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "tenantProperty": {
+      "type": "string"
+    }
+  },
+  "required": ["tenantProperty"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/tenant1-extension.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/tenant1-extension.json
@@ -1,0 +1,19 @@
+{
+  "$id": "https://vendor.test.com/schemas/json/events/dummy/extension/1-0-0",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "vendor": "com.vendor.test",
+    "name": "dummyExtension",
+    "format": "jsonschema",
+    "extends": "https://unomi.apache.org/schemas/json/events/view/properties/1-0-0",
+    "version": "1-0-0"
+  },
+  "title": "DummyEventExtension",
+  "type": "object",
+  "properties": {
+    "myNewProp": {
+      "type": "string"
+    }
+  },
+  "required": ["myNewProp"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/tenant1-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/tenant1-schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/dual-tenant-schema-tenant1",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "tenant1-schema",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": ["name"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/tenant2-extension.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/tenant2-extension.json
@@ -1,0 +1,19 @@
+{
+  "$id": "https://tenant2.test.com/schemas/json/events/tenant2/extension/1-0-0",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "vendor": "com.tenant2.test",
+    "name": "tenant2Extension",
+    "format": "jsonschema",
+    "extends": "https://unomi.apache.org/schemas/json/events/view/properties/1-0-0",
+    "version": "1-0-0"
+  },
+  "title": "Tenant2Extension",
+  "type": "object",
+  "properties": {
+    "tenant2Prop": {
+      "type": "string"
+    }
+  },
+  "required": ["tenant2Prop"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/test-scope-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/test-scope-schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/scoped-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "system",
+    "target": "test-scope"
+  },
+  "type": "object",
+  "properties": {
+    "scopedProperty": {
+      "type": "string"
+    }
+  },
+  "required": ["scopedProperty"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/updated-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/updated-schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/dynamic-schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "dynamic",
+    "target": "test"
+  },
+  "type": "object",
+  "properties": {
+    "updatedField": {
+      "type": "string"
+    }
+  },
+  "required": ["updatedField"]
+} 

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/validation-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/validation-schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/test/test-validation",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "name": "validation",
+    "target": "test"
+  },
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  }
+}

--- a/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/view-event-schema.json
+++ b/extensions/json-schema/services/src/test/resources/META-INF/cxs/schemas/view-event-schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://unomi.apache.org/schemas/json/events/view/properties/1-0-0",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "self": {
+    "vendor": "org.apache.unomi",
+    "name": "view",
+    "format": "jsonschema",
+    "target": "events",
+    "version": "1-0-0"
+  },
+  "title": "ViewEvent",
+  "type": "object",
+  "properties": {
+    "source": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    }
+  },
+  "required": ["source", "url"]
+} 

--- a/services/src/test/java/org/apache/unomi/services/TestHelper.java
+++ b/services/src/test/java/org/apache/unomi/services/TestHelper.java
@@ -352,10 +352,7 @@ public class TestHelper {
             schedulerService.setLockTimeout(lockTimeout); // Set a default lock timeout for tests
         }
 
-        // Set the persistence provider on the scheduler service (optional dependency)
-        if (persistenceSchedulerProvider != null) {
-            schedulerService.setPersistenceProvider(persistenceSchedulerProvider);
-        }
+        schedulerService.setPersistenceProvider(persistenceSchedulerProvider);
 
         // Set the schedulerService on all managers that need it
         taskLockManager.setSchedulerService(schedulerService);

--- a/services/src/test/java/org/apache/unomi/services/TestHelper.java
+++ b/services/src/test/java/org/apache/unomi/services/TestHelper.java
@@ -36,9 +36,15 @@ import org.apache.unomi.services.common.security.KarafSecurityService;
 import org.apache.unomi.services.impl.*;
 import org.apache.unomi.services.impl.cluster.ClusterServiceImpl;
 import org.apache.unomi.services.impl.definitions.DefinitionsServiceImpl;
+import org.apache.unomi.services.impl.events.EventServiceImpl;
+import org.apache.unomi.services.impl.rules.RulesServiceImpl;
+import org.apache.unomi.services.impl.rules.TestActionExecutorDispatcher;
 import org.apache.unomi.services.impl.scheduler.*;
 import org.apache.unomi.services.impl.validation.ConditionValidationServiceImpl;
 import org.apache.unomi.services.impl.validation.validators.*;
+import org.apache.unomi.tracing.api.RequestTracer;
+import org.apache.unomi.tracing.api.TraceNode;
+import org.apache.unomi.tracing.api.TracerService;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.event.EventAdmin;
@@ -113,12 +119,14 @@ public class TestHelper {
         EventAdmin eventAdmin
     ) {
         DefinitionsServiceImpl definitionsService = new DefinitionsServiceImpl();
+        TracerService tracerService = createTracerService();
         definitionsService.setPersistenceService(persistenceService);
         definitionsService.setBundleContext(bundleContext);
         definitionsService.setSchedulerService(schedulerService);
         definitionsService.setCacheService(multiTypeCacheService);
         definitionsService.setContextManager(executionContextManager);
         definitionsService.setTenantService(tenantService);
+        definitionsService.setTracerService(tracerService);
         definitionsService.setEventAdmin(eventAdmin);
 
         // Configure built-in validators for the ConditionValidationService created internally
@@ -167,6 +175,86 @@ public class TestHelper {
         return new AbstractMap.SimpleEntry<>(definitionsService, eventAdmin);
     }
 
+    public static RulesServiceImpl createRulesService(
+        PersistenceService persistenceService,
+        BundleContext bundleContext,
+        SchedulerService schedulerService,
+        DefinitionsServiceImpl definitionsService,
+        EventServiceImpl eventService,
+        ExecutionContextManager executionContextManager,
+        TenantService tenantService,
+        MultiTypeCacheService multiTypeCacheService,
+        TestActionExecutorDispatcher actionExecutorDispatcher
+    ) {
+        return createRulesService(persistenceService, bundleContext, schedulerService,
+            definitionsService, eventService, executionContextManager, tenantService,
+            multiTypeCacheService, actionExecutorDispatcher, null);
+    }
+
+    public static RulesServiceImpl createRulesService(
+        PersistenceService persistenceService,
+        BundleContext bundleContext,
+        SchedulerService schedulerService,
+        DefinitionsServiceImpl definitionsService,
+        EventServiceImpl eventService,
+        ExecutionContextManager executionContextManager,
+        TenantService tenantService,
+        MultiTypeCacheService multiTypeCacheService,
+        TestActionExecutorDispatcher actionExecutorDispatcher,
+        EventAdmin eventAdmin
+    ) {
+        RulesServiceImpl rulesService = new RulesServiceImpl();
+
+        // Set up tracing
+        TracerService tracerService = createTracerService();
+        TestRequestTracer tracer = new TestRequestTracer(true);
+        actionExecutorDispatcher.setTracer(tracer);
+
+        rulesService.setBundleContext(bundleContext);
+        rulesService.setPersistenceService(persistenceService);
+        rulesService.setDefinitionsService(definitionsService);
+        rulesService.setEventService(eventService);
+        rulesService.setActionExecutorDispatcher(actionExecutorDispatcher);
+        rulesService.setTenantService(tenantService);
+        rulesService.setSchedulerService(schedulerService);
+        rulesService.setContextManager(executionContextManager);
+        rulesService.setTracerService(tracerService);
+        rulesService.setCacheService(multiTypeCacheService);
+
+
+        // Create and register test action type
+        ActionType testActionType = new ActionType();
+        testActionType.setItemId("test");
+        Metadata actionMetadata = new Metadata();
+        actionMetadata.setId("test");
+        actionMetadata.setEnabled(true);
+        testActionType.setMetadata(actionMetadata);
+        testActionType.setActionExecutor("test");
+        definitionsService.setActionType(testActionType);
+
+        // Create and register setEventOccurenceCountAction type
+        ActionType setEventOccurenceCountActionType = new ActionType();
+        setEventOccurenceCountActionType.setItemId("setEventOccurenceCountAction");
+        Metadata setEventOccurenceCountMetadata = new Metadata();
+        setEventOccurenceCountMetadata.setId("setEventOccurenceCountAction");
+        setEventOccurenceCountMetadata.setEnabled(true);
+        setEventOccurenceCountActionType.setMetadata(setEventOccurenceCountMetadata);
+        setEventOccurenceCountActionType.setActionExecutor("setEventOccurenceCountAction");
+        definitionsService.setActionType(setEventOccurenceCountActionType);
+
+        // Initialize rule caches
+        rulesService.postConstruct();
+        eventService.addEventListenerService(rulesService);
+
+        // Register RulesServiceImpl as EventHandler with EventAdmin if provided
+        // In real OSGi, this would be done via service registry, but for tests we register manually
+        if (eventAdmin instanceof TestEventAdmin) {
+            ((TestEventAdmin) eventAdmin).registerHandler(
+                rulesService, "org/apache/unomi/definitions/**");
+        }
+
+        return rulesService;
+    }
 
     /**
      * Creates a scheduler service instance for testing purposes with ClusterService support.
@@ -397,8 +485,6 @@ public class TestHelper {
         return schedulerService;
     }
 
-
-
     public static ConditionValidationService createConditionValidationService() {
         ConditionValidationServiceImpl conditionValidationService = new ConditionValidationServiceImpl();
         List<ValueTypeValidator> validators = new ArrayList<>();
@@ -415,9 +501,13 @@ public class TestHelper {
         return conditionValidationService;
     }
 
+    public static TracerService createTracerService() {
+        return new TestTracerService();
+    }
+
     /**
-     * Creates and wires a new ClusterServiceImpl with the specified persistence service and node ID.
-     * Callers must invoke postConstruct() themselves if initialization behaviour is needed.
+     * Creates a cluster service instance for testing purposes.
+     * Initializes a new ClusterServiceImpl with the specified persistence service and node ID.
      *
      * NOTE: Due to circular dependency between ClusterService and SchedulerService,
      * when using both services together:
@@ -435,10 +525,9 @@ public class TestHelper {
     }
 
 
-
     /**
-     * Creates and wires a new ClusterServiceImpl with custom addresses and bundle context.
-     * Callers must invoke postConstruct() themselves if initialization behaviour is needed.
+     * Creates a cluster service instance for testing purposes with custom addresses and bundle context.
+     * Initializes a new ClusterServiceImpl with the specified persistence service, node ID, addresses, and bundle context.
      *
      * NOTE: Due to circular dependency between ClusterService and SchedulerService,
      * when using both services together:
@@ -469,6 +558,43 @@ public class TestHelper {
         return clusterService;
     }
 
+    /**
+     * Test implementation of TracerService for testing purposes.
+     * Provides basic tracing functionality with a test request tracer.
+     */
+    private static class TestTracerService implements TracerService {
+        private final RequestTracer requestTracer = new TestRequestTracer(true);
+
+        @Override
+        public RequestTracer getCurrentTracer() {
+            return requestTracer;
+        }
+
+        @Override
+        public void enableTracing() {
+            requestTracer.setEnabled(true);
+        }
+
+        @Override
+        public void disableTracing() {
+            requestTracer.setEnabled(false);
+        }
+
+        @Override
+        public boolean isTracingEnabled() {
+            return requestTracer.isEnabled();
+        }
+
+        @Override
+        public TraceNode getTraceNode() {
+            return requestTracer.getTraceNode();
+        }
+
+        @Override
+        public void cleanup() {
+            requestTracer.reset();
+        }
+    }
 
     /**
      * Creates a test action type with specified configuration.
@@ -557,6 +683,22 @@ public class TestHelper {
      * @param tracerService The tracer service to use
      * @return A configured EventServiceImpl instance
      */
+    public static EventServiceImpl createEventService(
+            PersistenceService persistenceService,
+            BundleContext bundleContext,
+            DefinitionsServiceImpl definitionsService,
+            TenantService tenantService,
+            TracerService tracerService) {
+        EventServiceImpl eventService = new EventServiceImpl();
+        eventService.setBundleContext(bundleContext);
+        eventService.setPersistenceService(persistenceService);
+        eventService.setDefinitionsService(definitionsService);
+        eventService.setTenantService(tenantService);
+        eventService.setTracerService(tracerService);
+
+
+        return eventService;
+    }
 
     /**
      * Creates a TypeResolutionService instance for testing purposes.
@@ -564,6 +706,9 @@ public class TestHelper {
      * @param definitionsService The definitions service to use
      * @return A configured TypeResolutionServiceImpl instance
      */
+    public static TypeResolutionService createTypeResolutionService(DefinitionsService definitionsService) {
+        return new TypeResolutionServiceImpl(definitionsService);
+    }
 
     public static void setupSegmentActionTypes(DefinitionsServiceImpl definitionsService) {
         // Register the evaluateProfileSegmentsAction type
@@ -651,7 +796,7 @@ public class TestHelper {
                     return;
                 }
             } catch (IOException e) {
-                LOGGER.warn("Error deleting default storage directory, will retry", e);
+                LOGGER.warn("Error deleting default storage directory, will retry: {}", e.getMessage());
             }
             // Use shorter sleep time (100ms instead of 1000ms) for faster retries
             // This significantly speeds up test execution when cleanup is needed
@@ -749,7 +894,7 @@ public class TestHelper {
                 Thread.sleep(retryDelay);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new RuntimeException("Retry interrupted", e);
+                break;
             }
 
             result = querySupplier.get();
@@ -813,8 +958,7 @@ public class TestHelper {
             String... tenantIds) throws Exception {
 
         // Stop scheduler service
-        if (schedulerService instanceof SchedulerServiceImpl) {
-            // instanceof already handles null; preDestroy shuts down threads cleanly
+        if (schedulerService != null && schedulerService instanceof SchedulerServiceImpl) {
             ((SchedulerServiceImpl) schedulerService).preDestroy();
         }
 
@@ -828,13 +972,12 @@ public class TestHelper {
         }
 
         // Clear persistence service data if possible
-        if (persistenceService instanceof InMemoryPersistenceServiceImpl) {
-            // purge(null) purges all items — used to reset test state between test methods
-            ((InMemoryPersistenceServiceImpl) persistenceService).purge((Date) null);
+        if (persistenceService != null && persistenceService instanceof InMemoryPersistenceServiceImpl) {
+            ((InMemoryPersistenceServiceImpl) persistenceService).purge((Date)null);
         }
 
         // Reset tenant context
-        if (tenantService instanceof TestTenantService) {
+        if (tenantService != null && tenantService instanceof TestTenantService) {
             // clearCurrentTenantId() removes the ThreadLocal entry rather than setting it to null
             ((TestTenantService) tenantService).clearCurrentTenantId();
         }

--- a/services/src/test/java/org/apache/unomi/services/TestHelper.java
+++ b/services/src/test/java/org/apache/unomi/services/TestHelper.java
@@ -796,7 +796,7 @@ public class TestHelper {
                     return;
                 }
             } catch (IOException e) {
-                LOGGER.warn("Error deleting default storage directory, will retry: {}", e.getMessage());
+                LOGGER.warn("Error deleting default storage directory, will retry", e);
             }
             // Use shorter sleep time (100ms instead of 1000ms) for faster retries
             // This significantly speeds up test execution when cleanup is needed
@@ -894,7 +894,7 @@ public class TestHelper {
                 Thread.sleep(retryDelay);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                break;
+                throw new RuntimeException("Retry interrupted", e);
             }
 
             result = querySupplier.get();

--- a/services/src/test/java/org/apache/unomi/services/actions/impl/ActionExecutorDispatcherImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/actions/impl/ActionExecutorDispatcherImplTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.services.actions.impl;
+
+import org.apache.unomi.api.Event;
+import org.apache.unomi.api.actions.Action;
+import org.apache.unomi.api.actions.ActionDispatcher;
+import org.apache.unomi.api.actions.ActionType;
+import org.apache.unomi.api.services.DefinitionsService;
+import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.services.impl.TypeResolutionServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ActionExecutorDispatcherImplTest {
+
+    @Mock
+    DefinitionsService definitionsService;
+
+    @Mock
+    ActionDispatcher actionDispatcher;
+
+    @Mock
+    Event event;
+
+    @Test
+    void shouldResolveActionTypeBeforeDispatchingToActionDispatcher() throws Exception {
+        ActionExecutorDispatcherImpl dispatcher = new ActionExecutorDispatcherImpl();
+        dispatcher.setDefinitionsService(definitionsService);
+
+        putActionDispatcher(dispatcher, "test", actionDispatcher);
+
+        ActionType actionType = new ActionType();
+        actionType.setItemId("testActionType");
+        actionType.setActionExecutor("test:doSomething");
+        when(definitionsService.getActionType("testActionType")).thenReturn(actionType);
+        when(definitionsService.getTypeResolutionService()).thenReturn(new TypeResolutionServiceImpl(definitionsService));
+        when(actionDispatcher.execute(any(Action.class), eq(event), eq("doSomething"))).thenReturn(EventService.NO_CHANGE);
+
+        // Simulate JSON-deserialized action: only actionTypeId is present
+        Action action = new Action();
+        action.setActionTypeId("testActionType");
+
+        int result = dispatcher.execute(action, event);
+
+        assertEquals(EventService.NO_CHANGE, result, "Dispatcher should return the result from ActionDispatcher when action type is resolved");
+        assertNotNull(action.getActionType(), "Action type should be resolved from actionTypeId before dispatching");
+        verify(actionDispatcher).execute(any(Action.class), eq(event), eq("doSomething"));
+    }
+
+    @Test
+    void shouldReturnNoChangeWhenActionTypeCannotBeResolved() {
+        ActionExecutorDispatcherImpl dispatcher = new ActionExecutorDispatcherImpl();
+        dispatcher.setDefinitionsService(definitionsService);
+
+        // Mock TypeResolutionService to be available but return null for missing type
+        when(definitionsService.getTypeResolutionService()).thenReturn(new TypeResolutionServiceImpl(definitionsService));
+        when(definitionsService.getActionType("missingType")).thenReturn(null);
+
+        Action action = new Action();
+        action.setActionTypeId("missingType");
+
+        int result = dispatcher.execute(action, event);
+
+        assertEquals(EventService.NO_CHANGE, result, "Dispatcher should return NO_CHANGE when actionTypeId cannot be resolved");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void putActionDispatcher(ActionExecutorDispatcherImpl dispatcher, String prefix, ActionDispatcher actionDispatcher) throws Exception {
+        Field field = ActionExecutorDispatcherImpl.class.getDeclaredField("actionDispatchers");
+        field.setAccessible(true);
+        Map<String, ActionDispatcher> map = (Map<String, ActionDispatcher>) field.get(dispatcher);
+        map.put(prefix, actionDispatcher);
+    }
+}
+
+

--- a/services/src/test/java/org/apache/unomi/services/impl/InMemoryPersistenceServiceImpl.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/InMemoryPersistenceServiceImpl.java
@@ -52,7 +52,7 @@ public class InMemoryPersistenceServiceImpl implements PersistenceService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryPersistenceServiceImpl.class);
     private static final Pattern SAFE_FILENAME_PATTERN = Pattern.compile("[^a-zA-Z0-9-_.]");
-    public static final String DEFAULT_STORAGE_DIR = "data/persistence";
+    public static final String DEFAULT_STORAGE_DIR = "target/persistence-data";
 
     // System items list - matches Elasticsearch/OpenSearch persistence services
     // System items have their itemType appended to the document ID: tenantId_itemId_itemType
@@ -2864,4 +2864,3 @@ public class InMemoryPersistenceServiceImpl implements PersistenceService {
         this.defaultQueryLimit = defaultQueryLimit != null && defaultQueryLimit > 0 ? defaultQueryLimit : 10;
     }
 }
-

--- a/services/src/test/java/org/apache/unomi/services/impl/InMemoryPersistenceServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/InMemoryPersistenceServiceImplTest.java
@@ -6248,10 +6248,11 @@ public class InMemoryPersistenceServiceImplTest {
                 service.save(item);
             }
 
-            // Query with explicit size should respect it - retry until items are available
-            PartialList<TestMetadataItem> result = TestHelper.retryQueryUntilAvailable(
+            // Retry until both list size and totalSize are correct — totalSize reflects only refreshed items,
+            // so checking list.size() == 5 alone can succeed before all 20 items are indexed.
+            PartialList<TestMetadataItem> result = TestHelper.retryUntil(
                 () -> service.query(null, null, TestMetadataItem.class, 0, 5),
-                5
+                r -> r != null && r.getTotalSize() == 20 && r.getList().size() == 5
             );
             assertEquals(5, result.getList().size(), "Query with explicit size=5 should return 5 items");
             assertEquals(20, result.getTotalSize(), "Total size should be 20");
@@ -6271,10 +6272,10 @@ public class InMemoryPersistenceServiceImplTest {
                 service.save(item);
             }
 
-            // Query with size = -1 should return custom default limit (5) - retry until items are available
-            PartialList<TestMetadataItem> result = TestHelper.retryQueryUntilAvailable(
+            // Retry until both list size and totalSize are correct — same race as shouldRespectExplicitSizeWhenProvided.
+            PartialList<TestMetadataItem> result = TestHelper.retryUntil(
                 () -> service.query(null, null, TestMetadataItem.class, 0, -1),
-                5
+                r -> r != null && r.getTotalSize() == 20 && r.getList().size() == 5
             );
             assertEquals(5, result.getList().size(), "Query with size=-1 should return custom default limit of 5");
             assertEquals(20, result.getTotalSize(), "Total size should be 20");

--- a/services/src/test/java/org/apache/unomi/services/impl/TestBundleContext.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/TestBundleContext.java
@@ -21,7 +21,6 @@ import org.osgi.framework.*;
 import java.io.File;
 import java.io.InputStream;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Map;
@@ -149,7 +148,7 @@ public class TestBundleContext implements BundleContext {
 
     @Override
     public <S> Collection<ServiceReference<S>> getServiceReferences(Class<S> clazz, String filter) {
-        return Collections.emptyList();
+        return null;
     }
 
     @Override

--- a/services/src/test/java/org/apache/unomi/services/impl/TestBundleContext.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/TestBundleContext.java
@@ -21,6 +21,7 @@ import org.osgi.framework.*;
 import java.io.File;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Map;
@@ -148,7 +149,7 @@ public class TestBundleContext implements BundleContext {
 
     @Override
     public <S> Collection<ServiceReference<S>> getServiceReferences(Class<S> clazz, String filter) {
-        return null;
+        return Collections.emptyList();
     }
 
     @Override

--- a/services/src/test/java/org/apache/unomi/services/impl/TestConditionEvaluators.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/TestConditionEvaluators.java
@@ -29,11 +29,11 @@ import org.apache.unomi.persistence.spi.conditions.evaluator.ConditionEvaluator;
 import org.apache.unomi.persistence.spi.conditions.evaluator.ConditionEvaluatorDispatcher;
 import org.apache.unomi.persistence.spi.conditions.evaluator.impl.ConditionEvaluatorDispatcherImpl;
 import org.apache.unomi.persistence.spi.conditions.geo.DistanceUnit;
+import org.apache.unomi.tracing.api.RequestTracer;
 import org.osgi.framework.BundleContext;
 
 import java.lang.reflect.Method;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
@@ -45,14 +45,17 @@ import java.util.stream.Collectors;
 public class TestConditionEvaluators {
 
     private static Map<String, ConditionType> conditionTypes = new ConcurrentHashMap<>();
-    private static final DateTimeFormatter ISO_DATE_FORMAT =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
-    private static final DateTimeFormatter YEAR_MONTH_DAY_FORMAT =
-            DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneOffset.UTC);
+    private static final SimpleDateFormat ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    private static final SimpleDateFormat yearMonthDayDateFormat = new SimpleDateFormat("yyyyMMdd");
     private static EventService eventService;
     private static BundleContext bundleContext;
     private static TestRequestTracer tracer = new TestRequestTracer(false);
     private static Map<String, ConditionEvaluator> evaluators = new HashMap<>();
+
+    static {
+        ISO_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+        yearMonthDayDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
 
     public static void setEventService(EventService service) {
         eventService = service;
@@ -62,7 +65,7 @@ public class TestConditionEvaluators {
         TestConditionEvaluators.bundleContext = bundleContext;
     }
 
-    public static TestRequestTracer getTracer() {
+    public static RequestTracer getTracer() {
         return tracer;
     }
 
@@ -83,15 +86,9 @@ public class TestConditionEvaluators {
         return (condition, item, context, dispatcher) -> {
             tracer.startOperation("boolean", "Evaluating boolean condition with operator: " + condition.getParameter("operator"), condition);
             String operator = (String) condition.getParameter("operator");
-            Object subConditionsParam = condition.getParameter("subConditions");
-            if (!(subConditionsParam instanceof List)) {
-                tracer.endOperation(true, "No subconditions found, returning true");
-                return true;
-            }
-            @SuppressWarnings("unchecked")
-            List<Condition> subConditions = (List<Condition>) subConditionsParam;
+            List<Condition> subConditions = (List<Condition>) condition.getParameter("subConditions");
 
-            if (subConditions.isEmpty()) {
+            if (subConditions == null || subConditions.isEmpty()) {
                 tracer.endOperation(true, "No subconditions found, returning true");
                 return true;
             }
@@ -373,13 +370,8 @@ public class TestConditionEvaluators {
     private static boolean evaluateDateCondition(Object actualValue, Object expectedValueDate,
                                                Object expectedValueDateExpr, String operator) {
         Object expectedDate = expectedValueDate == null ? expectedValueDateExpr : expectedValueDate;
-        Date actualDateVal = getDate(actualValue);
-        Date expectedDateVal = getDate(expectedDate);
-        if (actualDateVal == null || expectedDateVal == null) {
-            return false;
-        }
-        boolean isSameDay = YEAR_MONTH_DAY_FORMAT.format(actualDateVal.toInstant())
-                .equals(YEAR_MONTH_DAY_FORMAT.format(expectedDateVal.toInstant()));
+        boolean isSameDay = yearMonthDayDateFormat.format(getDate(actualValue))
+                .equals(yearMonthDayDateFormat.format(getDate(expectedDate)));
         return operator.equals("isDay") ? isSameDay : !isSameDay;
     }
 
@@ -431,7 +423,7 @@ public class TestConditionEvaluators {
         switch (operator) {
             case "in": return actual.stream().anyMatch(expected::contains);
             case "inContains": return actual.stream().anyMatch(a ->
-                (a instanceof String) && expected.stream().anyMatch(b -> (b instanceof String) && ((String) a).contains((String) b)));
+                expected.stream().anyMatch(b -> ((String) a).contains((String) b)));
             case "notIn": return actual.stream().noneMatch(expected::contains);
             case "all": return expected.stream().allMatch(actual::contains);
             case "hasNoneOf": return Collections.disjoint(actual, expected);
@@ -532,13 +524,8 @@ public class TestConditionEvaluators {
                 String key = (String) parameters.get("generatedPropertyKey");
                 tracer.trace(condition, "Using generated property key: " + key);
 
-                Object pastEventsObj = profile.getSystemProperties().get("pastEvents");
-                if (!(pastEventsObj instanceof List)) {
-                    tracer.trace(condition, "No pastEvents found in profile system properties");
-                    count = 0;
-                } else {
-                    @SuppressWarnings("unchecked")
-                    List<Map<String, Object>> pastEvents = (List<Map<String, Object>>) pastEventsObj;
+                List<Map<String, Object>> pastEvents = (ArrayList<Map<String, Object>>) profile.getSystemProperties().get("pastEvents");
+                if (pastEvents != null) {
                     tracer.trace(condition, "Found pastEvents in profile system properties");
                     Number l = (Number) pastEvents
                             .stream()
@@ -547,6 +534,9 @@ public class TestConditionEvaluators {
                             .map(pastEvent -> pastEvent.get("count")).orElse(0L);
                     count = l.longValue();
                     tracer.trace(condition, "Found count=" + count + " for key=" + key);
+                } else {
+                    tracer.trace(condition, "No pastEvents found in profile system properties");
+                    count = 0;
                 }
             } else {
                 tracer.trace(condition, "No generatedPropertyKey found, querying events directly");
@@ -916,7 +906,7 @@ public class TestConditionEvaluators {
     }
 
     public static Map<String, ConditionType> getConditionTypes() {
-        return Collections.unmodifiableMap(conditionTypes);
+        return conditionTypes;
     }
 
     public static ConditionType getConditionType(String conditionTypeId) {

--- a/services/src/test/java/org/apache/unomi/services/impl/TestConditionEvaluators.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/TestConditionEvaluators.java
@@ -86,9 +86,15 @@ public class TestConditionEvaluators {
         return (condition, item, context, dispatcher) -> {
             tracer.startOperation("boolean", "Evaluating boolean condition with operator: " + condition.getParameter("operator"), condition);
             String operator = (String) condition.getParameter("operator");
-            List<Condition> subConditions = (List<Condition>) condition.getParameter("subConditions");
+            Object subConditionsParam = condition.getParameter("subConditions");
+            if (!(subConditionsParam instanceof List)) {
+                tracer.endOperation(true, "No subconditions found, returning true");
+                return true;
+            }
+            @SuppressWarnings("unchecked")
+            List<Condition> subConditions = (List<Condition>) subConditionsParam;
 
-            if (subConditions == null || subConditions.isEmpty()) {
+            if (subConditions.isEmpty()) {
                 tracer.endOperation(true, "No subconditions found, returning true");
                 return true;
             }
@@ -370,8 +376,13 @@ public class TestConditionEvaluators {
     private static boolean evaluateDateCondition(Object actualValue, Object expectedValueDate,
                                                Object expectedValueDateExpr, String operator) {
         Object expectedDate = expectedValueDate == null ? expectedValueDateExpr : expectedValueDate;
-        boolean isSameDay = yearMonthDayDateFormat.format(getDate(actualValue))
-                .equals(yearMonthDayDateFormat.format(getDate(expectedDate)));
+        Date actualDateVal = getDate(actualValue);
+        Date expectedDateVal = getDate(expectedDate);
+        if (actualDateVal == null || expectedDateVal == null) {
+            return false;
+        }
+        boolean isSameDay = yearMonthDayDateFormat.format(actualDateVal)
+                .equals(yearMonthDayDateFormat.format(expectedDateVal));
         return operator.equals("isDay") ? isSameDay : !isSameDay;
     }
 
@@ -423,7 +434,7 @@ public class TestConditionEvaluators {
         switch (operator) {
             case "in": return actual.stream().anyMatch(expected::contains);
             case "inContains": return actual.stream().anyMatch(a ->
-                expected.stream().anyMatch(b -> ((String) a).contains((String) b)));
+                (a instanceof String) && expected.stream().anyMatch(b -> (b instanceof String) && ((String) a).contains((String) b)));
             case "notIn": return actual.stream().noneMatch(expected::contains);
             case "all": return expected.stream().allMatch(actual::contains);
             case "hasNoneOf": return Collections.disjoint(actual, expected);
@@ -524,8 +535,13 @@ public class TestConditionEvaluators {
                 String key = (String) parameters.get("generatedPropertyKey");
                 tracer.trace(condition, "Using generated property key: " + key);
 
-                List<Map<String, Object>> pastEvents = (ArrayList<Map<String, Object>>) profile.getSystemProperties().get("pastEvents");
-                if (pastEvents != null) {
+                Object pastEventsObj = profile.getSystemProperties().get("pastEvents");
+                if (!(pastEventsObj instanceof List)) {
+                    tracer.trace(condition, "No pastEvents found in profile system properties");
+                    count = 0;
+                } else {
+                    @SuppressWarnings("unchecked")
+                    List<Map<String, Object>> pastEvents = (List<Map<String, Object>>) pastEventsObj;
                     tracer.trace(condition, "Found pastEvents in profile system properties");
                     Number l = (Number) pastEvents
                             .stream()
@@ -534,9 +550,6 @@ public class TestConditionEvaluators {
                             .map(pastEvent -> pastEvent.get("count")).orElse(0L);
                     count = l.longValue();
                     tracer.trace(condition, "Found count=" + count + " for key=" + key);
-                } else {
-                    tracer.trace(condition, "No pastEvents found in profile system properties");
-                    count = 0;
                 }
             } else {
                 tracer.trace(condition, "No generatedPropertyKey found, querying events directly");
@@ -906,7 +919,7 @@ public class TestConditionEvaluators {
     }
 
     public static Map<String, ConditionType> getConditionTypes() {
-        return conditionTypes;
+        return Collections.unmodifiableMap(conditionTypes);
     }
 
     public static ConditionType getConditionType(String conditionTypeId) {

--- a/services/src/test/java/org/apache/unomi/services/impl/TestConditionEvaluators.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/TestConditionEvaluators.java
@@ -485,6 +485,7 @@ public class TestConditionEvaluators {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private static List<Object> getValueSet(Object value) {
         if (value instanceof List) {
             return (List<Object>) value;
@@ -967,4 +968,3 @@ public class TestConditionEvaluators {
         };
     }
 }
-

--- a/services/src/test/java/org/apache/unomi/services/impl/TestEventAdmin.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/TestEventAdmin.java
@@ -62,9 +62,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  *    - EVENT_FILTER property is optional and not implemented (minimal compliance)
  * 
  * Threading model:
- * - postEvent(): Each handler has a dedicated daemon thread (from a cached thread pool) consuming
- *   events from its own queue, guaranteeing per-handler ordered delivery
+ * - postEvent(): Uses a single-threaded executor to process events in order
  * - sendEvent(): Calls handlers directly in the current thread (synchronous)
+ * - Each handler has a dedicated queue to guarantee ordered delivery per handler
  * 
  * Note: Security (TopicPermission) is not enforced in this test mock, as it's not required for minimal compliance
  * in a test environment. Real OSGi implementations must enforce TopicPermission checks.
@@ -81,18 +81,10 @@ public class TestEventAdmin implements EventAdmin {
     private final Map<EventHandler, Set<String>> handlers = new ConcurrentHashMap<>();
 
     /**
-     * Cached thread pool providing one daemon thread per registered handler.
-     * A single-thread executor cannot be shared across handlers because each handler's
-     * worker blocks on queue.take(), starving all subsequent handler submissions.
+     * Single-threaded executor for processing asynchronous events in order.
+     * This ensures events are delivered to handlers in the order they were posted.
      */
     private final ExecutorService asyncExecutor;
-
-    /**
-     * Number of events currently being processed (taken from queue but not yet finished).
-     * Used by waitForEventProcessing to avoid a race where the queue appears empty before
-     * handleEvent has actually completed.
-     */
-    private final AtomicInteger inFlightCount = new AtomicInteger(0);
 
     /**
      * Queue per handler to guarantee event sequencing.
@@ -125,9 +117,13 @@ public class TestEventAdmin implements EventAdmin {
      */
     private final List<Event> sentEvents = new CopyOnWriteArrayList<>();
 
+    /**
+     * Creates a TestEventAdmin with a single-threaded executor for ordered event delivery.
+     */
     public TestEventAdmin() {
-        this.asyncExecutor = Executors.newCachedThreadPool(r -> {
-            Thread t = new Thread(r, "TestEventAdmin-Handler-" + System.identityHashCode(this));
+        // Use single-threaded executor to guarantee ordered delivery
+        this.asyncExecutor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "TestEventAdmin-Async-" + System.identityHashCode(this));
             t.setDaemon(true);
             return t;
         });
@@ -165,15 +161,15 @@ public class TestEventAdmin implements EventAdmin {
             try {
                 while (!Thread.currentThread().isInterrupted()) {
                     Event event = queue.take(); // Blocks until event is available
-                    inFlightCount.incrementAndGet();
-                    try {
-                        handler.handleEvent(event);
-                    } catch (Exception e) {
-                        // OSGi spec: catch exceptions, log them, and continue
-                        LOGGER.warn("Exception in event handler {} while processing event {}: {}",
-                            handler.getClass().getName(), event.getTopic(), e.getMessage(), e);
-                    } finally {
-                        inFlightCount.decrementAndGet();
+                    if (event != null) {
+                        try {
+                            handler.handleEvent(event);
+                        } catch (Exception e) {
+                            // OSGi spec: catch exceptions, log them, and continue
+                            // If LogService is available, it should be used (we use SLF4J)
+                            LOGGER.warn("Exception in event handler {} while processing event {}: {}",
+                                handler.getClass().getName(), event.getTopic(), e.getMessage(), e);
+                        }
                     }
                 }
             } catch (InterruptedException e) {
@@ -327,10 +323,6 @@ public class TestEventAdmin implements EventAdmin {
                 return true;
             }
 
-            if ("**".equals(filter)) {
-                return true;
-            }
-
             // Support wildcard pattern: "org/apache/unomi/**"
             // Matches all topics starting with the prefix (including the prefix itself)
             if (filter.endsWith("/**")) {
@@ -426,24 +418,23 @@ public class TestEventAdmin implements EventAdmin {
      */
     public boolean waitForEventProcessing(long timeoutMs) {
         long deadline = System.currentTimeMillis() + timeoutMs;
-
-        // Wait until all queues are drained AND all in-flight handleEvent calls have returned.
-        // Checking only queue.isEmpty() is insufficient: workers remove events from the queue
-        // before calling handleEvent, so the queue can appear empty while processing is ongoing.
-        while (System.currentTimeMillis() < deadline) {
-            boolean allQueuesEmpty = handlerQueues.values().stream().allMatch(BlockingQueue::isEmpty);
-            if (allQueuesEmpty && inFlightCount.get() == 0) {
-                return true;
+        
+        // Wait for all handler queues to be empty
+        for (BlockingQueue<Event> queue : handlerQueues.values()) {
+            while (!queue.isEmpty() && System.currentTimeMillis() < deadline) {
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return false;
+                }
             }
-            try {
-                Thread.sleep(10);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+            if (!queue.isEmpty()) {
                 return false;
             }
         }
-
-        return false;
+        
+        return true;
     }
 
     /**

--- a/services/src/test/java/org/apache/unomi/services/impl/TestEventAdmin.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/TestEventAdmin.java
@@ -98,6 +98,13 @@ public class TestEventAdmin implements EventAdmin {
     private final Map<EventHandler, Future<?>> handlerWorkers = new ConcurrentHashMap<>();
 
     /**
+     * Counter for in-flight handleEvent calls across all handlers.
+     * Used by waitForEventProcessing to confirm all processing has truly completed,
+     * not just that queues are drained (workers dequeue before calling handleEvent).
+     */
+    private final AtomicInteger inFlightCount = new AtomicInteger(0);
+
+    /**
      * Counter for tracking posted events (for test verification).
      */
     private final AtomicInteger postedEventCount = new AtomicInteger(0);
@@ -118,12 +125,13 @@ public class TestEventAdmin implements EventAdmin {
     private final List<Event> sentEvents = new CopyOnWriteArrayList<>();
 
     /**
-     * Creates a TestEventAdmin with a single-threaded executor for ordered event delivery.
+     * Creates a TestEventAdmin with a cached thread pool so each registered handler
+     * can run its own long-lived worker thread without blocking other handlers.
+     * Per-handler ordering is guaranteed by the per-handler BlockingQueue.
      */
     public TestEventAdmin() {
-        // Use single-threaded executor to guarantee ordered delivery
-        this.asyncExecutor = Executors.newSingleThreadExecutor(r -> {
-            Thread t = new Thread(r, "TestEventAdmin-Async-" + System.identityHashCode(this));
+        this.asyncExecutor = Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, "TestEventAdmin-Handler-" + System.identityHashCode(this));
             t.setDaemon(true);
             return t;
         });
@@ -162,6 +170,7 @@ public class TestEventAdmin implements EventAdmin {
                 while (!Thread.currentThread().isInterrupted()) {
                     Event event = queue.take(); // Blocks until event is available
                     if (event != null) {
+                        inFlightCount.incrementAndGet();
                         try {
                             handler.handleEvent(event);
                         } catch (Exception e) {
@@ -169,6 +178,8 @@ public class TestEventAdmin implements EventAdmin {
                             // If LogService is available, it should be used (we use SLF4J)
                             LOGGER.warn("Exception in event handler {} while processing event {}: {}",
                                 handler.getClass().getName(), event.getTopic(), e.getMessage(), e);
+                        } finally {
+                            inFlightCount.decrementAndGet();
                         }
                     }
                 }
@@ -418,23 +429,23 @@ public class TestEventAdmin implements EventAdmin {
      */
     public boolean waitForEventProcessing(long timeoutMs) {
         long deadline = System.currentTimeMillis() + timeoutMs;
-        
-        // Wait for all handler queues to be empty
-        for (BlockingQueue<Event> queue : handlerQueues.values()) {
-            while (!queue.isEmpty() && System.currentTimeMillis() < deadline) {
-                try {
-                    Thread.sleep(10);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    return false;
-                }
+
+        // Wait until all queues are drained AND all in-flight handleEvent calls have returned.
+        // Checking only queue.isEmpty() is insufficient: workers remove events from the queue
+        // before calling handleEvent, so the queue can appear empty while processing is ongoing.
+        while (System.currentTimeMillis() < deadline) {
+            boolean allQueuesEmpty = handlerQueues.values().stream().allMatch(BlockingQueue::isEmpty);
+            if (allQueuesEmpty && inFlightCount.get() == 0) {
+                return true;
             }
-            if (!queue.isEmpty()) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 return false;
             }
         }
-        
-        return true;
+        return false;
     }
 
     /**

--- a/services/src/test/java/org/apache/unomi/services/impl/TestRequestTracer.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/TestRequestTracer.java
@@ -17,6 +17,7 @@
 package org.apache.unomi.services.impl;
 
 import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.tracing.impl.LoggingRequestTracer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,85 +27,113 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Lightweight no-op tracer for unit tests. Does not depend on the tracing modules
- * (added in UNOMI-873); sufficient for {@link TestConditionEvaluators}.
+ * Test implementation of RequestTracer that extends LoggingRequestTracer to provide test-specific
+ * functionality for verification while leveraging the base logging and indentation features.
+ *
+ * <p>Features:
+ * <ul>
+ *   <li>Thread-safe trace collection</li>
+ *   <li>Optional console logging</li>
+ *   <li>Support for condition evaluation tracing</li>
+ *   <li>Proper null handling</li>
+ *   <li>Immutable trace history access</li>
+ *   <li>Hierarchical indentation for better readability</li>
+ * </ul>
  */
-public class TestRequestTracer {
+public class TestRequestTracer extends LoggingRequestTracer {
     private static final Logger logger = LoggerFactory.getLogger(TestRequestTracer.class);
-
-    private final List<String> traces = Collections.synchronizedList(new ArrayList<>());
+    
+    private final List<String> traces;
     private final boolean logToConsole;
-    private volatile boolean enabled;
 
+    /**
+     * Creates a new TestRequestTracer instance.
+     *
+     * @param logToConsole if true, all traces will also be logged to the console via SLF4J
+     */
     public TestRequestTracer(boolean logToConsole) {
+        super(true);
+        this.traces = Collections.synchronizedList(new ArrayList<>());
         this.logToConsole = logToConsole;
-        this.enabled = logToConsole;
     }
 
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
+    @Override
+    protected void logMessage(String message, Object context) {
+        String formattedMessage = formatMessage(message, context);
+        String indentedMessage = indent(formattedMessage);
+        traces.add(indentedMessage);
+        
+        if (logToConsole) {
+            logger.debug(indentedMessage);
+        }
     }
 
-    public boolean isEnabled() {
-        return enabled;
-    }
-
+    @Override
     public void reset() {
         traces.clear();
+        super.reset();
     }
 
+    /**
+     * Get an immutable copy of all traces collected so far.
+     * The traces include proper indentation to visualize the operation hierarchy.
+     *
+     * @return Unmodifiable list of trace messages
+     */
     public List<String> getTraces() {
         return Collections.unmodifiableList(new ArrayList<>(traces));
     }
 
+    /**
+     * Clear all collected traces and reset the current trace node.
+     */
     public void clear() {
         traces.clear();
+        reset();
     }
 
-    public void startOperation(String operationType, String message, Condition condition) {
-        if (!enabled) {
-            return;
-        }
-        record("START " + operationType + ": " + message, condition);
-    }
-
-    public void endOperation(boolean result, String message) {
-        if (!enabled) {
-            return;
-        }
-        record("END result=" + result + ": " + message, null);
-    }
-
-    public void trace(String message, Condition condition) {
-        if (!enabled) {
-            return;
-        }
-        record(message, condition);
-    }
-
-    public void trace(Condition condition, String message) {
-        trace(message, condition);
-    }
-
+    /**
+     * Start tracing a condition evaluation.
+     *
+     * @param condition the condition being evaluated
+     * @param message description of what's being evaluated
+     * @throws NullPointerException if condition is null
+     */
     public void startEvaluation(Condition condition, String message) {
         Objects.requireNonNull(condition, "Condition cannot be null");
-        if (enabled) {
-            record("Starting evaluation: " + message, condition);
+        if (isEnabled()) {
+            super.trace("Starting evaluation: " + message, condition);
+            indentLevel.set(indentLevel.get() + 1);
         }
     }
 
+    /**
+     * End tracing a condition evaluation.
+     *
+     * @param condition the condition that was evaluated
+     * @param result the evaluation result
+     * @param message description of the evaluation outcome
+     * @throws NullPointerException if condition is null
+     */
     public void endEvaluation(Condition condition, boolean result, String message) {
         Objects.requireNonNull(condition, "Condition cannot be null");
-        if (enabled) {
-            record("Evaluation completed: " + message + " - Result: " + result, condition);
+        if (isEnabled()) {
+            indentLevel.set(Math.max(0, indentLevel.get() - 1));
+            super.trace("Evaluation completed: " + message + " - Result: " + result, condition);
         }
     }
 
-    private void record(String message, Condition condition) {
-        String line = condition != null ? message + " [" + condition.getConditionTypeId() + "]" : message;
-        traces.add(line);
-        if (logToConsole) {
-            logger.debug(line);
+    /**
+     * Add a trace message for a condition.
+     *
+     * @param condition the condition being traced
+     * @param message the trace message
+     * @throws NullPointerException if condition is null
+     */
+    public void trace(Condition condition, String message) {
+        Objects.requireNonNull(condition, "Condition cannot be null");
+        if (isEnabled()) {
+            super.trace(message, condition);
         }
     }
 }

--- a/services/src/test/java/org/apache/unomi/services/impl/TypeResolutionServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/TypeResolutionServiceImplTest.java
@@ -757,13 +757,6 @@ public class TypeResolutionServiceImplTest {
         assertEquals(1, firstEncounterCount, "First encounter should have count of 1");
         assertEquals(1, info1.getMissingConditionTypeIds().size(), "Should have 1 missing condition type initially");
 
-        // Wait a bit to ensure timestamp difference
-        try {
-            Thread.sleep(10);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-
         // Second encounter with different missing type
         typeResolutionService.resolveCondition("segments", segment, condition2, "context2");
 
@@ -873,13 +866,6 @@ public class TypeResolutionServiceImplTest {
 
         assertTrue(firstSeen > 0, "First seen timestamp should be set");
         assertEquals(firstSeen, lastSeen, "First and last seen should be equal on first encounter");
-
-        // Wait a bit
-        try {
-            Thread.sleep(10);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
 
         // Second encounter
         typeResolutionService.markInvalid("rules", "rule1", "Updated reason");

--- a/services/src/test/java/org/apache/unomi/services/impl/definitions/DefinitionsServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/definitions/DefinitionsServiceImplTest.java
@@ -1,0 +1,3338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.services.impl.definitions;
+
+import org.apache.unomi.api.Metadata;
+import org.apache.unomi.api.PluginType;
+import org.apache.unomi.api.PropertyMergeStrategyType;
+import org.apache.unomi.api.ValueType;
+import org.apache.unomi.api.actions.ActionType;
+import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.api.conditions.ConditionType;
+import org.apache.unomi.api.services.SchedulerService;
+import org.apache.unomi.api.services.TypeResolutionService;
+import org.apache.unomi.persistence.spi.PersistenceService;
+import org.apache.unomi.persistence.spi.conditions.evaluator.ConditionEvaluatorDispatcher;
+import org.apache.unomi.services.TestHelper;
+import org.apache.unomi.services.common.security.ExecutionContextManagerImpl;
+import org.apache.unomi.services.common.security.KarafSecurityService;
+import org.apache.unomi.services.impl.InMemoryPersistenceServiceImpl;
+import org.apache.unomi.services.impl.TestConditionEvaluators;
+import org.apache.unomi.services.impl.TestTenantService;
+import org.apache.unomi.services.impl.cache.MultiTypeCacheServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.apache.unomi.services.impl.TestTenantService.SYSTEM_TENANT;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DefinitionsServiceImplTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefinitionsServiceImplTest.class);
+
+    @Mock
+    private BundleContext bundleContext;
+    @Mock
+    private Bundle bundle;
+    private SchedulerService schedulerService;
+
+    private TestTenantService tenantService;
+    private DefinitionsServiceImpl definitionsService;
+    private InMemoryPersistenceServiceImpl persistenceService;
+    private MultiTypeCacheServiceImpl multiTypeCacheService;
+    private KarafSecurityService securityService;
+    private ExecutionContextManagerImpl executionContextManager;
+
+    @BeforeEach
+    void setUp() {
+        tenantService = new TestTenantService();
+        tenantService.setCurrentTenantId("test-tenant");
+        ConditionEvaluatorDispatcher conditionEvaluatorDispatcher = TestConditionEvaluators.createDispatcher();
+        securityService = TestHelper.createSecurityService();
+        executionContextManager = TestHelper.createExecutionContextManager(securityService);
+        persistenceService = new InMemoryPersistenceServiceImpl(executionContextManager, conditionEvaluatorDispatcher);
+        // Mock bundle context
+        bundleContext = TestHelper.createMockBundleContext();
+        schedulerService = TestHelper.createSchedulerService("definitions-service-scheduler-node", persistenceService, executionContextManager, bundleContext, null, -1, true, true);
+        // Create scheduler service using TestHelper
+        multiTypeCacheService = new MultiTypeCacheServiceImpl();
+        definitionsService = TestHelper.createDefinitionService(persistenceService, bundleContext, schedulerService, multiTypeCacheService, executionContextManager, tenantService);
+        // Inject definitionsService into the dispatcher
+        TestHelper.injectDefinitionsServiceIntoDispatcher(conditionEvaluatorDispatcher, definitionsService);
+    }
+
+    @Nested
+    class BundleLifecycleTests {
+        @Test
+        void shouldHandleBundleStartup() {
+            // given
+            when(bundle.getBundleId()).thenReturn(1L);
+            when(bundleContext.getBundle()).thenReturn(bundle);
+
+            // Mock condition type JSON
+            String conditionJson = "{\"metadata\":{\"id\":\"test-condition\",\"name\":\"Test Condition\",\"tags\":[\"tag1\"],\"systemTags\":[\"systemTag1\"]},\"parentCondition\":null}";
+            InputStream conditionStream = null;
+            InputStream actionStream = null;
+            InputStream valueStream = null;
+
+            try {
+                conditionStream = new ByteArrayInputStream(conditionJson.getBytes());
+
+                // Mock action type JSON
+                String actionJson = "{\"metadata\":{\"id\":\"test-action\",\"name\":\"Test Action\",\"tags\":[\"tag1\"],\"systemTags\":[\"systemTag1\"]}}";
+                actionStream = new ByteArrayInputStream(actionJson.getBytes());
+
+                // Mock value type JSON
+                String valueJson = "{\"id\":\"test-value\",\"tags\":[\"tag1\"]}";
+                valueStream = new ByteArrayInputStream(valueJson.getBytes());
+
+                when(bundle.findEntries(eq("META-INF/cxs/conditions"), eq("*.json"), eq(true)))
+                    .thenReturn(Collections.enumeration(Collections.singletonList(createTestURL(conditionStream))));
+                when(bundle.findEntries(eq("META-INF/cxs/actions"), eq("*.json"), eq(true)))
+                    .thenReturn(Collections.enumeration(Collections.singletonList(createTestURL(actionStream))));
+                when(bundle.findEntries(eq("META-INF/cxs/values"), eq("*.json"), eq(true)))
+                    .thenReturn(Collections.enumeration(Collections.singletonList(createTestURL(valueStream))));
+
+                // when
+                definitionsService.processBundleStartup(bundleContext);
+
+                // then
+                // Verify condition type was saved
+                ConditionType savedConditionType = persistenceService.load("test-condition", ConditionType.class);
+                assertNotNull(savedConditionType, "Condition type should be saved");
+                assertEquals(SYSTEM_TENANT, savedConditionType.getTenantId());
+                assertTrue(savedConditionType.getMetadata().getTags().contains("tag1"));
+                assertTrue(savedConditionType.getMetadata().getSystemTags().contains("systemTag1"));
+
+                // Verify action type was saved
+                ActionType savedActionType = persistenceService.load("test-action", ActionType.class);
+                assertNotNull(savedActionType, "Action type should be saved");
+                assertEquals(SYSTEM_TENANT, savedActionType.getTenantId());
+                assertTrue(savedActionType.getMetadata().getTags().contains("tag1"));
+                assertTrue(savedActionType.getMetadata().getSystemTags().contains("systemTag1"));
+
+                // Verify value type was loaded (not persisted)
+                ValueType valueType = definitionsService.getValueType("test-value");
+                assertNotNull(valueType);
+                assertTrue(valueType.getTags().contains("tag1"));
+
+                // Verify plugin types list
+                List<PluginType> pluginTypes = definitionsService.getTypesByPlugin().get(1L);
+                assertNotNull(pluginTypes);
+                assertEquals(3, pluginTypes.size());
+                assertTrue(pluginTypes.stream().anyMatch(t -> t instanceof ConditionType));
+                assertTrue(pluginTypes.stream().anyMatch(t -> t instanceof ActionType));
+                assertTrue(pluginTypes.stream().anyMatch(t -> t instanceof ValueType));
+            } finally {
+                // Clean up resources
+                closeQuietly(conditionStream);
+                closeQuietly(actionStream);
+                closeQuietly(valueStream);
+            }
+        }
+
+        @Test
+        void shouldHandleMalformedJson() {
+            // given
+            when(bundle.getBundleId()).thenReturn(1L);
+            String malformedJson = "{malformed:json}";
+            InputStream jsonStream = new ByteArrayInputStream(malformedJson.getBytes());
+            when(bundle.findEntries(eq("META-INF/cxs/conditions"), eq("*.json"), eq(true)))
+                .thenReturn(Collections.enumeration(Collections.singletonList(createTestURL(jsonStream))));
+
+            // when
+            definitionsService.processBundleStartup(bundleContext);
+
+            // then
+            // Should not throw exception, but log error and continue
+            List<ConditionType> allConditions = persistenceService.getAllItems(ConditionType.class);
+            assertTrue(allConditions.isEmpty(), "No condition types should be saved");
+            assertTrue(definitionsService.getTypesByPlugin().isEmpty());
+        }
+
+        @Test
+        void shouldHandleConcurrentBundleOperations() throws InterruptedException {
+            int threadCount = 5;
+            CountDownLatch startCompletionLatch = new CountDownLatch(threadCount);
+            ConcurrentTestHelper startHelper = new ConcurrentTestHelper(threadCount);
+            ConcurrentTestHelper stopHelper = new ConcurrentTestHelper(threadCount);
+
+            // First start all bundles
+            for (int i = 0; i < threadCount; i++) {
+                final long bundleId = i;
+
+                startHelper.startThread("BundleStart-" + i, () -> {
+                    Bundle bundle = mock(Bundle.class);
+                    BundleContext context = mock(BundleContext.class);
+                    when(bundle.getBundleId()).thenReturn(bundleId);
+                    when(bundle.getBundleContext()).thenReturn(context);
+                    when(context.getBundle()).thenReturn(bundle);
+
+                    String valueJson = "{\"id\":\"test-value-" + bundleId + "\",\"tags\":[\"tag1\"]}";
+                    try (TestResource resource = new TestResource(valueJson)) {
+                        when(bundle.findEntries(eq("META-INF/cxs/values"), eq("*.json"), eq(true)))
+                            .thenReturn(Collections.enumeration(Collections.singletonList(
+                                createTestURL(resource.getStream()))));
+
+                        definitionsService.processBundleStartup(context);
+                        startCompletionLatch.countDown();
+                    }
+                });
+            }
+
+            // Wait for all starts to complete
+            assertTrue(startCompletionLatch.await(5, TimeUnit.SECONDS), "Timed out waiting for bundle starts");
+            startHelper.executeAndVerify("Bundle start operations", 5);
+
+            // Then stop all bundles
+            for (int i = 0; i < threadCount; i++) {
+                final long bundleId = i;
+                stopHelper.startThread("BundleStop-" + i, () -> {
+                    Bundle bundle = mock(Bundle.class);
+                    BundleContext context = mock(BundleContext.class);
+                    when(bundle.getBundleId()).thenReturn(bundleId);
+                    when(bundle.getBundleContext()).thenReturn(context);
+                    when(context.getBundle()).thenReturn(bundle);
+
+                    definitionsService.processBundleStop(context);
+                });
+            }
+
+            stopHelper.executeAndVerify("Bundle stop operations", 5);
+
+            // Verify final state
+            assertEquals(0, definitionsService.getAllValueTypes().size());
+            assertTrue(definitionsService.getTypesByPlugin().isEmpty());
+        }
+
+        @Test
+        void shouldHandleCrosstenantConcurrentAccess() throws InterruptedException {
+            int threadCount = 5;
+            CyclicBarrier barrier = new CyclicBarrier(threadCount * 2); // Two tenants
+            CountDownLatch endLatch = new CountDownLatch(threadCount * 2);
+            AtomicBoolean failed = new AtomicBoolean(false);
+
+            // Use synchronized mock to avoid race conditions
+            synchronized(tenantService) {
+                for (int i = 0; i < threadCount; i++) {
+                    final int index = i;
+
+                    // System tenant thread
+                    new Thread(() -> {
+                        try {
+                            barrier.await();
+                            executionContextManager.executeAsSystem(() -> {
+                                ConditionType conditionType = createTestConditionType("test" + index, new HashSet<>(Arrays.asList("tag1")), null);
+                                definitionsService.setConditionType(conditionType);
+
+                            });
+                        } catch (Exception e) {
+                            failed.set(true);
+                            LOGGER.error("Thread execution failed", e);
+                        } finally {
+                            endLatch.countDown();
+                        }
+                    }).start();
+
+                    // Custom tenant thread
+                    new Thread(() -> {
+                        try {
+                            barrier.await();
+                            executionContextManager.executeAsTenant("tenant1", () -> {
+                                ConditionType conditionType = createTestConditionType("test" + index + "-tenant", new HashSet<>(Arrays.asList("tag1")), null);
+                                definitionsService.setConditionType(conditionType);
+                            });
+                        } catch (Exception e) {
+                            failed.set(true);
+                            LOGGER.error("Thread execution failed", e);
+                        } finally {
+                            endLatch.countDown();
+                        }
+                    }).start();
+                }
+            }
+
+            assertTrue(endLatch.await(5, TimeUnit.SECONDS), "Test timed out");
+            assertFalse(failed.get(), "One or more threads failed execution");
+
+            // Verify tenant isolation
+            executionContextManager.executeAsSystem(() -> {
+                assertEquals(threadCount, definitionsService.getConditionTypesByTag("tag1").size());
+            });
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                assertEquals(threadCount*2, definitionsService.getConditionTypesByTag("tag1").size());
+            });
+        }
+
+        @Test
+        void shouldHandleTenantRemoval() {
+            // Add types for multiple tenants
+            executionContextManager.executeAsSystem(() -> {
+                ConditionType systemType = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+                definitionsService.setConditionType(systemType);
+            });
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType tenantType = createTestConditionType("test2", new HashSet<>(Arrays.asList("tag1")), null);
+                definitionsService.setConditionType(tenantType);
+            });
+
+            // Simulate tenant removal
+            definitionsService.onTenantRemoved("tenant1");
+
+            // Verify tenant caches are cleared
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                assertEquals(1, definitionsService.getConditionTypesByTag("tag1").size());
+                assertNull(definitionsService.getConditionType("test2"));
+            });
+
+            // Verify system tenant is unaffected
+            executionContextManager.executeAsSystem(() -> {
+                assertFalse(definitionsService.getConditionTypesByTag("tag1").isEmpty());
+                assertNotNull(definitionsService.getConditionType("test1"));
+            });
+        }
+
+        @Test
+        void shouldHandleConcurrentAccessDuringTenantRemoval() throws InterruptedException {
+            int numThreads = 10;
+            ConcurrentTestHelper testHelper = new ConcurrentTestHelper(numThreads);
+
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType tenantType = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+                definitionsService.setConditionType(tenantType);
+            });
+
+            // Create threads that will access the service while tenant is being removed
+            for (int i = 0; i < numThreads; i++) {
+                testHelper.startThread("TenantAccess-" + i, () -> {
+                    try {
+                        executionContextManager.executeAsTenant("tenant1", () -> {
+                            try {
+                                definitionsService.getConditionType("test1");
+                                definitionsService.getConditionTypesByTag("tag1");
+                                Thread.sleep(10); // Simulate some work
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                throw new RuntimeException("Thread interrupted during test", e);
+                            }
+                        });
+                    } catch (Exception e) {
+                        throw new RuntimeException("Error executing in tenant context", e);
+                    }
+                });
+            }
+
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                definitionsService.onTenantRemoved("tenant1");
+                try {
+                    testHelper.executeAndVerify("Tenant removal test", 5);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+
+                assertTrue(definitionsService.getConditionTypesByTag("tag1").isEmpty());
+                assertNull(definitionsService.getConditionType("test1"));
+            });
+        }
+
+        @Test
+        void shouldPreventSystemTenantRemoval() {
+            // Try to remove system tenant
+            definitionsService.onTenantRemoved(SYSTEM_TENANT);
+
+            // Verify system tenant data is still accessible
+            executionContextManager.executeAsSystem(() -> {
+                ConditionType systemType = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+                definitionsService.setConditionType(systemType);
+            });
+
+            assertNotNull(definitionsService.getConditionType("test1"));
+            assertFalse(definitionsService.getConditionTypesByTag("tag1").isEmpty());
+        }
+
+        @Test
+        void shouldHandleNullTagAccess() {
+            // Test with null tag
+            assertTrue(definitionsService.getValueTypeByTag(null).isEmpty());
+            assertTrue(definitionsService.getConditionTypesByTag(null).isEmpty());
+            assertTrue(definitionsService.getActionTypeByTag(null).isEmpty());
+
+            // Test with null tags collection
+            ValueType valueType = createTestValueType("test1", null, null);
+            definitionsService.setValueType(valueType);
+            assertNotNull(definitionsService.getValueType("test1"));
+        }
+
+        @Test
+        void shouldHandleBundleStop() {
+            // given
+            Long bundleId = 1L;
+            setupMockBundle(bundleId);
+            executionContextManager.executeAsSystem(() -> {
+                // Add all types of definitions
+                ValueType valueType = createTestValueType("test1", new HashSet<>(Arrays.asList("tag1")), bundleId);
+                ConditionType conditionType = createTestConditionType("test2", new HashSet<>(Arrays.asList("tag1")), bundleId);
+                ActionType actionType = createTestActionType("test3", new HashSet<>(Arrays.asList("tag1")), bundleId);
+
+                registerPluginType(valueType, bundleId);
+                registerPluginType(conditionType, bundleId);
+                registerPluginType(actionType, bundleId);
+            });
+
+            // when
+            definitionsService.processBundleStop(bundleContext);
+
+            // then
+            assertNull(definitionsService.getValueType("test1"));
+            assertNull(definitionsService.getConditionType("test2"));
+            assertNull(definitionsService.getActionType("test3"));
+            assertTrue(definitionsService.getValueTypeByTag("tag1").isEmpty());
+            assertTrue(definitionsService.getConditionTypesByTag("tag1").isEmpty());
+            assertTrue(definitionsService.getActionTypeByTag("tag1").isEmpty());
+
+            // Verify plugin types are removed
+            assertNull(definitionsService.getTypesByPlugin().get(bundleId));
+        }
+
+        @Test
+        void shouldInvalidateCachesOnBundleStop() {
+            // Add types from multiple bundles
+            Long bundleId1 = 1L;
+            Long bundleId2 = 2L;
+            executionContextManager.executeAsSystem(() -> {
+                ValueType valueType1 = createTestValueType("test1", new HashSet<>(Arrays.asList("tag1")), bundleId1);
+                registerPluginType(valueType1, bundleId1);
+
+                ValueType valueType2 = createTestValueType("test2", new HashSet<>(Arrays.asList("tag1")), bundleId2);
+                registerPluginType(valueType2, bundleId2);
+
+                // Stop one bundle
+                setupMockBundle(bundleId1);
+                definitionsService.processBundleStop(bundleContext);
+
+                // Verify only its types are removed
+                assertNull(definitionsService.getValueType("test1"));
+                assertNotNull(definitionsService.getValueType("test2"));
+
+                // Verify tag cache consistency
+                Set<ValueType> taggedTypes = definitionsService.getValueTypeByTag("tag1");
+                assertEquals(1, taggedTypes.size());
+                assertTrue(taggedTypes.contains(valueType2));
+            });
+        }
+
+        @Test
+        void shouldHandleValueTypeInheritance() {
+            // Create system tenant value type
+            ValueType valueType = new ValueType();
+            valueType.setId("test");
+            valueType.setTags(Collections.singleton("testTag"));
+
+            // Add to system tenant cache
+            executionContextManager.executeAsSystem(() -> {
+                definitionsService.setValueType(valueType);
+            });
+
+            // Switch to different tenant and verify inheritance
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ValueType result = definitionsService.getValueType("test");
+                assertNotNull(result);
+                assertEquals("test", result.getId());
+
+                // Second lookup should use cache
+                result = definitionsService.getValueType("test");
+                assertNotNull(result);
+                assertEquals("test", result.getId());
+            });
+        }
+
+        @Test
+        void shouldHandleConditionTypeMetadata() {
+            // Create condition type with metadata
+            ConditionType conditionType = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+            Metadata metadata = new Metadata();
+            metadata.setId("test1");
+            metadata.setName("Test Condition");
+            metadata.setDescription("Test Description");
+            metadata.setSystemTags(new HashSet<>(Arrays.asList("systemTag1")));
+            conditionType.setMetadata(metadata);
+
+            // Save and retrieve
+            definitionsService.setConditionType(conditionType);
+            ConditionType retrieved = definitionsService.getConditionType("test1");
+
+            // Verify metadata
+            assertNotNull(retrieved);
+            assertEquals("Test Condition", retrieved.getMetadata().getName());
+            assertEquals("Test Description", retrieved.getMetadata().getDescription());
+            assertTrue(retrieved.getMetadata().getSystemTags().contains("systemTag1"));
+
+            // Verify system tag lookup
+            assertTrue(definitionsService.getConditionTypesBySystemTag("systemTag1").contains(retrieved));
+        }
+
+        @Test
+        void shouldHandleActionTypeConcurrentAccess() throws InterruptedException {
+            int threadCount = 10;
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            CountDownLatch endLatch = new CountDownLatch(threadCount);
+            Set<String> expectedTags = new HashSet<>();
+            Set<String> expectedIds = new HashSet<>();
+
+            for (int i = 0; i < threadCount; i++) {
+                final int index = i;
+                String tag = "tag" + index;
+                String id = "test" + index;
+                expectedTags.add(tag);
+                expectedIds.add(id);
+
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        executionContextManager.executeAsTenant("test-tenant", () -> {
+                            ActionType actionType = createTestActionType(id, new HashSet<>(Arrays.asList(tag)), null);
+                            definitionsService.setActionType(actionType);
+                        });
+                    } catch (Exception e) {
+                        fail("Thread execution failed: " + e.getMessage());
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }).start();
+            }
+
+            assertTrue(endLatch.await(5, TimeUnit.SECONDS));
+
+            executionContextManager.executeAsTenant("test-tenant", () -> {
+                // Verify all types were saved
+                Collection<ActionType> allTypes = definitionsService.getAllActionTypes();
+                assertEquals(threadCount, allTypes.size());
+
+                // Verify all tags are present
+                for (String tag : expectedTags) {
+                    Set<ActionType> taggedTypes = definitionsService.getActionTypeByTag(tag);
+                    assertEquals(1, taggedTypes.size());
+                    ActionType taggedType = taggedTypes.iterator().next();
+                    assertTrue(taggedType.getMetadata().getTags().contains(tag));
+                }
+            });
+        }
+
+        @Test
+        void shouldMaintainTagCacheConsistency() {
+            // given
+            executionContextManager.executeAsTenant("tenant1", () -> {
+
+                // Add type with tags
+                ConditionType type1 = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1", "tag2")), null);
+                definitionsService.setConditionType(type1);
+
+            // Verify initial state
+            assertEquals(1, definitionsService.getConditionTypesByTag("tag1").size());
+            assertEquals(1, definitionsService.getConditionTypesByTag("tag2").size());
+
+            // Update tags
+            type1.getMetadata().setTags(new HashSet<>(Arrays.asList("tag2", "tag3")));
+            definitionsService.setConditionType(type1);
+
+            // Verify tag cache updates
+            assertTrue(definitionsService.getConditionTypesByTag("tag1").isEmpty());
+            assertEquals(1, definitionsService.getConditionTypesByTag("tag2").size());
+            assertEquals(1, definitionsService.getConditionTypesByTag("tag3").size());
+
+            // Remove type
+            definitionsService.removeConditionType("test1");
+
+            // Verify all tag caches are clean
+            assertTrue(definitionsService.getConditionTypesByTag("tag2").isEmpty());
+            assertTrue(definitionsService.getConditionTypesByTag("tag3").isEmpty());
+            });
+        }
+
+        @Test
+        void shouldHandleErrorsInJsonLoading() {
+            // given
+            when(bundle.getBundleId()).thenReturn(1L);
+            when(bundleContext.getBundle()).thenReturn(bundle);
+
+            // Malformed condition JSON
+            String malformedConditionJson = "{bad json}";
+            InputStream conditionStream = new ByteArrayInputStream(malformedConditionJson.getBytes());
+            when(bundle.findEntries(eq("META-INF/cxs/conditions"), eq("*.json"), eq(true)))
+                .thenReturn(Collections.enumeration(Collections.singletonList(createTestURL(conditionStream))));
+
+            // Malformed action JSON
+            String malformedActionJson = "{also bad}";
+            InputStream actionStream = new ByteArrayInputStream(malformedActionJson.getBytes());
+            when(bundle.findEntries(eq("META-INF/cxs/actions"), eq("*.json"), eq(true)))
+                .thenReturn(Collections.enumeration(Collections.singletonList(createTestURL(actionStream))));
+
+            // Valid value type JSON
+            String valueJson = "{\"id\":\"test-value\",\"tags\":[\"tag1\"]}";
+            InputStream valueStream = new ByteArrayInputStream(valueJson.getBytes());
+            when(bundle.findEntries(eq("META-INF/cxs/values"), eq("*.json"), eq(true)))
+                .thenReturn(Collections.enumeration(Collections.singletonList(createTestURL(valueStream))));
+
+            // when
+            definitionsService.processBundleStartup(bundleContext);
+
+            // then
+
+            // Should still load valid value type
+            ValueType valueType = definitionsService.getValueType("test-value");
+            assertNotNull(valueType);
+            assertTrue(valueType.getTags().contains("tag1"));
+        }
+
+        @Test
+        void shouldPreserveSystemTenantOnTenantRemoval() {
+            // Add system tenant types
+            final ConditionType[] systemType = new ConditionType[1];
+            executionContextManager.executeAsSystem(() -> {
+                systemType[0] = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+                definitionsService.setConditionType(systemType[0]);
+            });
+
+            // Add custom tenant types
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType tenantType = createTestConditionType("test2", new HashSet<>(Arrays.asList("tag1")), null);
+                definitionsService.setConditionType(tenantType);
+            });
+
+            // Remove tenant
+            definitionsService.onTenantRemoved("tenant1");
+
+            // Verify tenant caches are cleared
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                assertEquals(1, definitionsService.getConditionTypesByTag("tag1").size());
+                assertNull(definitionsService.getConditionType("test2"));
+            });
+
+            // Verify system tenant is unaffected
+            executionContextManager.executeAsSystem(() -> {
+                Set<ConditionType> systemTypes = definitionsService.getConditionTypesByTag("tag1");
+                assertEquals(1, systemTypes.size());
+                assertTrue(systemTypes.contains(systemType[0]));
+                assertEquals(systemType[0], definitionsService.getConditionType("test1"));
+            });
+        }
+
+        @Test
+        void shouldHandleResourceCleanup() {
+            // given
+            when(bundle.getBundleId()).thenReturn(1L);
+            when(bundleContext.getBundle()).thenReturn(bundle);
+
+            // Create a stream that tracks if it was closed
+            final AtomicBoolean streamClosed = new AtomicBoolean(false);
+            InputStream jsonStream = new ByteArrayInputStream("{\"id\":\"test\"}".getBytes()) {
+                @Override
+                public void close() throws IOException {
+                    super.close();
+                    streamClosed.set(true);
+                }
+            };
+
+            try {
+                when(bundle.findEntries(eq("META-INF/cxs/values"), eq("*.json"), eq(true)))
+                    .thenReturn(Collections.enumeration(Collections.singletonList(createTestURL(jsonStream))));
+
+                // when
+                definitionsService.processBundleStartup(bundleContext);
+
+                // then
+                assertTrue(streamClosed.get(), "Stream should be closed after reading");
+            } finally {
+                // Ensure stream is closed even if test fails
+                try {
+                    jsonStream.close();
+                } catch (IOException e) {
+                    LOGGER.error("Error closing test stream", e);
+                }
+            }
+        }
+
+        @Test
+        void shouldHandleInheritanceForAllTypes() {
+            // Create system tenant types
+            final ConditionType[] conditionType = new ConditionType[1];
+            final ActionType[] actionType = new ActionType[1];
+            final ValueType[] valueType = new ValueType[1];
+
+            executionContextManager.executeAsSystem(() -> {
+                conditionType[0] = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+                definitionsService.setConditionType(conditionType[0]);
+            });
+            executionContextManager.executeAsSystem(() -> {
+                actionType[0] = createTestActionType("test2", new HashSet<>(Arrays.asList("tag1")), null);
+                definitionsService.setActionType(actionType[0]);
+            });
+            executionContextManager.executeAsSystem(() -> {
+                valueType[0] = createTestValueType("test3", new HashSet<>(Arrays.asList("tag1")), null);
+                definitionsService.setValueType(valueType[0]);
+            });
+
+            // Switch to custom tenant
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                // Verify inheritance for condition types
+                assertEquals(conditionType[0], definitionsService.getConditionType("test1"));
+                assertTrue(definitionsService.getConditionTypesByTag("tag1").contains(conditionType[0]));
+
+                // Verify inheritance for action types
+                assertEquals(actionType[0], definitionsService.getActionType("test2"));
+                assertTrue(definitionsService.getActionTypeByTag("tag1").contains(actionType[0]));
+
+                // Verify inheritance for value types
+                assertEquals(valueType[0], definitionsService.getValueType("test3"));
+                assertTrue(definitionsService.getValueTypeByTag("tag1").contains(valueType[0]));
+
+                // Verify items were saved in persistence service
+                ConditionType savedCondition = definitionsService.getConditionType("test1");
+                ActionType savedAction = definitionsService.getActionType("test2");
+                assertNotNull(savedCondition, "Condition type should be saved");
+                assertNotNull(savedAction, "Action type should be saved");
+                assertEquals(SYSTEM_TENANT, savedCondition.getTenantId());
+                assertEquals(SYSTEM_TENANT, savedAction.getTenantId());
+            });
+        }
+
+        @Test
+        void shouldHandleConcurrentTenantAccess() throws InterruptedException {
+            int threadCount = 5;
+            CyclicBarrier barrier = new CyclicBarrier(threadCount * 2); // Two tenants
+            CountDownLatch endLatch = new CountDownLatch(threadCount * 2);
+            AtomicBoolean failed = new AtomicBoolean(false);
+
+            for (int i = 0; i < threadCount; i++) {
+                final int index = i;
+
+                // System tenant thread
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                            ConditionType conditionType = createTestConditionType("test" + index, new HashSet<>(Arrays.asList("tag1")), null);
+                            definitionsService.setConditionType(conditionType);
+                        });
+                    } catch (Exception e) {
+                        failed.set(true);
+                        LOGGER.error("Thread execution failed", e);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }).start();
+
+                // Custom tenant thread
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        executionContextManager.executeAsTenant("tenant1", () -> {
+                            ConditionType conditionType = createTestConditionType("test" + index + "-tenant", new HashSet<>(Arrays.asList("tag1")), null);
+                            definitionsService.setConditionType(conditionType);
+                        });
+                    } catch (Exception e) {
+                        failed.set(true);
+                        LOGGER.error("Thread execution failed", e);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }).start();
+            }
+
+            assertTrue(endLatch.await(5, TimeUnit.SECONDS), "Test timed out");
+            assertFalse(failed.get(), "One or more threads failed execution");
+
+            // Verify tenant isolation
+            executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                assertEquals(threadCount, definitionsService.getConditionTypesByTag("tag1").size());
+            });
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                assertEquals(threadCount*2 /* Because of inheritance */, definitionsService.getConditionTypesByTag("tag1").size());
+            });
+        }
+
+        @Test
+        void shouldHandleTenantLifecycle() {
+            // Setup system tenant data
+            final ConditionType[] systemConditionType = new ConditionType[1];
+            final ActionType[] systemActionType = new ActionType[1];
+
+            executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                systemConditionType[0] = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+                systemConditionType[0].setTenantId(SYSTEM_TENANT);
+                definitionsService.setConditionType(systemConditionType[0]);
+
+                systemActionType[0] = createTestActionType("test2", new HashSet<>(Arrays.asList("tag1")), null);
+                systemActionType[0].setTenantId(SYSTEM_TENANT);
+                definitionsService.setActionType(systemActionType[0]);
+            });
+
+            // Setup tenant data
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType tenantConditionType = createTestConditionType("test4", new HashSet<>(Arrays.asList("tag2")), null);
+                tenantConditionType.setTenantId("tenant1");
+                definitionsService.setConditionType(tenantConditionType);
+
+                ActionType tenantActionType = createTestActionType("test5", new HashSet<>(Arrays.asList("tag2")), null);
+                tenantActionType.setTenantId("tenant1");
+                definitionsService.setActionType(tenantActionType);
+
+                // Verify tenant data
+                assertEquals(tenantConditionType, definitionsService.getConditionType("test4"));
+                assertEquals(tenantActionType, definitionsService.getActionType("test5"));
+                assertTrue(definitionsService.getConditionTypesByTag("tag2").contains(tenantConditionType));
+                assertTrue(definitionsService.getActionTypeByTag("tag2").contains(tenantActionType));
+
+                // Verify system tenant data is accessible
+                assertNotNull(definitionsService.getConditionType("test1"));
+                assertNotNull(definitionsService.getActionType("test2"));
+
+                // Test tenant removal
+                definitionsService.onTenantRemoved("tenant1");
+
+                // Verify tenant data is removed
+                assertNull(definitionsService.getConditionType("test4"));
+                assertNull(definitionsService.getActionType("test5"));
+                assertTrue(definitionsService.getConditionTypesByTag("tag2").isEmpty());
+                assertTrue(definitionsService.getActionTypeByTag("tag2").isEmpty());
+            });
+
+            // Verify system tenant data is preserved
+            executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                assertEquals(systemConditionType[0], definitionsService.getConditionType("test1"));
+                assertEquals(systemActionType[0], definitionsService.getActionType("test2"));
+            });
+        }
+
+        @Test
+        void shouldHandleConcurrentAccess() throws InterruptedException {
+            int numThreads = 10;
+            ConcurrentTestHelper testHelper = new ConcurrentTestHelper(numThreads);
+
+            // Setup initial data
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType tenantType = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+                definitionsService.setConditionType(tenantType);
+            });
+
+            // Create threads that will access the service while tenant is being removed
+            for (int i = 0; i < numThreads; i++) {
+                testHelper.startThread("TenantAccess-" + i, () -> {
+                    try {
+                        executionContextManager.executeAsTenant("tenant1", () -> {
+                            try {
+                                definitionsService.getConditionType("test1");
+                                definitionsService.getConditionTypesByTag("tag1");
+                                Thread.sleep(10); // Simulate some work
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                throw new RuntimeException("Thread interrupted during test", e);
+                            }
+                        });
+                    } catch (Exception e) {
+                        throw new RuntimeException("Error executing in tenant context", e);
+                    }
+                });
+            }
+
+            try {
+                definitionsService.onTenantRemoved("tenant1");
+                testHelper.executeAndVerify("Tenant removal test", 5);
+
+                // Verify tenant was properly removed
+                executionContextManager.executeAsTenant("tenant1", () -> {
+                    assertTrue(definitionsService.getConditionTypesByTag("tag1").isEmpty());
+                    assertNull(definitionsService.getConditionType("test1"));
+                });
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw e;
+            }
+        }
+
+        @Test
+        void shouldPreferTenantSpecificTypes() {
+            // Create system tenant types
+            final ConditionType[] systemConditionType = new ConditionType[1];
+            final ActionType[] systemActionType = new ActionType[1];
+            final ValueType[] systemValueType = new ValueType[1];
+
+            executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                systemConditionType[0] = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+                systemConditionType[0].setTenantId(SYSTEM_TENANT);
+                definitionsService.setConditionType(systemConditionType[0]);
+
+                systemActionType[0] = createTestActionType("test2", new HashSet<>(Arrays.asList("tag1")), null);
+                systemActionType[0].setTenantId(SYSTEM_TENANT);
+                definitionsService.setActionType(systemActionType[0]);
+
+                systemValueType[0] = createTestValueType("test3", new HashSet<>(Arrays.asList("tag1")), null);
+                definitionsService.setValueType(systemValueType[0]);
+            });
+
+            // Create tenant-specific types with same IDs but different tags
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType tenantConditionType = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag2")), null);
+                tenantConditionType.setTenantId("tenant1");
+                definitionsService.setConditionType(tenantConditionType);
+
+                ActionType tenantActionType = createTestActionType("test2", new HashSet<>(Arrays.asList("tag2")), null);
+                tenantActionType.setTenantId("tenant1");
+                definitionsService.setActionType(tenantActionType);
+
+                ValueType tenantValueType = createTestValueType("test3", new HashSet<>(Arrays.asList("tag2")), null);
+                definitionsService.setValueType(tenantValueType);
+
+                // Verify that tenant-specific types are returned
+                assertEquals(tenantConditionType, definitionsService.getConditionType("test1"));
+                assertEquals(tenantActionType, definitionsService.getActionType("test2"));
+                assertEquals(tenantValueType, definitionsService.getValueType("test3"));
+
+                // Verify that only tenant-specific tags are returned
+                assertTrue(definitionsService.getConditionTypesByTag("tag2").contains(tenantConditionType));
+                assertTrue(definitionsService.getConditionTypesByTag("tag1").contains(systemConditionType[0]));
+
+                assertTrue(definitionsService.getActionTypeByTag("tag2").contains(tenantActionType));
+                assertTrue(definitionsService.getActionTypeByTag("tag1").contains(systemActionType[0]));
+
+                assertTrue(definitionsService.getValueTypeByTag("tag2").contains(tenantValueType));
+                assertTrue(definitionsService.getValueTypeByTag("tag1").contains(systemValueType[0]));
+            });
+        }
+
+        @Test
+        void shouldHandleTypeRemovalWithInheritance() {
+            // Create system tenant types
+            final ConditionType[] systemConditionType = new ConditionType[1];
+            final ActionType[] systemActionType = new ActionType[1];
+            final ValueType[] systemValueType = new ValueType[1];
+
+            executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                systemConditionType[0] = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+                systemConditionType[0].setTenantId(SYSTEM_TENANT);
+                definitionsService.setConditionType(systemConditionType[0]);
+                // Verify system tenant type was saved
+                assertEquals(systemConditionType[0], definitionsService.getConditionType("test1"));
+
+                systemActionType[0] = createTestActionType("test2", new HashSet<>(Arrays.asList("tag1")), null);
+                systemActionType[0].setTenantId(SYSTEM_TENANT);
+                definitionsService.setActionType(systemActionType[0]);
+                // Verify system tenant type was saved
+                assertEquals(systemActionType[0], definitionsService.getActionType("test2"));
+
+                systemValueType[0] = createTestValueType("test3", new HashSet<>(Arrays.asList("tag1")), null);
+                definitionsService.setValueType(systemValueType[0]);
+                // Verify system tenant type was saved
+                assertEquals(systemValueType[0], definitionsService.getValueType("test3"));
+            });
+
+            // Create tenant-specific types with same IDs
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType tenantConditionType = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag2")), null);
+                tenantConditionType.setTenantId("tenant1");
+                definitionsService.setConditionType(tenantConditionType);
+
+                ActionType tenantActionType = createTestActionType("test2", new HashSet<>(Arrays.asList("tag2")), null);
+                tenantActionType.setTenantId("tenant1");
+                definitionsService.setActionType(tenantActionType);
+
+                ValueType tenantValueType = createTestValueType("test3", new HashSet<>(Arrays.asList("tag2")), null);
+                definitionsService.setValueType(tenantValueType);
+
+                // Verify initial state
+                assertEquals(tenantConditionType, definitionsService.getConditionType("test1"));
+                assertEquals(tenantActionType, definitionsService.getActionType("test2"));
+                assertEquals(tenantValueType, definitionsService.getValueType("test3"));
+
+                // Remove tenant-specific types
+                definitionsService.removeConditionType("test1");
+                definitionsService.removeActionType("test2");
+                definitionsService.removeValueType("test3");
+
+                // Verify tenant-specific types are removed but system types are still accessible
+                assertEquals(systemConditionType[0], definitionsService.getConditionType("test1"));
+                assertEquals(systemActionType[0], definitionsService.getActionType("test2"));
+                assertEquals(systemValueType[0], definitionsService.getValueType("test3"));
+
+                // Verify tag-based queries
+                assertFalse(definitionsService.getConditionTypesByTag("tag2").contains(tenantConditionType));
+                assertFalse(definitionsService.getActionTypeByTag("tag2").contains(tenantActionType));
+                assertFalse(definitionsService.getValueTypeByTag("tag2").contains(tenantValueType));
+
+                assertTrue(definitionsService.getConditionTypesByTag("tag1").contains(systemConditionType[0]));
+                assertTrue(definitionsService.getActionTypeByTag("tag1").contains(systemActionType[0]));
+                assertTrue(definitionsService.getValueTypeByTag("tag1").contains(systemValueType[0]));
+            });
+
+            // Switch to system tenant and verify types still exist
+            executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                assertEquals(systemConditionType[0], definitionsService.getConditionType("test1"));
+                assertEquals(systemActionType[0], definitionsService.getActionType("test2"));
+                assertEquals(systemValueType[0], definitionsService.getValueType("test3"));
+            });
+        }
+
+        @Test
+        void shouldHandleBundleTypeRemovalWithInheritance() {
+            // Create system tenant types from a bundle
+            Long bundleId = 1L;
+            setupMockBundle(bundleId);
+
+            executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                ConditionType systemConditionType = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), bundleId);
+                systemConditionType.setTenantId(SYSTEM_TENANT);
+                registerPluginType(systemConditionType, bundleId);
+
+                ActionType systemActionType = createTestActionType("test2", new HashSet<>(Arrays.asList("tag1")), bundleId);
+                systemActionType.setTenantId(SYSTEM_TENANT);
+                registerPluginType(systemActionType, bundleId);
+
+                ValueType systemValueType = createTestValueType("test3", new HashSet<>(Arrays.asList("tag1")), bundleId);
+                registerPluginType(systemValueType, bundleId);
+            });
+
+            // Create tenant-specific overrides
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType tenantConditionType = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag2")), null);
+                tenantConditionType.setTenantId("tenant1");
+                definitionsService.setConditionType(tenantConditionType);
+
+                ActionType tenantActionType = createTestActionType("test2", new HashSet<>(Arrays.asList("tag2")), null);
+                tenantActionType.setTenantId("tenant1");
+                definitionsService.setActionType(tenantActionType);
+
+                ValueType tenantValueType = createTestValueType("test3", new HashSet<>(Arrays.asList("tag2")), null);
+                definitionsService.setValueType(tenantValueType);
+
+                // Stop the bundle, this should remove the system types
+                definitionsService.processBundleStop(bundleContext);
+
+                // Verify tenant-specific types are still available
+                assertEquals(tenantConditionType, definitionsService.getConditionType("test1"));
+                assertEquals(tenantActionType, definitionsService.getActionType("test2"));
+                assertEquals(tenantValueType, definitionsService.getValueType("test3"));
+
+                // Remove tenant-specific types
+                definitionsService.removeConditionType("test1");
+                definitionsService.removeActionType("test2");
+                definitionsService.removeValueType("test3");
+
+                // Verify all types are now gone (system types were removed by bundle stop)
+                assertNull(definitionsService.getConditionType("test1"));
+                assertNull(definitionsService.getActionType("test2"));
+                assertNull(definitionsService.getValueType("test3"));
+
+                assertTrue(definitionsService.getConditionTypesByTag("tag1").isEmpty());
+                assertTrue(definitionsService.getActionTypeByTag("tag1").isEmpty());
+                assertTrue(definitionsService.getValueTypeByTag("tag1").isEmpty());
+                assertTrue(definitionsService.getConditionTypesByTag("tag2").isEmpty());
+                assertTrue(definitionsService.getActionTypeByTag("tag2").isEmpty());
+                assertTrue(definitionsService.getValueTypeByTag("tag2").isEmpty());
+            });
+        }
+    }
+
+    @Nested
+    class ValueTypeTests {
+        @Test
+        void shouldManageValueTypes() {
+            // given
+            ValueType valueType = createTestValueType("test1", new HashSet<>(Arrays.asList("tag1", "tag2")), null);
+
+            // when
+            definitionsService.setValueType(valueType);
+
+            // then
+            assertEquals(valueType, definitionsService.getValueType("test1"));
+            assertTrue(definitionsService.getValueTypeByTag("tag1").contains(valueType));
+            assertTrue(definitionsService.getValueTypeByTag("tag2").contains(valueType));
+
+            // when removing
+            definitionsService.removeValueType("test1");
+
+            // then
+            assertNull(definitionsService.getValueType("test1"));
+            assertTrue(definitionsService.getValueTypeByTag("tag1").isEmpty());
+            assertTrue(definitionsService.getValueTypeByTag("tag2").isEmpty());
+
+        }
+
+        @Test
+        void shouldGetAllValueTypes() {
+            // given
+            ValueType valueType1 = createTestValueType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+            ValueType valueType2 = createTestValueType("test2", new HashSet<>(Arrays.asList("tag2")), null);
+            definitionsService.setValueType(valueType1);
+            definitionsService.setValueType(valueType2);
+
+            // when
+            Collection<ValueType> allTypes = definitionsService.getAllValueTypes();
+
+            // then
+            assertEquals(2, allTypes.size());
+            assertTrue(allTypes.contains(valueType1));
+            assertTrue(allTypes.contains(valueType2));
+
+        }
+
+        @Test
+        void shouldHandleNullTags() {
+            ValueType valueType = createTestValueType("test1", null, null);
+            definitionsService.setValueType(valueType);
+            assertNotNull(definitionsService.getValueType("test1"));
+        }
+
+        @Test
+        void shouldHandleEmptyTags() {
+            ValueType valueType = createTestValueType("test1", Collections.emptySet(), null);
+            definitionsService.setValueType(valueType);
+            assertNotNull(definitionsService.getValueType("test1"));
+        }
+
+        @Test
+        void shouldHandleConcurrentAccess() throws InterruptedException {
+            int threadCount = 10;
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            CountDownLatch endLatch = new CountDownLatch(threadCount);
+            Set<String> expectedTags = new HashSet<>();
+            Set<String> expectedIds = new HashSet<>();
+
+            for (int i = 0; i < threadCount; i++) {
+                final int index = i;
+                String tag = "tag" + index;
+                String id = "test" + index;
+                expectedTags.add(tag);
+                expectedIds.add(id);
+
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        executionContextManager.executeAsTenant("test-tenant", () -> {
+                            ValueType valueType = createTestValueType(id, new HashSet<>(Arrays.asList(tag)), null);
+                            definitionsService.setValueType(valueType);
+                        });
+                    } catch (Exception e) {
+                        fail("Thread execution failed: " + e.getMessage());
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }).start();
+            }
+
+            assertTrue(endLatch.await(5, TimeUnit.SECONDS));
+
+            executionContextManager.executeAsTenant("test-tenant", () -> {
+                // Verify all types were saved in memory
+                Collection<ValueType> allTypes = definitionsService.getAllValueTypes();
+                assertEquals(threadCount, allTypes.size());
+
+                // Verify all tags are present
+                Set<String> actualTags = new HashSet<>();
+                Set<String> actualIds = new HashSet<>();
+                for (ValueType type : allTypes) {
+                    actualIds.add(type.getId());
+                    actualTags.addAll(type.getTags());
+                }
+                assertEquals(expectedTags, actualTags);
+                assertEquals(expectedIds, actualIds);
+
+                // Verify tag cache consistency
+                for (String tag : expectedTags) {
+                    Set<ValueType> taggedTypes = definitionsService.getValueTypeByTag(tag);
+                    assertEquals(1, taggedTypes.size());
+                    ValueType taggedType = taggedTypes.iterator().next();
+                    assertTrue(taggedType.getTags().contains(tag));
+                }
+            });
+        }
+    }
+
+    @Nested
+    class ConditionTypeTests {
+        @Test
+        void shouldManageConditionTypes() {
+            // given
+            ConditionType conditionType = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1", "tag2")), null);
+
+            // when
+            definitionsService.setConditionType(conditionType);
+
+            // then
+            assertEquals(conditionType, definitionsService.getConditionType("test1"));
+            assertTrue(definitionsService.getConditionTypesByTag("tag1").contains(conditionType));
+            assertTrue(definitionsService.getConditionTypesByTag("tag2").contains(conditionType));
+
+            // when removing
+            definitionsService.removeConditionType("test1");
+
+            // then
+            assertNull(definitionsService.getConditionType("test1"));
+            assertTrue(definitionsService.getConditionTypesByTag("tag1").isEmpty());
+            assertTrue(definitionsService.getConditionTypesByTag("tag2").isEmpty());
+        }
+
+        @Test
+        void shouldGetAllConditionTypes() {
+            // given
+            ConditionType type1 = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+            ConditionType type2 = createTestConditionType("test2", new HashSet<>(Arrays.asList("tag2")), null);
+            definitionsService.setConditionType(type1);
+            definitionsService.setConditionType(type2);
+
+            // when
+            Collection<ConditionType> allTypes = definitionsService.getAllConditionTypes();
+
+            // then
+            assertEquals(2, allTypes.size());
+            assertTrue(allTypes.contains(type1));
+            assertTrue(allTypes.contains(type2));
+        }
+
+        @Test
+        void shouldHandleConcurrentAccess() throws InterruptedException {
+            int threadCount = 10;
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            CountDownLatch endLatch = new CountDownLatch(threadCount);
+            Set<String> expectedTags = new HashSet<>();
+            Set<String> expectedIds = new HashSet<>();
+
+            for (int i = 0; i < threadCount; i++) {
+                final int index = i;
+                String tag = "tag" + index;
+                String id = "test" + index;
+                expectedTags.add(tag);
+                expectedIds.add(id);
+
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        executionContextManager.executeAsTenant("test-tenant", () -> {
+                            ConditionType conditionType = createTestConditionType(id, new HashSet<>(Arrays.asList(tag)), null);
+                            definitionsService.setConditionType(conditionType);
+                        });
+                    } catch (Exception e) {
+                        fail("Thread execution failed: " + e.getMessage());
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }).start();
+            }
+
+            assertTrue(endLatch.await(10, TimeUnit.SECONDS));
+
+            executionContextManager.executeAsTenant("test-tenant", () -> {
+                // Verify all types were saved
+                Collection<ConditionType> allTypes = definitionsService.getAllConditionTypes();
+                assertEquals(threadCount, allTypes.size());
+
+                // Verify all tags are present
+                for (String tag : expectedTags) {
+                    Set<ConditionType> taggedTypes = definitionsService.getConditionTypesByTag(tag);
+                    assertEquals(1, taggedTypes.size());
+                    ConditionType taggedType = taggedTypes.iterator().next();
+                    assertTrue(taggedType.getMetadata().getTags().contains(tag));
+                }
+            });
+
+        }
+    }
+
+    @Nested
+    class ActionTypeTests {
+        @Test
+        void shouldManageActionTypes() {
+            executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                // given
+                ActionType actionType = createTestActionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+
+                // when
+                definitionsService.setActionType(actionType);
+
+                // then
+                assertEquals(actionType, definitionsService.getActionType("test1"));
+                assertTrue(definitionsService.getActionTypeByTag("tag1").contains(actionType));
+
+                // when removing
+                definitionsService.removeActionType("test1");
+
+                // then
+                assertNull(persistenceService.load("test1", ActionType.class), "Action type should be removed");
+                assertTrue(definitionsService.getActionTypeByTag("tag1").isEmpty());
+            });
+        }
+
+        @Test
+        void shouldGetAllActionTypes() {
+            // given
+            ActionType type1 = createTestActionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+            ActionType type2 = createTestActionType("test2", new HashSet<>(Arrays.asList("tag2")), null);
+            definitionsService.setActionType(type1);
+            definitionsService.setActionType(type2);
+
+            // when
+            Collection<ActionType> allTypes = definitionsService.getAllActionTypes();
+
+            // then
+            assertEquals(2, allTypes.size());
+            assertTrue(allTypes.contains(type1));
+            assertTrue(allTypes.contains(type2));
+        }
+    }
+
+    @Nested
+    class PropertyMergeStrategyTypeTests {
+        @Test
+        void shouldManagePropertyMergeStrategyTypes() {
+            // given
+            PropertyMergeStrategyType type = createTestPropertyMergeStrategyType("test1", null);
+
+            // when
+            definitionsService.setPropertyMergeStrategyType(type);
+
+            // then
+            assertEquals(type, definitionsService.getPropertyMergeStrategyType("test1"));
+
+            // when removing
+            definitionsService.removePropertyMergeStrategyType("test1");
+
+            // then
+            assertNull(definitionsService.getPropertyMergeStrategyType("test1"));
+        }
+    }
+
+    @Nested
+    class TenantAwarenessTests {
+        @Test
+        void shouldHandleTenantLifecycle() {
+            // Setup system tenant data
+            final ConditionType[] systemConditionType = new ConditionType[1];
+            final ActionType[] systemActionType = new ActionType[1];
+
+            executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                systemConditionType[0] = createTestConditionType("test1", new HashSet<>(Arrays.asList("tag1")), null);
+                systemConditionType[0].setTenantId(SYSTEM_TENANT);
+                definitionsService.setConditionType(systemConditionType[0]);
+
+                systemActionType[0] = createTestActionType("test2", new HashSet<>(Arrays.asList("tag1")), null);
+                systemActionType[0].setTenantId(SYSTEM_TENANT);
+                definitionsService.setActionType(systemActionType[0]);
+            });
+
+            // Setup tenant data
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType tenantConditionType = createTestConditionType("test4", new HashSet<>(Arrays.asList("tag2")), null);
+                tenantConditionType.setTenantId("tenant1");
+                definitionsService.setConditionType(tenantConditionType);
+
+                ActionType tenantActionType = createTestActionType("test5", new HashSet<>(Arrays.asList("tag2")), null);
+                tenantActionType.setTenantId("tenant1");
+                definitionsService.setActionType(tenantActionType);
+
+                // Verify tenant data
+                assertEquals(tenantConditionType, definitionsService.getConditionType("test4"));
+                assertEquals(tenantActionType, definitionsService.getActionType("test5"));
+                assertTrue(definitionsService.getConditionTypesByTag("tag2").contains(tenantConditionType));
+                assertTrue(definitionsService.getActionTypeByTag("tag2").contains(tenantActionType));
+
+                // Verify system tenant data is accessible
+                assertNotNull(definitionsService.getConditionType("test1"));
+                assertNotNull(definitionsService.getActionType("test2"));
+
+                // Test tenant removal
+                definitionsService.onTenantRemoved("tenant1");
+
+                // Verify tenant data is removed
+                assertNull(definitionsService.getConditionType("test4"));
+                assertNull(definitionsService.getActionType("test5"));
+                assertTrue(definitionsService.getConditionTypesByTag("tag2").isEmpty());
+                assertTrue(definitionsService.getActionTypeByTag("tag2").isEmpty());
+            });
+
+            // Verify system tenant data is preserved
+            executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                assertEquals(systemConditionType[0], definitionsService.getConditionType("test1"));
+                assertEquals(systemActionType[0], definitionsService.getActionType("test2"));
+            });
+        }
+
+        @Test
+        void shouldHandleConcurrentTenantAccess() throws InterruptedException {
+            int threadCount = 5;
+            CyclicBarrier barrier = new CyclicBarrier(threadCount * 2); // Two tenants
+            CountDownLatch endLatch = new CountDownLatch(threadCount * 2);
+            AtomicBoolean failed = new AtomicBoolean(false);
+
+            for (int i = 0; i < threadCount; i++) {
+                final int index = i;
+
+                // System tenant thread
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                            ConditionType conditionType = createTestConditionType("test" + index, new HashSet<>(Arrays.asList("tag1")), null);
+                            definitionsService.setConditionType(conditionType);
+                        });
+                    } catch (Exception e) {
+                        failed.set(true);
+                        LOGGER.error("Thread execution failed", e);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }).start();
+
+                // Custom tenant thread
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        executionContextManager.executeAsTenant("tenant1", () -> {
+                            ConditionType conditionType = createTestConditionType("test" + index + "-tenant", new HashSet<>(Arrays.asList("tag1")), null);
+                            definitionsService.setConditionType(conditionType);
+                        });
+                    } catch (Exception e) {
+                        failed.set(true);
+                        LOGGER.error("Thread execution failed", e);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }).start();
+            }
+
+            assertTrue(endLatch.await(5, TimeUnit.SECONDS), "Test timed out");
+            assertFalse(failed.get(), "One or more threads failed execution");
+
+            // Verify tenant isolation
+            executionContextManager.executeAsTenant(SYSTEM_TENANT, () -> {
+                assertEquals(threadCount, definitionsService.getConditionTypesByTag("tag1").size());
+            });
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                assertEquals(threadCount*2 /* Because of inheritance */, definitionsService.getConditionTypesByTag("tag1").size());
+            });
+        }
+    }
+
+    @Nested
+    class ExtractConditionTests {
+        @Test
+        void shouldExtractConditionsByType() {
+            // Create a complex condition structure
+            ConditionType propertyType = createTestConditionType("propertyCondition", new HashSet<>(), null);
+            ConditionType booleanType = createTestConditionType("booleanCondition", new HashSet<>(), null);
+            definitionsService.setConditionType(propertyType);
+            definitionsService.setConditionType(booleanType);
+
+            Condition property1 = new Condition(propertyType);
+            property1.setParameter("propertyName", "prop1");
+
+            Condition property2 = new Condition(propertyType);
+            property2.setParameter("propertyName", "prop2");
+
+            Condition andCondition = new Condition(booleanType);
+            andCondition.setParameter("operator", "and");
+            andCondition.setParameter("subConditions", Arrays.asList(property1, property2));
+
+            // Test extraction
+            List<Condition> extracted = definitionsService.extractConditionsByType(andCondition, "propertyCondition");
+            assertEquals(2, extracted.size());
+            assertTrue(extracted.contains(property1));
+            assertTrue(extracted.contains(property2));
+
+            // Test with non-existent type
+            List<Condition> emptyResult = definitionsService.extractConditionsByType(andCondition, "nonExistentType");
+            assertTrue(emptyResult.isEmpty());
+
+            // Test with null inputs
+            assertTrue(definitionsService.extractConditionsByType(null, "propertyCondition").isEmpty());
+            assertTrue(definitionsService.extractConditionsByType(andCondition, null).isEmpty());
+        }
+
+        @Test
+        void shouldHandleDeepNestedConditions() {
+            // Create condition types
+            ConditionType propertyType = createTestConditionType("propertyCondition", new HashSet<>(), null);
+            ConditionType booleanType = createTestConditionType("booleanCondition", new HashSet<>(), null);
+            definitionsService.setConditionType(propertyType);
+            definitionsService.setConditionType(booleanType);
+
+            // Create a deeply nested condition structure
+            Condition property1 = new Condition(propertyType);
+            Condition property2 = new Condition(propertyType);
+            Condition property3 = new Condition(propertyType);
+
+            Condition innerAnd = new Condition(booleanType);
+            innerAnd.setParameter("operator", "and");
+            innerAnd.setParameter("subConditions", Arrays.asList(property2, property3));
+
+            Condition outerAnd = new Condition(booleanType);
+            outerAnd.setParameter("operator", "and");
+            outerAnd.setParameter("subConditions", Arrays.asList(property1, innerAnd));
+
+            // Test extraction
+            List<Condition> extracted = definitionsService.extractConditionsByType(outerAnd, "propertyCondition");
+            assertEquals(3, extracted.size());
+            assertTrue(extracted.contains(property1));
+            assertTrue(extracted.contains(property2));
+            assertTrue(extracted.contains(property3));
+        }
+
+        @Test
+        void shouldHandleInvalidSubConditions() {
+            ConditionType booleanType = createTestConditionType("booleanCondition", new HashSet<>(), null);
+            definitionsService.setConditionType(booleanType);
+
+            // Create condition with invalid subConditions parameter
+            Condition invalidCondition = new Condition(booleanType);
+            invalidCondition.setParameter("operator", "and");
+            invalidCondition.setParameter("subConditions", "not a list"); // Invalid type
+
+            List<Condition> result = definitionsService.extractConditionsByType(invalidCondition, "anyType");
+            assertTrue(result.isEmpty());
+
+            // Test with list containing non-Condition objects
+            Condition invalidListCondition = new Condition(booleanType);
+            invalidListCondition.setParameter("operator", "and");
+            invalidListCondition.setParameter("subConditions", Arrays.asList("not a condition", 123)); // Invalid list contents
+
+            result = definitionsService.extractConditionsByType(invalidListCondition, "anyType");
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        void shouldExtractConditionBySystemTag() {
+            // Create condition types with system tags
+            ConditionType taggedType = createTestConditionType("taggedCondition", new HashSet<>(), null);
+            taggedType.getMetadata().setSystemTags(new HashSet<>(Arrays.asList("testTag")));
+            ConditionType untaggedType = createTestConditionType("untaggedCondition", new HashSet<>(), null);
+            definitionsService.setConditionType(taggedType);
+            definitionsService.setConditionType(untaggedType);
+
+            // Create test conditions (simulate JSON-deserialized conditions that only have type IDs)
+            Condition taggedCondition = new Condition();
+            taggedCondition.setConditionTypeId("taggedCondition");
+            Condition untaggedCondition = new Condition();
+            untaggedCondition.setConditionTypeId("untaggedCondition");
+
+            // Create boolean condition containing both
+            ConditionType booleanType = createTestConditionType("booleanCondition", new HashSet<>(), null);
+            definitionsService.setConditionType(booleanType);
+            Condition booleanCondition = new Condition(booleanType);
+            booleanCondition.setParameter("operator", "and");
+            booleanCondition.setParameter("subConditions", Arrays.asList(taggedCondition, untaggedCondition));
+
+            // Test extraction
+            Condition extracted = definitionsService.extractConditionBySystemTag(booleanCondition, "testTag");
+            assertNotNull(extracted, "Extracted condition should not be null when a sub-condition has systemTag=testTag");
+            assertEquals(taggedCondition, extracted, "Extracted condition should match the tagged sub-condition (systemTag=testTag)");
+
+            // Test with non-existent tag
+            assertNull(definitionsService.extractConditionBySystemTag(booleanCondition, "nonExistentTag"),
+                    "Extraction should return null when no sub-condition matches systemTag=nonExistentTag");
+
+            // Test with null inputs
+            assertNull(definitionsService.extractConditionBySystemTag(null, "testTag"),
+                    "Extraction should return null when root condition is null");
+            assertNull(definitionsService.extractConditionBySystemTag(booleanCondition, null),
+                    "Extraction should return null when systemTag is null");
+        }
+
+        @Test
+        void shouldHandleComplexSystemTagExtraction() {
+            // Create condition types with system tags
+            ConditionType taggedType = createTestConditionType("taggedCondition", new HashSet<>(), null);
+            taggedType.getMetadata().setSystemTags(new HashSet<>(Arrays.asList("testTag")));
+            ConditionType booleanType = createTestConditionType("booleanCondition", new HashSet<>(), null);
+            definitionsService.setConditionType(taggedType);
+            definitionsService.setConditionType(booleanType);
+
+            // Create multiple tagged conditions
+            Condition taggedCondition1 = new Condition(taggedType);
+            Condition taggedCondition2 = new Condition(taggedType);
+
+            // Create nested boolean structure
+            Condition innerAnd = new Condition(booleanType);
+            innerAnd.setParameter("operator", "and");
+            innerAnd.setParameter("subConditions", Arrays.asList(taggedCondition1, taggedCondition2));
+
+            // Test extraction returns combined boolean condition
+            Condition extracted = definitionsService.extractConditionBySystemTag(innerAnd, "testTag");
+            assertNotNull(extracted);
+            assertEquals(innerAnd, extracted);
+
+            // Test with single matching condition
+            Condition singleAnd = new Condition(booleanType);
+            singleAnd.setParameter("operator", "and");
+            singleAnd.setParameter("subConditions", Collections.singletonList(taggedCondition1));
+
+            extracted = definitionsService.extractConditionBySystemTag(singleAnd, "testTag");
+            assertNotNull(extracted);
+            assertEquals(singleAnd, extracted);
+        }
+
+        @Test
+        void shouldHandleInvalidSystemTagExtraction() {
+            // Create condition types
+            ConditionType taggedType = createTestConditionType("taggedCondition", new HashSet<>(), null);
+            taggedType.getMetadata().setSystemTags(new HashSet<>(Arrays.asList("testTag")));
+            ConditionType booleanType = createTestConditionType("booleanCondition", new HashSet<>(), null);
+            definitionsService.setConditionType(taggedType);
+            definitionsService.setConditionType(booleanType);
+
+            // Test with invalid subConditions parameter
+            Condition invalidCondition = new Condition(booleanType);
+            invalidCondition.setParameter("operator", "and");
+            invalidCondition.setParameter("subConditions", "invalid");
+            assertNull(definitionsService.extractConditionBySystemTag(invalidCondition, "testTag"));
+
+            // Test with condition type having no metadata
+            ConditionType noMetadataType = createTestConditionType("noMetadata", new HashSet<>(), null);
+            noMetadataType.setMetadata(null);
+            Condition noMetadataCondition = new Condition(noMetadataType);
+            assertNull(definitionsService.extractConditionBySystemTag(noMetadataCondition, "testTag"));
+
+            // Test with condition type having no system tags
+            ConditionType noTagsType = createTestConditionType("noTags", new HashSet<>(), null);
+            Condition noTagsCondition = new Condition(noTagsType);
+            assertNull(definitionsService.extractConditionBySystemTag(noTagsCondition, "testTag"));
+        }
+
+        @SuppressWarnings("deprecation")
+        @Test
+        void shouldHandleDeprecatedExtractConditionByTag() {
+            // Create condition types with tags
+            ConditionType taggedType = createTestConditionType("taggedCondition", new HashSet<>(Arrays.asList("testTag")), null);
+            ConditionType untaggedType = createTestConditionType("untaggedCondition", new HashSet<>(), null);
+            definitionsService.setConditionType(taggedType);
+            definitionsService.setConditionType(untaggedType);
+
+            // Create test conditions (simulate JSON-deserialized conditions that only have type IDs)
+            Condition taggedCondition = new Condition();
+            taggedCondition.setConditionTypeId("taggedCondition");
+            Condition untaggedCondition = new Condition();
+            untaggedCondition.setConditionTypeId("untaggedCondition");
+
+            // Test simple extraction
+            Condition extracted = definitionsService.extractConditionByTag(taggedCondition, "testTag");
+            assertEquals(taggedCondition, extracted, "Deprecated tag extraction should match when conditionTypeId=taggedCondition has tag=testTag");
+
+            // Test with boolean AND condition
+            ConditionType booleanType = createTestConditionType("booleanCondition", new HashSet<>(), null);
+            definitionsService.setConditionType(booleanType);
+            Condition booleanCondition = new Condition(booleanType);
+            booleanCondition.setParameter("operator", "and");
+            booleanCondition.setParameter("subConditions", Arrays.asList(taggedCondition, taggedCondition));
+
+            extracted = definitionsService.extractConditionByTag(booleanCondition, "testTag");
+            assertNotNull(extracted, "Deprecated tag extraction should not be null when all sub-conditions match tag=testTag");
+            assertEquals(booleanCondition, extracted, "Deprecated tag extraction should return the AND boolean condition when all sub-conditions match tag=testTag");
+
+            // Test with mixed conditions
+            booleanCondition.setParameter("subConditions", Arrays.asList(taggedCondition, untaggedCondition));
+            extracted = definitionsService.extractConditionByTag(booleanCondition, "testTag");
+            assertNotNull(extracted, "Deprecated tag extraction should not be null when at least one sub-condition matches tag=testTag");
+            assertEquals(taggedCondition, extracted, "Deprecated tag extraction should return the single matching sub-condition when only one matches tag=testTag");
+        }
+    }
+
+    @Nested
+    class RefreshTimerTests {
+        @Test
+        void shouldScheduleAndExecuteRefreshTask() throws InterruptedException {
+            // Create a test condition type
+            ConditionType testType = createTestConditionType("testCondition", new HashSet<>(), null);
+            definitionsService.setConditionType(testType);
+
+            // Set a short refresh interval for testing
+            definitionsService.setDefinitionsRefreshInterval(100);
+
+            // Wait for at least one refresh cycle
+            Thread.sleep(150);
+
+            // Verify the condition type is still available
+            ConditionType retrieved = definitionsService.getConditionType("testCondition");
+            assertNotNull(retrieved);
+            assertEquals(testType.getItemId(), retrieved.getItemId());
+        }
+
+        @Test
+        void shouldHandleRefreshFailureGracefully() throws InterruptedException {
+            // Save original persistence service
+            PersistenceService originalPersistence = definitionsService.getPersistenceService();
+
+            try {
+                // Create a test condition type before breaking persistence
+                ConditionType testType = createTestConditionType("testCondition", new HashSet<>(), null);
+                definitionsService.setConditionType(testType);
+
+                // Replace with failing persistence service
+                definitionsService.setPersistenceService(null);
+
+                // Set a short refresh interval
+                definitionsService.setDefinitionsRefreshInterval(100);
+
+                // Wait for at least one refresh cycle
+                Thread.sleep(150);
+
+                // Service should still be operational with in-memory data
+                assertNotNull(definitionsService.getConditionType("testCondition"));
+            } finally {
+                // Restore original persistence service
+                definitionsService.setPersistenceService(originalPersistence);
+            }
+        }
+
+        @Test
+        void shouldStopRefreshOnShutdown() throws Exception {
+            // Set a short refresh interval
+            definitionsService.setDefinitionsRefreshInterval(100);
+
+            // Trigger shutdown
+            definitionsService.preDestroy();
+
+            try {
+                // Verify the service is marked as shutdown
+                Field isShutdownField = DefinitionsServiceImpl.class.getDeclaredField("isShutdown");
+                isShutdownField.setAccessible(true);
+                assertTrue((Boolean) isShutdownField.get(definitionsService));
+
+                // Wait for potential refresh cycle
+                Thread.sleep(150);
+
+                // Service should still respond to direct calls but not refresh
+                ConditionType testType = createTestConditionType("testCondition", new HashSet<>(), null);
+                definitionsService.setConditionType(testType);
+                assertNotNull(definitionsService.getConditionType("testCondition"));
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new Exception("Failed to access isShutdown field", e);
+            }
+        }
+
+        @Test
+        void shouldHandleParentConditionResolutionDuringRefresh() {
+            // Create parent condition type
+            ConditionType parentType = createTestConditionType("parentCondition", new HashSet<>(Arrays.asList("tag1")), null);
+            parentType.setTenantId(SYSTEM_TENANT);
+
+            // Create child condition type with parent condition
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("parentCondition");
+            ConditionType childType = createTestConditionType("childCondition", new HashSet<>(Arrays.asList("tag2")), null);
+            childType.setTenantId(SYSTEM_TENANT);
+            childType.setParentCondition(parentCondition);
+
+            // Save both to persistence (order matters - child before parent to simulate the issue)
+            executionContextManager.executeAsSystem(() -> {
+                // Save child first (simulating the problematic order during refresh)
+                persistenceService.save(childType);
+                // Then save parent
+                persistenceService.save(parentType);
+            });
+
+            // Trigger refresh - this should handle parent resolution even if child was loaded first
+            definitionsService.refresh();
+
+            // Verify both condition types are loaded (parent condition resolution removed - happens on-demand in query builders/evaluators)
+            executionContextManager.executeAsSystem(() -> {
+                ConditionType loadedChild = definitionsService.getConditionType("childCondition");
+                assertNotNull(loadedChild, "Child condition type should be loaded");
+                assertNotNull(loadedChild.getParentCondition(), "Parent condition should be set");
+                assertEquals("parentCondition", loadedChild.getParentCondition().getConditionTypeId());
+                // Parent condition type is not automatically resolved - resolution happens on-demand
+                // If we need it resolved, we can manually call TypeResolutionService.resolveConditionType()
+                if (loadedChild.getParentCondition().getConditionType() == null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    if (typeResolutionService != null) {
+                        typeResolutionService.resolveConditionType(loadedChild.getParentCondition(), "test");
+                    }
+                }
+                assertNotNull(loadedChild.getParentCondition().getConditionType(), "Parent condition type should be resolvable");
+                assertEquals(parentType, loadedChild.getParentCondition().getConditionType());
+
+                ConditionType loadedParent = definitionsService.getConditionType("parentCondition");
+                assertNotNull(loadedParent, "Parent condition type should be loaded");
+            });
+        }
+    }
+
+    @Nested
+    class ParentConditionResolutionTests {
+        @Test
+        void shouldResolveParentConditionWhenChildLoadedBeforeParentDuringInitialLoad() {
+            // Create a chain: grandparent -> parent -> child
+            ConditionType grandparentType = createTestConditionType("grandparentCondition", new HashSet<>(Arrays.asList("tag1")), null);
+            grandparentType.setTenantId(SYSTEM_TENANT);
+
+            Condition grandparentCondition = new Condition();
+            grandparentCondition.setConditionTypeId("grandparentCondition");
+            ConditionType parentType = createTestConditionType("parentCondition", new HashSet<>(Arrays.asList("tag2")), null);
+            parentType.setTenantId(SYSTEM_TENANT);
+            parentType.setParentCondition(grandparentCondition);
+
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("parentCondition");
+            ConditionType childType = createTestConditionType("childCondition", new HashSet<>(Arrays.asList("tag3")), null);
+            childType.setTenantId(SYSTEM_TENANT);
+            childType.setParentCondition(parentCondition);
+
+            // Save in worst-case order: child, then parent, then grandparent
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(childType);
+                persistenceService.save(parentType);
+                persistenceService.save(grandparentType);
+            });
+
+            // Trigger refresh (parent condition resolution removed - happens on-demand in query builders/evaluators)
+            definitionsService.refresh();
+
+            // Verify condition types are loaded (parent resolution happens on-demand)
+            executionContextManager.executeAsSystem(() -> {
+                ConditionType loadedChild = definitionsService.getConditionType("childCondition");
+                assertNotNull(loadedChild, "Child condition type should be loaded");
+                assertNotNull(loadedChild.getParentCondition(), "Child should have parent condition");
+                // Manually resolve parent if needed for test
+                if (loadedChild.getParentCondition().getConditionType() == null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    if (typeResolutionService != null) {
+                        typeResolutionService.resolveConditionType(loadedChild.getParentCondition(), "test");
+                    }
+                }
+                assertNotNull(loadedChild.getParentCondition().getConditionType(), "Child's parent condition type should be resolvable");
+                assertEquals("parentCondition", loadedChild.getParentCondition().getConditionTypeId());
+
+                ConditionType loadedParent = definitionsService.getConditionType("parentCondition");
+                assertNotNull(loadedParent, "Parent condition type should be loaded");
+                assertNotNull(loadedParent.getParentCondition(), "Parent should have parent condition");
+                // Manually resolve parent's parent if needed for test
+                if (loadedParent.getParentCondition().getConditionType() == null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    if (typeResolutionService != null) {
+                        typeResolutionService.resolveConditionType(loadedParent.getParentCondition(), "test");
+                    }
+                }
+                assertNotNull(loadedParent.getParentCondition().getConditionType(), "Parent's parent condition type should be resolvable");
+                assertEquals("grandparentCondition", loadedParent.getParentCondition().getConditionTypeId());
+
+                ConditionType loadedGrandparent = definitionsService.getConditionType("grandparentCondition");
+                assertNotNull(loadedGrandparent, "Grandparent condition type should be loaded");
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionForBundleLoadedItems() {
+            // Simulate bundle loading: items loaded from bundles before persistence refresh
+            Long bundleId = 1L;
+            setupMockBundle(bundleId);
+
+            // Create parent and child condition types
+            ConditionType parentType = createTestConditionType("bundleParentCondition", new HashSet<>(Arrays.asList("tag1")), bundleId);
+            parentType.setTenantId(SYSTEM_TENANT);
+
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("bundleParentCondition");
+            ConditionType childType = createTestConditionType("bundleChildCondition", new HashSet<>(Arrays.asList("tag2")), bundleId);
+            childType.setTenantId(SYSTEM_TENANT);
+            childType.setParentCondition(parentCondition);
+
+            // Simulate bundle loading (child loaded before parent)
+            executionContextManager.executeAsSystem(() -> {
+                // Load child first (simulating bundle load order)
+                registerPluginType(childType, bundleId);
+                // Then load parent
+                registerPluginType(parentType, bundleId);
+            });
+
+            // Trigger refresh (parent condition resolution removed - happens on-demand in query builders/evaluators)
+            definitionsService.refresh();
+
+            // Verify condition types are loaded (parent resolution happens on-demand)
+            executionContextManager.executeAsSystem(() -> {
+                ConditionType loadedChild = definitionsService.getConditionType("bundleChildCondition");
+                assertNotNull(loadedChild, "Child condition type from bundle should be loaded");
+                assertNotNull(loadedChild.getParentCondition(), "Child should have parent condition");
+                // Manually resolve parent if needed for test
+                if (loadedChild.getParentCondition().getConditionType() == null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    if (typeResolutionService != null) {
+                        typeResolutionService.resolveConditionType(loadedChild.getParentCondition(), "test");
+                    }
+                }
+                assertNotNull(loadedChild.getParentCondition().getConditionType(), "Child's parent condition type should be resolvable");
+                assertEquals("bundleParentCondition", loadedChild.getParentCondition().getConditionTypeId());
+                assertEquals(parentType, loadedChild.getParentCondition().getConditionType());
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWithTenantOverride() {
+            // Create system tenant condition types
+            ConditionType systemParentType = createTestConditionType("sharedParent", new HashSet<>(Arrays.asList("tag1")), null);
+            systemParentType.setTenantId(SYSTEM_TENANT);
+
+            Condition systemParentCondition = new Condition();
+            systemParentCondition.setConditionTypeId("sharedParent");
+            ConditionType systemChildType = createTestConditionType("sharedChild", new HashSet<>(Arrays.asList("tag2")), null);
+            systemChildType.setTenantId(SYSTEM_TENANT);
+            systemChildType.setParentCondition(systemParentCondition);
+
+            // Create tenant-specific override for child (with different parent reference)
+            Condition tenantParentCondition = new Condition();
+            tenantParentCondition.setConditionTypeId("sharedParent");
+            ConditionType tenantChildType = createTestConditionType("sharedChild", new HashSet<>(Arrays.asList("tag3")), null);
+            tenantChildType.setTenantId("tenant1");
+            tenantChildType.setParentCondition(tenantParentCondition);
+
+            // Save system tenant types
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemParentType);
+                persistenceService.save(systemChildType);
+            });
+
+            // Save tenant-specific override
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                persistenceService.save(tenantChildType);
+            });
+
+            // Trigger refresh
+            definitionsService.refresh();
+
+            // Verify system tenant resolution (parent resolution happens on-demand)
+            executionContextManager.executeAsSystem(() -> {
+                ConditionType loadedChild = definitionsService.getConditionType("sharedChild");
+                assertNotNull(loadedChild, "System child condition type should be loaded");
+                assertNotNull(loadedChild.getParentCondition(), "System child should have parent condition");
+                // Manually resolve parent if needed for test
+                if (loadedChild.getParentCondition().getConditionType() == null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    if (typeResolutionService != null) {
+                        typeResolutionService.resolveConditionType(loadedChild.getParentCondition(), "test");
+                    }
+                }
+                assertNotNull(loadedChild.getParentCondition().getConditionType(), "System child's parent should be resolvable");
+                assertEquals(SYSTEM_TENANT, loadedChild.getTenantId());
+            });
+
+            // Verify tenant-specific override resolution (parent resolution happens on-demand)
+            // Note: getConditionType uses inheritance, so it may return system version if tenant version not in cache
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType loadedChild = definitionsService.getConditionType("sharedChild");
+                assertNotNull(loadedChild, "Child condition type should be loaded (may be system or tenant version)");
+                assertNotNull(loadedChild.getParentCondition(), "Child should have parent condition");
+                // Manually resolve parent if needed for test
+                if (loadedChild.getParentCondition().getConditionType() == null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    if (typeResolutionService != null) {
+                        typeResolutionService.resolveConditionType(loadedChild.getParentCondition(), "test");
+                    }
+                }
+                assertNotNull(loadedChild.getParentCondition().getConditionType(), "Child's parent should be resolvable");
+                // Parent should resolve to system tenant version (inheritance)
+                assertEquals("sharedParent", loadedChild.getParentCondition().getConditionTypeId());
+                assertNotNull(loadedChild.getParentCondition().getConditionType());
+
+                // Verify tenant-specific version exists in persistence
+                ConditionType tenantChild = persistenceService.load("sharedChild", ConditionType.class);
+                assertNotNull(tenantChild, "Tenant-specific child should exist in persistence");
+                assertEquals("tenant1", tenantChild.getTenantId(), "Tenant-specific child should have correct tenant ID");
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWithTenantSpecificParent() {
+            // Create system tenant parent
+            ConditionType systemParentType = createTestConditionType("parentType", new HashSet<>(Arrays.asList("tag1")), null);
+            systemParentType.setTenantId(SYSTEM_TENANT);
+
+            // Create tenant-specific parent
+            ConditionType tenantParentType = createTestConditionType("parentType", new HashSet<>(Arrays.asList("tag2")), null);
+            tenantParentType.setTenantId("tenant1");
+
+            // Create child that references parent (will resolve to tenant-specific if available)
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("parentType");
+            ConditionType childType = createTestConditionType("childType", new HashSet<>(Arrays.asList("tag3")), null);
+            childType.setTenantId("tenant1");
+            childType.setParentCondition(parentCondition);
+
+            // Save all types
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemParentType);
+            });
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                persistenceService.save(tenantParentType);
+                persistenceService.save(childType);
+            });
+
+            // Trigger refresh
+            definitionsService.refresh();
+
+            // Verify tenant child resolves parent condition
+            // The key test is that parent conditions are resolved correctly
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                // Verify items exist in persistence
+                ConditionType tenantChild = persistenceService.load("childType", ConditionType.class);
+                assertNotNull(tenantChild, "Tenant child should exist in persistence");
+                assertEquals("tenant1", tenantChild.getTenantId(), "Tenant child should have correct tenant ID");
+
+                ConditionType tenantParent = persistenceService.load("parentType", ConditionType.class);
+                assertNotNull(tenantParent, "Tenant-specific parent should exist in persistence");
+                assertEquals("tenant1", tenantParent.getTenantId(), "Tenant-specific parent should have correct tenant ID");
+
+                // Verify parent condition resolution works when resolving the condition directly
+                // This tests the core functionality: parent conditions should be resolvable
+                if (tenantChild.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(tenantChild.getParentCondition(), "test");
+                    assertTrue(resolved, "Parent condition should be resolvable");
+                    assertNotNull(tenantChild.getParentCondition().getConditionType(), "Parent condition type should be resolved");
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveComplexParentChainWithTenantOverrides() {
+            // Create a complex chain: base -> intermediate -> derived
+            // With system tenant base and intermediate, tenant override for derived
+
+            // System tenant: base condition
+            ConditionType systemBaseType = createTestConditionType("baseCondition", new HashSet<>(Arrays.asList("base")), null);
+            systemBaseType.setTenantId(SYSTEM_TENANT);
+
+            // System tenant: intermediate condition (references base)
+            Condition baseCondition = new Condition();
+            baseCondition.setConditionTypeId("baseCondition");
+            ConditionType systemIntermediateType = createTestConditionType("intermediateCondition", new HashSet<>(Arrays.asList("intermediate")), null);
+            systemIntermediateType.setTenantId(SYSTEM_TENANT);
+            systemIntermediateType.setParentCondition(baseCondition);
+
+            // Tenant override: derived condition (references intermediate, which references base)
+            Condition intermediateCondition = new Condition();
+            intermediateCondition.setConditionTypeId("intermediateCondition");
+            ConditionType tenantDerivedType = createTestConditionType("derivedCondition", new HashSet<>(Arrays.asList("derived")), null);
+            tenantDerivedType.setTenantId("tenant1");
+            tenantDerivedType.setParentCondition(intermediateCondition);
+
+            // Save in worst-case order: derived, then intermediate, then base
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemBaseType);
+                persistenceService.save(systemIntermediateType);
+            });
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                persistenceService.save(tenantDerivedType);
+            });
+
+            // Trigger refresh
+            definitionsService.refresh();
+
+            // Verify entire chain is resolved
+            // The key test is that parent conditions are resolved correctly, even in complex chains
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                // Verify item exists in persistence
+                ConditionType tenantDerived = persistenceService.load("derivedCondition", ConditionType.class);
+                assertNotNull(tenantDerived, "Derived condition type should exist in persistence");
+                assertEquals("tenant1", tenantDerived.getTenantId(), "Derived should have correct tenant ID");
+
+                // Verify parent condition resolution works when resolving the condition directly
+                // This tests the core functionality: parent conditions should be resolvable in chains
+                if (tenantDerived.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(tenantDerived.getParentCondition(), "test");
+                    assertTrue(resolved, "Derived's parent condition should be resolvable");
+                    assertNotNull(tenantDerived.getParentCondition().getConditionType(), "Derived's parent should be resolved");
+
+                    // Verify intermediate is resolved
+                    ConditionType intermediate = tenantDerived.getParentCondition().getConditionType();
+                    assertEquals("intermediateCondition", intermediate.getItemId());
+                    if (intermediate.getParentCondition() != null) {
+                        boolean intermediateResolved = typeResolutionService != null &&
+                            typeResolutionService.resolveConditionType(intermediate.getParentCondition(), "test");
+                        assertTrue(intermediateResolved, "Intermediate's parent condition should be resolvable");
+                        assertNotNull(intermediate.getParentCondition().getConditionType(), "Intermediate's parent should be resolved");
+
+                        // Verify base is resolved
+                        ConditionType base = intermediate.getParentCondition().getConditionType();
+                        assertEquals("baseCondition", base.getItemId());
+                        assertNull(base.getParentCondition(), "Base should not have parent condition");
+                    }
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionAfterBundleStopAndRestart() {
+            // Create condition types from a bundle
+            Long bundleId = 1L;
+            setupMockBundle(bundleId);
+
+            ConditionType parentType = createTestConditionType("bundleParent", new HashSet<>(Arrays.asList("tag1")), bundleId);
+            parentType.setTenantId(SYSTEM_TENANT);
+
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("bundleParent");
+            ConditionType childType = createTestConditionType("bundleChild", new HashSet<>(Arrays.asList("tag2")), bundleId);
+            childType.setTenantId(SYSTEM_TENANT);
+            childType.setParentCondition(parentCondition);
+
+            // Load from bundle
+            executionContextManager.executeAsSystem(() -> {
+                registerPluginType(parentType, bundleId);
+                registerPluginType(childType, bundleId);
+            });
+
+            // Trigger refresh (parent condition resolution removed - happens on-demand in query builders/evaluators)
+            definitionsService.refresh();
+
+            // Verify condition types are loaded (parent resolution happens on-demand)
+            executionContextManager.executeAsSystem(() -> {
+                ConditionType loadedChild = definitionsService.getConditionType("bundleChild");
+                assertNotNull(loadedChild, "Child should be loaded");
+                assertNotNull(loadedChild.getParentCondition(), "Child should have parent condition");
+                // Manually resolve parent if needed for test
+                if (loadedChild.getParentCondition().getConditionType() == null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    if (typeResolutionService != null) {
+                        typeResolutionService.resolveConditionType(loadedChild.getParentCondition(), "test");
+                    }
+                }
+                assertNotNull(loadedChild.getParentCondition().getConditionType(), "Parent should be resolvable after bundle load");
+            });
+
+            // Stop bundle (removes types)
+            definitionsService.processBundleStop(bundleContext);
+
+            // Verify types are removed
+            executionContextManager.executeAsSystem(() -> {
+                assertNull(definitionsService.getConditionType("bundleChild"), "Child should be removed");
+                assertNull(definitionsService.getConditionType("bundleParent"), "Parent should be removed");
+            });
+
+            // Save to persistence and restart
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(parentType);
+                persistenceService.save(childType);
+            });
+
+            // Trigger refresh (parent condition resolution removed - happens on-demand in query builders/evaluators)
+            definitionsService.refresh();
+
+            // Verify condition types are loaded (parent resolution happens on-demand)
+            executionContextManager.executeAsSystem(() -> {
+                ConditionType loadedChild = definitionsService.getConditionType("bundleChild");
+                assertNotNull(loadedChild, "Child should be loaded from persistence");
+                assertNotNull(loadedChild.getParentCondition(), "Child should have parent condition");
+                // Manually resolve parent if needed for test
+                if (loadedChild.getParentCondition().getConditionType() == null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    if (typeResolutionService != null) {
+                        typeResolutionService.resolveConditionType(loadedChild.getParentCondition(), "test");
+                    }
+                }
+                assertNotNull(loadedChild.getParentCondition().getConditionType(), "Parent should be resolvable after restart");
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWithMultipleTenants() {
+            // Create system tenant parent
+            ConditionType systemParentType = createTestConditionType("multiTenantParent", new HashSet<>(Arrays.asList("system")), null);
+            systemParentType.setTenantId(SYSTEM_TENANT);
+
+            // Create child for tenant1
+            Condition parentCondition1 = new Condition();
+            parentCondition1.setConditionTypeId("multiTenantParent");
+            ConditionType tenant1ChildType = createTestConditionType("multiTenantChild", new HashSet<>(Arrays.asList("tenant1")), null);
+            tenant1ChildType.setTenantId("tenant1");
+            tenant1ChildType.setParentCondition(parentCondition1);
+
+            // Create child for tenant2
+            Condition parentCondition2 = new Condition();
+            parentCondition2.setConditionTypeId("multiTenantParent");
+            ConditionType tenant2ChildType = createTestConditionType("multiTenantChild", new HashSet<>(Arrays.asList("tenant2")), null);
+            tenant2ChildType.setTenantId("tenant2");
+            tenant2ChildType.setParentCondition(parentCondition2);
+
+            // Save all
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemParentType);
+            });
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                persistenceService.save(tenant1ChildType);
+            });
+            executionContextManager.executeAsTenant("tenant2", () -> {
+                persistenceService.save(tenant2ChildType);
+            });
+
+            // Trigger refresh
+            definitionsService.refresh();
+
+            // Verify both tenants resolve correctly
+            // The key test is that parent conditions are resolved correctly for multiple tenants
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                // Verify tenant1 child exists in persistence
+                ConditionType tenant1Child = persistenceService.load("multiTenantChild", ConditionType.class);
+                assertNotNull(tenant1Child, "Tenant1 child should exist in persistence");
+                assertEquals("tenant1", tenant1Child.getTenantId(), "Tenant1 child should have correct tenant ID");
+
+                // Verify parent condition resolution works
+                if (tenant1Child.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(tenant1Child.getParentCondition(), "test");
+                    assertTrue(resolved, "Tenant1 child's parent condition should be resolvable");
+                    assertNotNull(tenant1Child.getParentCondition().getConditionType(), "Tenant1 child's parent should be resolved");
+                }
+            });
+
+            executionContextManager.executeAsTenant("tenant2", () -> {
+                // Verify tenant2 child exists in persistence
+                ConditionType tenant2Child = persistenceService.load("multiTenantChild", ConditionType.class);
+                assertNotNull(tenant2Child, "Tenant2 child should exist in persistence");
+                assertEquals("tenant2", tenant2Child.getTenantId(), "Tenant2 child should have correct tenant ID");
+
+                // Verify parent condition resolution works
+                if (tenant2Child.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(tenant2Child.getParentCondition(), "test");
+                    assertTrue(resolved, "Tenant2 child's parent condition should be resolvable");
+                    assertNotNull(tenant2Child.getParentCondition().getConditionType(), "Tenant2 child's parent should be resolved");
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWhenParentIsInSystemTenantAndChildIsInCustomTenant() {
+            // System tenant parent
+            ConditionType systemParentType = createTestConditionType("systemParent", new HashSet<>(Arrays.asList("system")), null);
+            systemParentType.setTenantId(SYSTEM_TENANT);
+
+            // Custom tenant child that references system parent
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("systemParent");
+            ConditionType tenantChildType = createTestConditionType("tenantChild", new HashSet<>(Arrays.asList("tenant")), null);
+            tenantChildType.setTenantId("tenant1");
+            tenantChildType.setParentCondition(parentCondition);
+
+            // Save
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemParentType);
+            });
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                persistenceService.save(tenantChildType);
+            });
+
+            // Trigger refresh
+            definitionsService.refresh();
+
+            // Verify child resolves to system parent (inheritance)
+            // The key test is that parent conditions are resolved correctly, even when parent is in system tenant
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                // Verify item exists in persistence
+                ConditionType tenantChild = persistenceService.load("tenantChild", ConditionType.class);
+                assertNotNull(tenantChild, "Tenant child should exist in persistence");
+                assertEquals("tenant1", tenantChild.getTenantId(), "Tenant child should have correct tenant ID");
+
+                // Verify parent condition resolution works when resolving the condition directly
+                // This tests the core functionality: parent conditions should be resolvable across tenants
+                if (tenantChild.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(tenantChild.getParentCondition(), "test");
+                    assertTrue(resolved, "Child's parent condition should be resolvable");
+                    assertNotNull(tenantChild.getParentCondition().getConditionType(), "Child's parent should be resolved");
+
+                    // Parent should resolve to system tenant version (inheritance)
+                    ConditionType resolvedParent = tenantChild.getParentCondition().getConditionType();
+                    assertNotNull(resolvedParent, "Parent should be resolved");
+                    assertEquals(SYSTEM_TENANT, resolvedParent.getTenantId(), "Should resolve to system tenant parent");
+                    assertEquals("systemParent", resolvedParent.getItemId());
+                }
+            });
+        }
+
+        @Test
+        void shouldHandleParentConditionResolutionDuringConcurrentRefresh() throws InterruptedException {
+            // Create multiple condition types with parent conditions
+            int numTypes = 10;
+            List<ConditionType> types = new ArrayList<>();
+
+            executionContextManager.executeAsSystem(() -> {
+                // Create a chain: type0 -> type1 -> ... -> type9
+                for (int i = 0; i < numTypes; i++) {
+                    ConditionType type = createTestConditionType("type" + i, new HashSet<>(Arrays.asList("tag" + i)), null);
+                    type.setTenantId(SYSTEM_TENANT);
+
+                    if (i > 0) {
+                        Condition parentCondition = new Condition();
+                        parentCondition.setConditionTypeId("type" + (i - 1));
+                        type.setParentCondition(parentCondition);
+                    }
+
+                    types.add(type);
+                    // Save in reverse order to maximize load order issues
+                    persistenceService.save(type);
+                }
+            });
+
+            // Trigger refresh from multiple threads
+            int threadCount = 5;
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch endLatch = new CountDownLatch(threadCount);
+            AtomicBoolean failed = new AtomicBoolean(false);
+
+            for (int i = 0; i < threadCount; i++) {
+                new Thread(() -> {
+                    try {
+                        startLatch.await();
+                        definitionsService.refresh();
+                    } catch (Exception e) {
+                        failed.set(true);
+                        LOGGER.error("Thread execution failed", e);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }).start();
+            }
+
+            startLatch.countDown();
+            assertTrue(endLatch.await(5, TimeUnit.SECONDS), "Test timed out");
+            assertFalse(failed.get(), "One or more threads failed");
+
+            // Verify condition types are loaded (parent resolution happens on-demand)
+            executionContextManager.executeAsSystem(() -> {
+                for (int i = 1; i < numTypes; i++) {
+                    ConditionType loadedType = definitionsService.getConditionType("type" + i);
+                    assertNotNull(loadedType, "Type " + i + " should be loaded");
+                    assertNotNull(loadedType.getParentCondition(), "Type " + i + " should have parent condition");
+                    // Manually resolve parent if needed for test
+                    if (loadedType.getParentCondition().getConditionType() == null) {
+                        TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                        if (typeResolutionService != null) {
+                            typeResolutionService.resolveConditionType(loadedType.getParentCondition(), "test");
+                        }
+                    }
+                    assertNotNull(loadedType.getParentCondition().getConditionType(),
+                        "Type " + i + "'s parent condition should be resolvable");
+                    assertEquals("type" + (i - 1), loadedType.getParentCondition().getConditionTypeId());
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionAfterPostConstruct() {
+            // Create condition types and save to persistence
+            ConditionType parentType = createTestConditionType("postConstructParent", new HashSet<>(Arrays.asList("tag1")), null);
+            parentType.setTenantId(SYSTEM_TENANT);
+
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("postConstructParent");
+            ConditionType childType = createTestConditionType("postConstructChild", new HashSet<>(Arrays.asList("tag2")), null);
+            childType.setTenantId(SYSTEM_TENANT);
+            childType.setParentCondition(parentCondition);
+
+            // Save in problematic order
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(childType);
+                persistenceService.save(parentType);
+            });
+
+            // Create a new service instance to trigger postConstruct
+            // This simulates the real startup scenario
+            DefinitionsServiceImpl newService = TestHelper.createDefinitionService(
+                persistenceService, bundleContext, schedulerService, multiTypeCacheService,
+                executionContextManager, tenantService);
+
+            // Verify condition types are loaded (parent resolution happens on-demand, not in postConstruct)
+            executionContextManager.executeAsSystem(() -> {
+                ConditionType loadedChild = newService.getConditionType("postConstructChild");
+                assertNotNull(loadedChild, "Child condition type should be loaded after postConstruct");
+                assertNotNull(loadedChild.getParentCondition(), "Child should have parent condition");
+                // Manually resolve parent if needed for test
+                if (loadedChild.getParentCondition().getConditionType() == null) {
+                    TypeResolutionService typeResolutionService = newService.getTypeResolutionService();
+                    if (typeResolutionService != null) {
+                        typeResolutionService.resolveConditionType(loadedChild.getParentCondition(), "test");
+                    }
+                }
+                assertNotNull(loadedChild.getParentCondition().getConditionType(),
+                    "Child's parent condition should be resolvable after postConstruct");
+                assertEquals("postConstructParent", loadedChild.getParentCondition().getConditionTypeId());
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWhenGrandparentLoadedLast() {
+            // Test: child -> parent -> grandparent (worst case load order)
+            ConditionType grandparentType = createTestConditionType("grandparentLast", new HashSet<>(Arrays.asList("tag1")), null);
+            grandparentType.setTenantId(SYSTEM_TENANT);
+
+            Condition grandparentCondition = new Condition();
+            grandparentCondition.setConditionTypeId("grandparentLast");
+            ConditionType parentType = createTestConditionType("parentLast", new HashSet<>(Arrays.asList("tag2")), null);
+            parentType.setTenantId(SYSTEM_TENANT);
+            parentType.setParentCondition(grandparentCondition);
+
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("parentLast");
+            ConditionType childType = createTestConditionType("childLast", new HashSet<>(Arrays.asList("tag3")), null);
+            childType.setTenantId(SYSTEM_TENANT);
+            childType.setParentCondition(parentCondition);
+
+            // Save in worst-case order: child, then parent, then grandparent
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(childType);
+                persistenceService.save(parentType);
+                persistenceService.save(grandparentType);
+            });
+
+            definitionsService.refresh();
+
+            // Verify entire chain is resolved
+            executionContextManager.executeAsSystem(() -> {
+                ConditionType loadedChild = persistenceService.load("childLast", ConditionType.class);
+                assertNotNull(loadedChild, "Child should exist");
+                if (loadedChild.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(loadedChild.getParentCondition(), "test");
+                    assertTrue(resolved, "Child's parent should be resolvable");
+                    ConditionType parent = loadedChild.getParentCondition().getConditionType();
+                    assertNotNull(parent, "Parent should be resolved");
+                    if (parent.getParentCondition() != null) {
+                        boolean parentResolved = typeResolutionService != null &&
+                            typeResolutionService.resolveConditionType(parent.getParentCondition(), "test");
+                        assertTrue(parentResolved, "Parent's parent (grandparent) should be resolvable");
+                        assertNotNull(parent.getParentCondition().getConditionType(), "Grandparent should be resolved");
+                    }
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveMultipleChildrenWithSameParentLoadedInVariousOrders() {
+            // Create one parent and multiple children
+            ConditionType parentType = createTestConditionType("sharedParent", new HashSet<>(Arrays.asList("tag1")), null);
+            parentType.setTenantId(SYSTEM_TENANT);
+
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("sharedParent");
+
+            List<ConditionType> children = new ArrayList<>();
+            for (int i = 1; i <= 5; i++) {
+                Condition childParentCondition = new Condition();
+                childParentCondition.setConditionTypeId("sharedParent");
+                ConditionType childType = createTestConditionType("child" + i, new HashSet<>(Arrays.asList("tag" + i)), null);
+                childType.setTenantId(SYSTEM_TENANT);
+                childType.setParentCondition(childParentCondition);
+                children.add(childType);
+            }
+
+            // Save in random order: parent in middle, children before and after
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(children.get(0)); // child1
+                persistenceService.save(children.get(2)); // child3
+                persistenceService.save(parentType);      // parent
+                persistenceService.save(children.get(1)); // child2
+                persistenceService.save(children.get(4)); // child5
+                persistenceService.save(children.get(3)); // child4
+            });
+
+            definitionsService.refresh();
+
+            // Verify all children resolve to same parent
+            executionContextManager.executeAsSystem(() -> {
+                for (int i = 1; i <= 5; i++) {
+                    ConditionType child = persistenceService.load("child" + i, ConditionType.class);
+                    assertNotNull(child, "Child " + i + " should exist");
+                    if (child.getParentCondition() != null) {
+                        TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                        boolean resolved = typeResolutionService != null &&
+                            typeResolutionService.resolveConditionType(child.getParentCondition(), "test");
+                        assertTrue(resolved, "Child " + i + "'s parent should be resolvable");
+                        assertEquals("sharedParent", child.getParentCondition().getConditionTypeId());
+                        assertNotNull(child.getParentCondition().getConditionType(), "Child " + i + "'s parent should be resolved");
+                    }
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWhenParentHasUnresolvedParentInitially() {
+            // Test: child references parent, parent references grandparent, but grandparent loaded last
+            ConditionType grandparentType = createTestConditionType("grandparentDelayed", new HashSet<>(Arrays.asList("tag1")), null);
+            grandparentType.setTenantId(SYSTEM_TENANT);
+
+            Condition grandparentCondition = new Condition();
+            grandparentCondition.setConditionTypeId("grandparentDelayed");
+            ConditionType parentType = createTestConditionType("parentDelayed", new HashSet<>(Arrays.asList("tag2")), null);
+            parentType.setTenantId(SYSTEM_TENANT);
+            parentType.setParentCondition(grandparentCondition);
+
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("parentDelayed");
+            ConditionType childType = createTestConditionType("childDelayed", new HashSet<>(Arrays.asList("tag3")), null);
+            childType.setTenantId(SYSTEM_TENANT);
+            childType.setParentCondition(parentCondition);
+
+            // Save: child first, then parent (with unresolved parent), then grandparent
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(childType);
+                persistenceService.save(parentType);
+                persistenceService.save(grandparentType);
+            });
+
+            definitionsService.refresh();
+
+            // Verify both parent and grandparent are resolved
+            executionContextManager.executeAsSystem(() -> {
+                ConditionType loadedChild = persistenceService.load("childDelayed", ConditionType.class);
+                assertNotNull(loadedChild, "Child should exist");
+                if (loadedChild.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(loadedChild.getParentCondition(), "test");
+                    assertTrue(resolved, "Child's parent should be resolvable");
+                    ConditionType parent = loadedChild.getParentCondition().getConditionType();
+                    assertNotNull(parent, "Parent should be resolved");
+                    // Parent should also have its parent resolved
+                    if (parent.getParentCondition() != null) {
+                        boolean parentResolved = typeResolutionService != null &&
+                            typeResolutionService.resolveConditionType(parent.getParentCondition(), "test");
+                        assertTrue(parentResolved, "Parent's parent should be resolvable");
+                        assertNotNull(parent.getParentCondition().getConditionType(), "Grandparent should be resolved");
+                    }
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWithBundleAndPersistenceMixedLoadOrder() {
+            // Test: Some items from bundle, some from persistence, loaded in various orders
+            Long bundleId = 1L;
+            setupMockBundle(bundleId);
+
+            // Bundle items
+            ConditionType bundleParentType = createTestConditionType("bundleParent", new HashSet<>(Arrays.asList("tag1")), bundleId);
+            bundleParentType.setTenantId(SYSTEM_TENANT);
+
+            Condition bundleParentCondition = new Condition();
+            bundleParentCondition.setConditionTypeId("bundleParent");
+            ConditionType bundleChildType = createTestConditionType("bundleChild", new HashSet<>(Arrays.asList("tag2")), bundleId);
+            bundleChildType.setTenantId(SYSTEM_TENANT);
+            bundleChildType.setParentCondition(bundleParentCondition);
+
+            // Persistence items
+            ConditionType persistenceParentType = createTestConditionType("persistenceParent", new HashSet<>(Arrays.asList("tag3")), null);
+            persistenceParentType.setTenantId(SYSTEM_TENANT);
+
+            Condition persistenceParentCondition = new Condition();
+            persistenceParentCondition.setConditionTypeId("persistenceParent");
+            ConditionType persistenceChildType = createTestConditionType("persistenceChild", new HashSet<>(Arrays.asList("tag4")), null);
+            persistenceChildType.setTenantId(SYSTEM_TENANT);
+            persistenceChildType.setParentCondition(persistenceParentCondition);
+
+            // Load bundle items first (child before parent)
+            executionContextManager.executeAsSystem(() -> {
+                registerPluginType(bundleChildType, bundleId);
+                registerPluginType(bundleParentType, bundleId);
+            });
+
+            // Save persistence items in wrong order
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(persistenceChildType);
+                persistenceService.save(persistenceParentType);
+            });
+
+            definitionsService.refresh();
+
+            // Verify both bundle and persistence items have resolved parents
+            executionContextManager.executeAsSystem(() -> {
+                // Bundle child
+                ConditionType bundleChild = persistenceService.load("bundleChild", ConditionType.class);
+                if (bundleChild == null) {
+                    bundleChild = definitionsService.getConditionType("bundleChild");
+                }
+                if (bundleChild != null && bundleChild.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(bundleChild.getParentCondition(), "test");
+                    assertTrue(resolved, "Bundle child's parent should be resolvable");
+                }
+
+                // Persistence child
+                ConditionType persistenceChild = persistenceService.load("persistenceChild", ConditionType.class);
+                assertNotNull(persistenceChild, "Persistence child should exist");
+                if (persistenceChild.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(persistenceChild.getParentCondition(), "test");
+                    assertTrue(resolved, "Persistence child's parent should be resolvable");
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWhenTenantChildReferencesSystemParentNotYetLoaded() {
+            // Test: Tenant child saved before system parent
+            ConditionType systemParentType = createTestConditionType("systemParentDelayed", new HashSet<>(Arrays.asList("tag1")), null);
+            systemParentType.setTenantId(SYSTEM_TENANT);
+
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("systemParentDelayed");
+            ConditionType tenantChildType = createTestConditionType("tenantChildDelayed", new HashSet<>(Arrays.asList("tag2")), null);
+            tenantChildType.setTenantId("tenant1");
+            tenantChildType.setParentCondition(parentCondition);
+
+            // Save tenant child first, then system parent
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                persistenceService.save(tenantChildType);
+            });
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemParentType);
+            });
+
+            definitionsService.refresh();
+
+            // Verify tenant child resolves to system parent
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType tenantChild = persistenceService.load("tenantChildDelayed", ConditionType.class);
+                assertNotNull(tenantChild, "Tenant child should exist");
+                if (tenantChild.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(tenantChild.getParentCondition(), "test");
+                    assertTrue(resolved, "Tenant child's parent should be resolvable");
+                    assertNotNull(tenantChild.getParentCondition().getConditionType(), "Parent should be resolved");
+                    assertEquals(SYSTEM_TENANT, tenantChild.getParentCondition().getConditionType().getTenantId());
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWhenMultipleTenantsHaveSameChildIdButDifferentParents() {
+            // Test: Multiple tenants, same child ID, different parents, loaded in various orders
+            ConditionType systemParent1 = createTestConditionType("systemParent1", new HashSet<>(Arrays.asList("tag1")), null);
+            systemParent1.setTenantId(SYSTEM_TENANT);
+
+            ConditionType systemParent2 = createTestConditionType("systemParent2", new HashSet<>(Arrays.asList("tag2")), null);
+            systemParent2.setTenantId(SYSTEM_TENANT);
+
+            // Tenant1 child references parent1
+            Condition parent1Condition = new Condition();
+            parent1Condition.setConditionTypeId("systemParent1");
+            ConditionType tenant1Child = createTestConditionType("sharedChild", new HashSet<>(Arrays.asList("tag3")), null);
+            tenant1Child.setTenantId("tenant1");
+            tenant1Child.setParentCondition(parent1Condition);
+
+            // Tenant2 child references parent2
+            Condition parent2Condition = new Condition();
+            parent2Condition.setConditionTypeId("systemParent2");
+            ConditionType tenant2Child = createTestConditionType("sharedChild", new HashSet<>(Arrays.asList("tag4")), null);
+            tenant2Child.setTenantId("tenant2");
+            tenant2Child.setParentCondition(parent2Condition);
+
+            // Save in mixed order
+            executionContextManager.executeAsTenant("tenant2", () -> {
+                persistenceService.save(tenant2Child);
+            });
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemParent1);
+            });
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                persistenceService.save(tenant1Child);
+            });
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemParent2);
+            });
+
+            definitionsService.refresh();
+
+            // Verify each tenant's child resolves to correct parent
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType child = persistenceService.load("sharedChild", ConditionType.class);
+                assertNotNull(child, "Tenant1 child should exist");
+                assertEquals("tenant1", child.getTenantId());
+                if (child.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(child.getParentCondition(), "test");
+                    assertTrue(resolved, "Tenant1 child's parent should be resolvable");
+                    assertEquals("systemParent1", child.getParentCondition().getConditionTypeId());
+                }
+            });
+
+            executionContextManager.executeAsTenant("tenant2", () -> {
+                ConditionType child = persistenceService.load("sharedChild", ConditionType.class);
+                assertNotNull(child, "Tenant2 child should exist");
+                assertEquals("tenant2", child.getTenantId());
+                if (child.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(child.getParentCondition(), "test");
+                    assertTrue(resolved, "Tenant2 child's parent should be resolvable");
+                    assertEquals("systemParent2", child.getParentCondition().getConditionTypeId());
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWhenTenantOverrideHasDifferentParentThanSystem() {
+            // Test: System child has one parent, tenant override has different parent
+            ConditionType systemParent1 = createTestConditionType("systemParent1", new HashSet<>(Arrays.asList("tag1")), null);
+            systemParent1.setTenantId(SYSTEM_TENANT);
+
+            ConditionType systemParent2 = createTestConditionType("systemParent2", new HashSet<>(Arrays.asList("tag2")), null);
+            systemParent2.setTenantId(SYSTEM_TENANT);
+
+            // System child references parent1
+            Condition parent1Condition = new Condition();
+            parent1Condition.setConditionTypeId("systemParent1");
+            ConditionType systemChild = createTestConditionType("overrideChild", new HashSet<>(Arrays.asList("tag3")), null);
+            systemChild.setTenantId(SYSTEM_TENANT);
+            systemChild.setParentCondition(parent1Condition);
+
+            // Tenant override references parent2
+            Condition parent2Condition = new Condition();
+            parent2Condition.setConditionTypeId("systemParent2");
+            ConditionType tenantChild = createTestConditionType("overrideChild", new HashSet<>(Arrays.asList("tag4")), null);
+            tenantChild.setTenantId("tenant1");
+            tenantChild.setParentCondition(parent2Condition);
+
+            // Save in mixed order
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemChild);
+                persistenceService.save(systemParent2);
+            });
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                persistenceService.save(tenantChild);
+            });
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemParent1);
+            });
+
+            definitionsService.refresh();
+
+            // Verify system child resolves to parent1
+            executionContextManager.executeAsSystem(() -> {
+                ConditionType child = persistenceService.load("overrideChild", ConditionType.class);
+                assertNotNull(child, "System child should exist");
+                if (child.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(child.getParentCondition(), "test");
+                    assertTrue(resolved, "System child's parent should be resolvable");
+                    assertEquals("systemParent1", child.getParentCondition().getConditionTypeId());
+                }
+            });
+
+            // Verify tenant override resolves to parent2
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType child = persistenceService.load("overrideChild", ConditionType.class);
+                assertNotNull(child, "Tenant child should exist");
+                assertEquals("tenant1", child.getTenantId());
+                if (child.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(child.getParentCondition(), "test");
+                    assertTrue(resolved, "Tenant child's parent should be resolvable");
+                    assertEquals("systemParent2", child.getParentCondition().getConditionTypeId());
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWhenTenantParentHasSystemGrandparent() {
+            // Test: Tenant-specific parent, but parent's parent is in system tenant
+            ConditionType systemGrandparent = createTestConditionType("systemGrandparent", new HashSet<>(Arrays.asList("tag1")), null);
+            systemGrandparent.setTenantId(SYSTEM_TENANT);
+
+            Condition grandparentCondition = new Condition();
+            grandparentCondition.setConditionTypeId("systemGrandparent");
+            ConditionType tenantParent = createTestConditionType("tenantParent", new HashSet<>(Arrays.asList("tag2")), null);
+            tenantParent.setTenantId("tenant1");
+            tenantParent.setParentCondition(grandparentCondition);
+
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("tenantParent");
+            ConditionType tenantChild = createTestConditionType("tenantChild", new HashSet<>(Arrays.asList("tag3")), null);
+            tenantChild.setTenantId("tenant1");
+            tenantChild.setParentCondition(parentCondition);
+
+            // Save in worst-case order: child, then parent, then grandparent
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                persistenceService.save(tenantChild);
+                persistenceService.save(tenantParent);
+            });
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemGrandparent);
+            });
+
+            definitionsService.refresh();
+
+            // Verify entire chain resolves
+            // Load items from persistence and verify parent condition resolution
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType child = persistenceService.load("tenantChild", ConditionType.class);
+                assertNotNull(child, "Tenant child should exist in persistence");
+                assertEquals("tenant1", child.getTenantId());
+
+                ConditionType parent = persistenceService.load("tenantParent", ConditionType.class);
+                assertNotNull(parent, "Tenant parent should exist in persistence");
+                assertEquals("tenant1", parent.getTenantId());
+
+                // Verify child's parent condition can be resolved
+                if (child.getParentCondition() != null) {
+                    // Ensure parent is in cache first
+                    definitionsService.setConditionType(parent);
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(child.getParentCondition(), "test");
+                    assertTrue(resolved, "Child's parent should be resolvable");
+                    ConditionType resolvedParent = child.getParentCondition().getConditionType();
+                    assertNotNull(resolvedParent, "Parent should be resolved");
+                    assertEquals("tenant1", resolvedParent.getTenantId());
+
+                    // Verify parent's parent (grandparent) can be resolved
+                    if (resolvedParent.getParentCondition() != null) {
+                        // Ensure grandparent is in cache first
+                        executionContextManager.executeAsSystem(() -> {
+                            ConditionType grandparent = definitionsService.getConditionType("systemGrandparent");
+                            if (grandparent == null) {
+                                grandparent = persistenceService.load("systemGrandparent", ConditionType.class);
+                                if (grandparent != null) {
+                                    definitionsService.setConditionType(grandparent);
+                                }
+                            }
+                            return null;
+                        });
+
+                        boolean parentResolved = typeResolutionService != null &&
+                            typeResolutionService.resolveConditionType(resolvedParent.getParentCondition(), "test");
+                        assertTrue(parentResolved, "Parent's parent (grandparent) should be resolvable");
+                        assertNotNull(resolvedParent.getParentCondition().getConditionType(), "Grandparent should be resolved");
+                        assertEquals(SYSTEM_TENANT, resolvedParent.getParentCondition().getConditionType().getTenantId());
+                    }
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWhenSystemParentOverriddenByTenantParent() {
+            // Test: System parent, tenant override of parent, child references parent (should resolve to tenant override)
+            ConditionType systemParent = createTestConditionType("overriddenParent", new HashSet<>(Arrays.asList("tag1")), null);
+            systemParent.setTenantId(SYSTEM_TENANT);
+
+            ConditionType tenantParent = createTestConditionType("overriddenParent", new HashSet<>(Arrays.asList("tag2")), null);
+            tenantParent.setTenantId("tenant1");
+
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("overriddenParent");
+            ConditionType tenantChild = createTestConditionType("tenantChild", new HashSet<>(Arrays.asList("tag3")), null);
+            tenantChild.setTenantId("tenant1");
+            tenantChild.setParentCondition(parentCondition);
+
+            // Save in mixed order
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemParent);
+            });
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                persistenceService.save(tenantChild);
+                persistenceService.save(tenantParent);
+            });
+
+            definitionsService.refresh();
+
+            // Verify tenant child resolves to tenant-specific parent (preference for tenant-specific)
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                ConditionType child = persistenceService.load("tenantChild", ConditionType.class);
+                assertNotNull(child, "Tenant child should exist");
+                if (child.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(child.getParentCondition(), "test");
+                    assertTrue(resolved, "Child's parent should be resolvable");
+                    // Should prefer tenant-specific parent if available
+                    ConditionType resolvedParent = child.getParentCondition().getConditionType();
+                    assertNotNull(resolvedParent, "Parent should be resolved");
+                    // Note: Resolution may prefer tenant-specific, but inheritance might return system
+                    // The key is that it's resolved, not which version
+                }
+            });
+        }
+
+        @Test
+        void shouldResolveParentConditionWithDeepNestedChainAcrossTenants() {
+            // Test: Deep chain (4 levels) with mix of system and tenant items
+            // Level 1: System base
+            ConditionType systemBase = createTestConditionType("systemBase", new HashSet<>(Arrays.asList("tag1")), null);
+            systemBase.setTenantId(SYSTEM_TENANT);
+
+            // Level 2: Tenant intermediate (references system base)
+            Condition baseCondition = new Condition();
+            baseCondition.setConditionTypeId("systemBase");
+            ConditionType tenantIntermediate = createTestConditionType("tenantIntermediate", new HashSet<>(Arrays.asList("tag2")), null);
+            tenantIntermediate.setTenantId("tenant1");
+            tenantIntermediate.setParentCondition(baseCondition);
+
+            // Level 3: System derived (references tenant intermediate)
+            Condition intermediateCondition = new Condition();
+            intermediateCondition.setConditionTypeId("tenantIntermediate");
+            ConditionType systemDerived = createTestConditionType("systemDerived", new HashSet<>(Arrays.asList("tag3")), null);
+            systemDerived.setTenantId(SYSTEM_TENANT);
+            systemDerived.setParentCondition(intermediateCondition);
+
+            // Level 4: Tenant final (references system derived)
+            Condition derivedCondition = new Condition();
+            derivedCondition.setConditionTypeId("systemDerived");
+            ConditionType tenantFinal = createTestConditionType("tenantFinal", new HashSet<>(Arrays.asList("tag4")), null);
+            tenantFinal.setTenantId("tenant1");
+            tenantFinal.setParentCondition(derivedCondition);
+
+            // Save in worst-case order: final, derived, intermediate, base
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                persistenceService.save(tenantFinal);
+                persistenceService.save(tenantIntermediate);
+            });
+            executionContextManager.executeAsSystem(() -> {
+                persistenceService.save(systemDerived);
+                persistenceService.save(systemBase);
+            });
+
+            definitionsService.refresh();
+
+            // Verify entire deep chain resolves
+            // Note: This tests a complex scenario. System items referencing tenant items is an edge case
+            // that may not be fully supported due to tenant isolation. We verify what can be resolved.
+            executionContextManager.executeAsTenant("tenant1", () -> {
+                // Load tenant items from persistence
+                ConditionType finalType = persistenceService.load("tenantFinal", ConditionType.class);
+                assertNotNull(finalType, "Final type should exist in persistence");
+                assertEquals("tenant1", finalType.getTenantId());
+
+                ConditionType intermediate = persistenceService.load("tenantIntermediate", ConditionType.class);
+                assertNotNull(intermediate, "Intermediate should exist in persistence");
+                assertEquals("tenant1", intermediate.getTenantId());
+
+                // Ensure system items are in cache
+                executionContextManager.executeAsSystem(() -> {
+                    ConditionType cachedDerived = definitionsService.getConditionType("systemDerived");
+                    if (cachedDerived == null) {
+                        ConditionType loadedDerived = persistenceService.load("systemDerived", ConditionType.class);
+                        if (loadedDerived != null) {
+                            definitionsService.setConditionType(loadedDerived);
+                        }
+                    }
+                    ConditionType cachedBase = definitionsService.getConditionType("systemBase");
+                    if (cachedBase == null) {
+                        ConditionType loadedBase = persistenceService.load("systemBase", ConditionType.class);
+                        if (loadedBase != null) {
+                            definitionsService.setConditionType(loadedBase);
+                        }
+                    }
+                    return null;
+                });
+
+                // Verify tenant intermediate can resolve its parent (systemBase via inheritance)
+                // This is the valid scenario: tenant items resolving to system items
+                if (intermediate.getParentCondition() != null) {
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean intermediateResolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(intermediate.getParentCondition(), "test");
+                    assertTrue(intermediateResolved, "Intermediate's parent (systemBase) should be resolvable via inheritance");
+                    ConditionType base = intermediate.getParentCondition().getConditionType();
+                    assertNotNull(base, "Base should be resolved");
+                    assertEquals("systemBase", base.getItemId());
+                    assertEquals(SYSTEM_TENANT, base.getTenantId());
+                }
+
+                // Verify tenant final can resolve its parent (systemDerived via inheritance)
+                // Note: systemDerived references tenantIntermediate, which is an edge case
+                // We verify that tenant->system resolution works (the valid part)
+                if (finalType.getParentCondition() != null) {
+                    // Ensure all items are in cache before resolving
+                    // This ensures that resolution can find all referenced items
+                    executionContextManager.executeAsSystem(() -> {
+                        ConditionType cachedDerived = definitionsService.getConditionType("systemDerived");
+                        if (cachedDerived == null) {
+                            ConditionType loadedDerived = persistenceService.load("systemDerived", ConditionType.class);
+                            if (loadedDerived != null) {
+                                definitionsService.setConditionType(loadedDerived);
+                            }
+                        }
+                        return null;
+                    });
+
+                    // Ensure tenantIntermediate is also in cache (from tenant context)
+                    definitionsService.setConditionType(intermediate);
+
+                    // Now verify tenant final can resolve to systemDerived
+                    // Since both systemDerived and tenantIntermediate are in cache,
+                    // the resolution should work from tenant context
+                    TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
+                    boolean resolved = typeResolutionService != null &&
+                        typeResolutionService.resolveConditionType(finalType.getParentCondition(), "test");
+                    assertTrue(resolved, "Final's parent (systemDerived) should be resolvable via inheritance from tenant context");
+                    ConditionType derived = finalType.getParentCondition().getConditionType();
+                    assertNotNull(derived, "Derived should be resolved");
+                    assertEquals(SYSTEM_TENANT, derived.getTenantId(), "Derived should be system tenant");
+
+                    // Verify that systemDerived's parent (tenantIntermediate) can also be resolved
+                    // This should work because we're in tenant context and tenantIntermediate is in cache
+                    if (derived.getParentCondition() != null) {
+                        boolean derivedParentResolved = typeResolutionService != null &&
+                            typeResolutionService.resolveConditionType(derived.getParentCondition(), "test");
+                        assertTrue(derivedParentResolved, "SystemDerived's parent (tenantIntermediate) should be resolvable from tenant context");
+                        assertNotNull(derived.getParentCondition().getConditionType(), "TenantIntermediate should be resolved");
+                        assertEquals("tenant1", derived.getParentCondition().getConditionType().getTenantId());
+                    }
+                }
+
+                // Note: systemDerived references tenantIntermediate, which is an edge case
+                // System items typically shouldn't reference tenant items due to tenant isolation
+                // We verify that the parts that can be resolved (tenant->system) work correctly
+                // The systemDerived->tenantIntermediate reference may not resolve from system context,
+                // but that's expected behavior for this edge case
+            });
+        }
+    }
+
+    // Helper methods to create test objects
+    private ValueType createTestValueType(String id, Set<String> tags, Long pluginId) {
+        ValueType valueType = new ValueType();
+        valueType.setId(id);
+        valueType.setTags(tags);
+        if (pluginId != null) {
+            valueType.setPluginId(pluginId);
+        }
+        return valueType;
+    }
+
+    /**
+     * Creates a test condition type with specified configuration.
+     * Initializes a condition type with the provided ID, tags, and plugin ID.
+     *
+     * @param id The unique identifier for the condition type
+     * @param tags The set of tags to associate with the condition type
+     * @param pluginId The ID of the plugin that owns this condition type, or null if none
+     * @return A configured ConditionType instance
+     */
+    private ConditionType createTestConditionType(String id, Set<String> tags, Long pluginId) {
+        ConditionType conditionType = new ConditionType();
+        conditionType.setItemId(id);
+        if (pluginId != null) {
+            conditionType.setPluginId(pluginId);
+        }
+        Metadata metadata = new Metadata();
+        metadata.setId(id);
+        metadata.setTags(tags);
+        conditionType.setMetadata(metadata);
+        return conditionType;
+    }
+
+    /**
+     * Creates a test action type with specified configuration.
+     * Initializes an action type with the provided ID, tags, and plugin ID.
+     *
+     * @param id The unique identifier for the action type
+     * @param tags The set of tags to associate with the action type
+     * @param pluginId The ID of the plugin that owns this action type, or null if none
+     * @return A configured ActionType instance
+     */
+    private ActionType createTestActionType(String id, Set<String> tags, Long pluginId) {
+        ActionType actionType = new ActionType();
+        actionType.setItemId(id);
+        if (pluginId != null) {
+            actionType.setPluginId(pluginId);
+        }
+        Metadata metadata = new Metadata();
+        metadata.setId(id);
+        metadata.setTags(tags);
+        actionType.setMetadata(metadata);
+        return actionType;
+    }
+
+    /**
+     * Creates a test property merge strategy type with specified configuration.
+     * Initializes a property merge strategy type with the provided ID and plugin ID.
+     *
+     * @param id The unique identifier for the merge strategy type
+     * @param pluginId The ID of the plugin that owns this strategy type, or null if none
+     * @return A configured PropertyMergeStrategyType instance
+     */
+    private PropertyMergeStrategyType createTestPropertyMergeStrategyType(String id, Long pluginId) {
+        PropertyMergeStrategyType type = new PropertyMergeStrategyType();
+        if (pluginId != null) {
+            type.setPluginId(pluginId);
+        }
+        type.setId(id);
+        return type;
+    }
+
+    /**
+     * Registers a plugin type with the definitions service.
+     * Sets up the bundle context if needed and adds the type to plugin tracking.
+     *
+     * @param type The plugin type to register (ConditionType, ActionType, ValueType, or PropertyMergeStrategyType)
+     * @param bundleId The ID of the bundle that owns this plugin type
+     */
+    private void registerPluginType(PluginType type, Long bundleId) {
+        if (type == null || bundleId == null) {
+            return;
+        }
+
+        // Set up the bundle context if needed
+        if (bundle == null) {
+            bundle = mock(Bundle.class);
+            when(bundle.getBundleId()).thenReturn(bundleId);
+            when(bundleContext.getBundle()).thenReturn(bundle);
+        }
+
+        // Register the type with the definitions service
+        if (type instanceof ConditionType) {
+            definitionsService.setConditionType((ConditionType) type);
+        } else if (type instanceof ActionType) {
+            definitionsService.setActionType((ActionType) type);
+        } else if (type instanceof ValueType) {
+            definitionsService.setValueType((ValueType) type);
+        } else if (type instanceof PropertyMergeStrategyType) {
+            definitionsService.setPropertyMergeStrategyType((PropertyMergeStrategyType) type);
+        }
+
+        // Add to plugin types tracking
+        synchronized(definitionsService.getTypesByPlugin()) {
+            List<PluginType> bundlePluginTypes = definitionsService.getTypesByPlugin()
+                .computeIfAbsent(bundleId, k -> new CopyOnWriteArrayList<>());
+            bundlePluginTypes.add(type);
+        }
+    }
+
+    /**
+     * Safely closes an input stream, logging any errors.
+     * Helper method to ensure streams are properly closed in tests.
+     *
+     * @param stream The input stream to close
+     */
+    private void closeQuietly(InputStream stream) {
+        if (stream != null) {
+            try {
+                stream.close();
+            } catch (IOException e) {
+                LOGGER.error("Error closing stream", e);
+            }
+        }
+    }
+
+    /**
+     * Helper class for managing concurrent test execution.
+     * Provides utilities for synchronizing threads and tracking test failures.
+     */
+    private static class ConcurrentTestHelper {
+        private final CyclicBarrier barrier;
+        private final CountDownLatch endLatch;
+        private final AtomicBoolean failed;
+        private final List<Thread> threads;
+
+        /**
+         * Creates a new concurrent test helper.
+         * Initializes synchronization primitives for the specified number of threads.
+         *
+         * @param threadCount The number of threads that will participate in the test
+         */
+        public ConcurrentTestHelper(int threadCount) {
+            this.barrier = new CyclicBarrier(threadCount);
+            this.endLatch = new CountDownLatch(threadCount);
+            this.failed = new AtomicBoolean(false);
+            this.threads = Collections.synchronizedList(new ArrayList<>());
+        }
+
+        /**
+         * Executes test threads and verifies their completion.
+         * Waits for all threads to complete and checks for failures.
+         *
+         * @param testName The name of the test for error reporting
+         * @param timeoutSeconds Maximum time to wait for thread completion
+         * @throws InterruptedException if the wait is interrupted
+         */
+        public void executeAndVerify(String testName, int timeoutSeconds) throws InterruptedException {
+            try {
+                assertTrue(endLatch.await(timeoutSeconds, TimeUnit.SECONDS),
+                    testName + " timed out waiting for threads");
+                assertFalse(failed.get(), testName + " had thread failures");
+            } finally {
+                cleanupThreads();
+            }
+        }
+
+        /**
+         * Starts a new test thread with the specified task.
+         * The thread will wait at the barrier before executing the task.
+         *
+         * @param name The name of the thread for identification
+         * @param task The task to execute in the thread
+         */
+        public void startThread(String name, ThrowingRunnable task) {
+            Thread thread = new Thread(() -> {
+                try {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    task.run();
+                } catch (Exception e) {
+                    failed.set(true);
+                    LOGGER.error("Thread execution failed in {}", name, e);
+                } finally {
+                    endLatch.countDown();
+                }
+            }, name);
+            threads.add(thread);
+            thread.start();
+        }
+
+        /**
+         * Cleans up any remaining test threads.
+         * Interrupts and waits for threads to complete.
+         */
+        private void cleanupThreads() {
+            for (Thread thread : threads) {
+                if (thread.isAlive()) {
+                    thread.interrupt();
+                    try {
+                        thread.join(1000);
+                        if (thread.isAlive()) {
+                            LOGGER.warn("Thread {} could not be stopped gracefully", thread.getName());
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        LOGGER.error("Interrupted while waiting for thread cleanup", e);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    // Test utilities for resource management
+    private static class TestResource implements AutoCloseable {
+        private final InputStream stream;
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+
+        public TestResource(String content) {
+            this.stream = new ByteArrayInputStream(content.getBytes());
+        }
+
+        public InputStream getStream() {
+            return stream;
+        }
+
+        @Override
+        public void close() {
+            if (!closed.getAndSet(true)) {
+                try {
+                    stream.close();
+                } catch (IOException e) {
+                    LOGGER.error("Error closing test resource", e);
+                }
+            }
+        }
+
+        public boolean wasClosed() {
+            return closed.get();
+        }
+    }
+
+    // Simplified test setup methods
+    private void setupMockBundle(long bundleId) {
+        when(bundle.getBundleId()).thenReturn(bundleId);
+        when(bundle.getBundleContext()).thenReturn(bundleContext);
+        when(bundleContext.getBundle()).thenReturn(bundle);
+    }
+
+    private URL createTestURL(final InputStream content) {
+        try {
+            return new URL("memory", "", -1, "/test-condition.json", new URLStreamHandler() {
+                @Override
+                protected URLConnection openConnection(URL u) {
+                    return new URLConnection(u) {
+                        private boolean connected = false;
+
+                        @Override
+                        public void connect() {
+                            if (!connected) {
+                                connected = true;
+                            }
+                        }
+
+                        @Override
+                        public InputStream getInputStream() {
+                            return new BufferedInputStream(content) {
+                                private volatile boolean closed = false;
+
+                                @Override
+                                public void close() throws IOException {
+                                    if (!closed) {
+                                        try {
+                                            super.close();
+                                        } finally {
+                                            content.close();
+                                            closed = true;
+                                        }
+                                    }
+                                }
+                            };
+                        }
+                    };
+                }
+            });
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/services/src/test/java/org/apache/unomi/services/impl/definitions/DefinitionsServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/definitions/DefinitionsServiceImplTest.java
@@ -34,6 +34,7 @@ import org.apache.unomi.services.impl.InMemoryPersistenceServiceImpl;
 import org.apache.unomi.services.impl.TestConditionEvaluators;
 import org.apache.unomi.services.impl.TestTenantService;
 import org.apache.unomi.services.impl.cache.MultiTypeCacheServiceImpl;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -104,6 +105,16 @@ class DefinitionsServiceImplTest {
         definitionsService = TestHelper.createDefinitionService(persistenceService, bundleContext, schedulerService, multiTypeCacheService, executionContextManager, tenantService);
         // Inject definitionsService into the dispatcher
         TestHelper.injectDefinitionsServiceIntoDispatcher(conditionEvaluatorDispatcher, definitionsService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (definitionsService != null) {
+            definitionsService.preDestroy();
+        }
+        if (schedulerService instanceof org.apache.unomi.services.impl.scheduler.SchedulerServiceImpl) {
+            ((org.apache.unomi.services.impl.scheduler.SchedulerServiceImpl) schedulerService).preDestroy();
+        }
     }
 
     @Nested
@@ -257,44 +268,41 @@ class DefinitionsServiceImplTest {
             CountDownLatch endLatch = new CountDownLatch(threadCount * 2);
             AtomicBoolean failed = new AtomicBoolean(false);
 
-            // Use synchronized mock to avoid race conditions
-            synchronized(tenantService) {
-                for (int i = 0; i < threadCount; i++) {
-                    final int index = i;
+            for (int i = 0; i < threadCount; i++) {
+                final int index = i;
 
-                    // System tenant thread
-                    new Thread(() -> {
-                        try {
-                            barrier.await();
-                            executionContextManager.executeAsSystem(() -> {
-                                ConditionType conditionType = createTestConditionType("test" + index, new HashSet<>(Arrays.asList("tag1")), null);
-                                definitionsService.setConditionType(conditionType);
+                // System tenant thread
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        executionContextManager.executeAsSystem(() -> {
+                            ConditionType conditionType = createTestConditionType("test" + index, new HashSet<>(Arrays.asList("tag1")), null);
+                            definitionsService.setConditionType(conditionType);
 
-                            });
-                        } catch (Exception e) {
-                            failed.set(true);
-                            LOGGER.error("Thread execution failed", e);
-                        } finally {
-                            endLatch.countDown();
-                        }
-                    }).start();
+                        });
+                    } catch (Exception e) {
+                        failed.set(true);
+                        LOGGER.error("Thread execution failed", e);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }).start();
 
-                    // Custom tenant thread
-                    new Thread(() -> {
-                        try {
-                            barrier.await();
-                            executionContextManager.executeAsTenant("tenant1", () -> {
-                                ConditionType conditionType = createTestConditionType("test" + index + "-tenant", new HashSet<>(Arrays.asList("tag1")), null);
-                                definitionsService.setConditionType(conditionType);
-                            });
-                        } catch (Exception e) {
-                            failed.set(true);
-                            LOGGER.error("Thread execution failed", e);
-                        } finally {
-                            endLatch.countDown();
-                        }
-                    }).start();
-                }
+                // Custom tenant thread
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        executionContextManager.executeAsTenant("tenant1", () -> {
+                            ConditionType conditionType = createTestConditionType("test" + index + "-tenant", new HashSet<>(Arrays.asList("tag1")), null);
+                            definitionsService.setConditionType(conditionType);
+                        });
+                    } catch (Exception e) {
+                        failed.set(true);
+                        LOGGER.error("Thread execution failed", e);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                }).start();
             }
 
             assertTrue(endLatch.await(5, TimeUnit.SECONDS), "Test timed out");
@@ -1681,7 +1689,7 @@ class DefinitionsServiceImplTest {
     @Nested
     class RefreshTimerTests {
         @Test
-        void shouldScheduleAndExecuteRefreshTask() throws InterruptedException {
+        void shouldScheduleAndExecuteRefreshTask() {
             // Create a test condition type
             ConditionType testType = createTestConditionType("testCondition", new HashSet<>(), null);
             definitionsService.setConditionType(testType);
@@ -1689,17 +1697,17 @@ class DefinitionsServiceImplTest {
             // Set a short refresh interval for testing
             definitionsService.setDefinitionsRefreshInterval(100);
 
-            // Wait for at least one refresh cycle
-            Thread.sleep(150);
-
-            // Verify the condition type is still available
-            ConditionType retrieved = definitionsService.getConditionType("testCondition");
+            // Poll until the condition type survives at least one refresh cycle
+            ConditionType retrieved = TestHelper.retryUntil(
+                () -> definitionsService.getConditionType("testCondition"),
+                r -> r != null && testType.getItemId().equals(r.getItemId())
+            );
             assertNotNull(retrieved);
             assertEquals(testType.getItemId(), retrieved.getItemId());
         }
 
         @Test
-        void shouldHandleRefreshFailureGracefully() throws InterruptedException {
+        void shouldHandleRefreshFailureGracefully() {
             // Save original persistence service
             PersistenceService originalPersistence = definitionsService.getPersistenceService();
 
@@ -1714,11 +1722,11 @@ class DefinitionsServiceImplTest {
                 // Set a short refresh interval
                 definitionsService.setDefinitionsRefreshInterval(100);
 
-                // Wait for at least one refresh cycle
-                Thread.sleep(150);
-
-                // Service should still be operational with in-memory data
-                assertNotNull(definitionsService.getConditionType("testCondition"));
+                // Poll until a refresh cycle fires with null persistence and in-memory data is still intact
+                assertNotNull(TestHelper.retryUntil(
+                    () -> definitionsService.getConditionType("testCondition"),
+                    r -> r != null
+                ));
             } finally {
                 // Restore original persistence service
                 definitionsService.setPersistenceService(originalPersistence);
@@ -1739,10 +1747,7 @@ class DefinitionsServiceImplTest {
                 isShutdownField.setAccessible(true);
                 assertTrue((Boolean) isShutdownField.get(definitionsService));
 
-                // Wait for potential refresh cycle
-                Thread.sleep(150);
-
-                // Service should still respond to direct calls but not refresh
+                // Poll briefly — refresh must not fire after shutdown; direct calls must still work
                 ConditionType testType = createTestConditionType("testCondition", new HashSet<>(), null);
                 definitionsService.setConditionType(testType);
                 assertNotNull(definitionsService.getConditionType("testCondition"));

--- a/services/src/test/java/org/apache/unomi/services/impl/events/EventServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/events/EventServiceImplTest.java
@@ -1,0 +1,840 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.services.impl.events;
+
+import org.apache.unomi.api.*;
+import org.apache.unomi.api.actions.ActionPostExecutor;
+import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.api.query.Query;
+import org.apache.unomi.api.services.EventListenerService;
+import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.api.services.SchedulerService;
+import org.apache.unomi.api.tenants.Tenant;
+import org.apache.unomi.persistence.spi.PersistenceService;
+import org.apache.unomi.persistence.spi.conditions.evaluator.ConditionEvaluatorDispatcher;
+import org.apache.unomi.services.TestHelper;
+import org.apache.unomi.services.common.security.AuditServiceImpl;
+import org.apache.unomi.services.common.security.ExecutionContextManagerImpl;
+import org.apache.unomi.services.common.security.KarafSecurityService;
+import org.apache.unomi.services.impl.InMemoryPersistenceServiceImpl;
+import org.apache.unomi.services.impl.TestConditionEvaluators;
+import org.apache.unomi.services.impl.TestTenantService;
+import org.apache.unomi.services.impl.cache.MultiTypeCacheServiceImpl;
+import org.apache.unomi.services.impl.definitions.DefinitionsServiceImpl;
+import org.apache.unomi.tracing.api.TracerService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class EventServiceImplTest {
+
+    private EventServiceImpl eventService;
+    private TestTenantService tenantService;
+    private PersistenceService persistenceService;
+    private DefinitionsServiceImpl definitionsService;
+    private MultiTypeCacheServiceImpl multiTypeCacheService;
+    private ExecutionContextManagerImpl executionContextManager;
+    private KarafSecurityService securityService;
+    private AuditServiceImpl auditService;
+
+    @Mock
+    private BundleContext bundleContext;
+    private SchedulerService schedulerService;
+    @Mock
+    private EventListenerService eventListener;
+    @Mock
+    private ServiceReference<EventListenerService> eventListenerReference;
+    private TracerService tracerService;
+
+    private static final String TENANT_1 = "tenant1";
+    private static final String TENANT_2 = "tenant2";
+    private static final String SYSTEM_TENANT = "system";
+
+    @BeforeEach
+    public void setUp() {
+
+        tenantService = new TestTenantService();
+
+        // Create tenants using TestHelper
+        TestHelper.setupCommonTestData(tenantService);
+
+        // Set up condition evaluator dispatcher
+        ConditionEvaluatorDispatcher conditionEvaluatorDispatcher = TestConditionEvaluators.createDispatcher();
+
+        // Set up bundle context using TestHelper
+        bundleContext = TestHelper.createMockBundleContext();
+
+        securityService = TestHelper.createSecurityService();
+        executionContextManager = TestHelper.createExecutionContextManager(securityService);
+        multiTypeCacheService = new MultiTypeCacheServiceImpl();
+
+        // Set up persistence service
+        persistenceService = new InMemoryPersistenceServiceImpl(executionContextManager, conditionEvaluatorDispatcher);
+
+        // Create scheduler service using TestHelper
+        schedulerService = TestHelper.createSchedulerService("event-service-scheduler-node", persistenceService, executionContextManager, bundleContext, null, -1, true, true);
+
+        // Set up definitions service
+        definitionsService = TestHelper.createDefinitionService(persistenceService, bundleContext, schedulerService, multiTypeCacheService, executionContextManager, tenantService);
+        // Inject definitionsService into the dispatcher
+        TestHelper.injectDefinitionsServiceIntoDispatcher(conditionEvaluatorDispatcher, definitionsService);
+
+        TestConditionEvaluators.getConditionTypes().forEach((key, value) -> definitionsService.setConditionType(value));
+
+        // Set up event service using TestHelper
+        tracerService = TestHelper.createTracerService();
+        eventService = TestHelper.createEventService(persistenceService, bundleContext, definitionsService, tenantService, tracerService);
+
+        // Set up event listener mock
+        when(bundleContext.getService(eventListenerReference)).thenReturn(eventListener);
+        when(eventListener.canHandle(any(Event.class))).thenReturn(true);
+        eventService.bind(eventListenerReference);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        // Use the common tearDown method from TestHelper
+        TestHelper.tearDown(
+            schedulerService,
+            multiTypeCacheService,
+            persistenceService,
+            tenantService,
+            TENANT_1, TENANT_2, SYSTEM_TENANT
+        );
+
+        // Clean up references using the helper method
+        TestHelper.cleanupReferences(
+            tenantService, securityService, executionContextManager, eventService,
+            persistenceService, definitionsService, schedulerService,
+            multiTypeCacheService, auditService, bundleContext, eventListener,
+            eventListenerReference, tracerService
+        );
+    }
+
+    // ========= Event Creation and Basic Operations Tests =========
+
+    @Test
+    public void testSend_BasicEvent() {
+        // Create test event
+        Event event = createTestEvent();
+        event.setPersistent(true);
+
+        // Test
+        int result = eventService.send(event);
+
+        // Verify
+        assertEquals(EventService.NO_CHANGE, result, "Basic event should not change profile/session state (eventType=test)");
+        assertNotNull(persistenceService.load(event.getItemId(), Event.class), "Event should be persisted (eventId=" + event.getItemId() + ")");
+        verify(eventListener, times(1)).onEvent(event);
+    }
+
+    @Test
+    public void testSend_WithProfileUpdate() {
+        // Create test event
+        Event event = createTestEvent();
+        event.setPersistent(true);
+
+        // Setup event listener to trigger profile update
+        when(eventListener.canHandle(any(Event.class))).thenReturn(true);
+        when(eventListener.onEvent(any(Event.class))).thenReturn(EventService.PROFILE_UPDATED);
+
+        // Test
+        int result = eventService.send(event);
+
+        // Verify
+        assertEquals(EventService.PROFILE_UPDATED, result & EventService.PROFILE_UPDATED, "Profile update flag should be set after listener triggers update");
+        verify(eventListener, times(21)).onEvent(any(Event.class)); // Original event + profileUpdated event recursive (max depth 20)
+    }
+
+    @Test
+    public void testSend_WithPostExecutor() {
+        // Create test event
+        Event event = createTestEvent();
+        event.setPersistent(true);
+
+        // Add post executor
+        ActionPostExecutor postExecutor = mock(ActionPostExecutor.class);
+        when(postExecutor.execute()).thenReturn(true);
+        event.getActionPostExecutors().add(postExecutor);
+
+        // Test
+        int result = eventService.send(event);
+
+        // Verify
+        verify(postExecutor, times(1)).execute();
+        assertEquals(EventService.NO_CHANGE, result, "Post executor should not alter result flags (eventType=test)");
+    }
+
+    @Test
+    public void testSend_MaxRecursionDepth() {
+        // Create test event that triggers profile update
+        Event event = createTestEvent();
+        event.setPersistent(true);
+        when(eventListener.canHandle(any(Event.class))).thenReturn(true);
+        when(eventListener.onEvent(any(Event.class))).thenReturn(EventService.PROFILE_UPDATED);
+
+        // Test
+        int result = eventService.send(event);
+
+        // Verify that after max recursion is reached, we get NO_CHANGE
+        verify(eventListener, times(21)).onEvent(any(Event.class)); // 20 is max recursion depth
+        assertEquals(EventService.PROFILE_UPDATED | EventService.SESSION_UPDATED, result, "Result flags should reflect last recursion state");
+    }
+
+    @Test
+    public void testGetEvent() {
+        // Create and save test event
+        Event event = createTestEvent();
+        persistenceService.save(event);
+
+        // Test
+        Event result = eventService.getEvent(event.getItemId());
+
+        // Verify
+        assertNotNull(result, "Loaded event should exist (eventId=" + event.getItemId() + ")");
+        assertEquals(event.getItemId(), result.getItemId(), "Loaded event id should match requested id");
+    }
+
+    @Test
+    public void testDeleteEvent() {
+        // Create and save test event
+        Event event = createTestEvent();
+        event.setItemId("testEventId");
+        persistenceService.save(event);
+
+        // Test
+        eventService.deleteEvent("testEventId");
+
+        // Verify
+        assertNull(persistenceService.load("testEventId", Event.class), "Deleted event should not be found (eventId=testEventId)");
+    }
+
+    // ========= Event Property and Type Management Tests =========
+
+    @Test
+    public void testGetEventProperties() {
+        // Create test event properties directly in persistence service
+        Map<String, Map<String, Object>> mapping = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> fieldProperties = new HashMap<>();
+        fieldProperties.put("type", "string");
+        properties.put("properties", fieldProperties);
+        mapping.put("testProperty", properties);
+
+        Map<String, Object> nestedProperties = new HashMap<>();
+        Map<String, Map<String, Object>> subProperties = new HashMap<>();
+        Map<String, Object> subProperty = new HashMap<>();
+        subProperty.put("type", "string");
+        subProperties.put("subProp", subProperty);
+        nestedProperties.put("properties", subProperties);
+        mapping.put("nestedProperty", nestedProperties);
+
+        // Set properties mapping directly
+        persistenceService.setPropertyMapping(new PropertyType(new Metadata("testProperty")), Event.ITEM_TYPE);
+        persistenceService.setPropertyMapping(new PropertyType(new Metadata("nestedProperty")), Event.ITEM_TYPE);
+
+        // Test
+        List<EventProperty> result = eventService.getEventProperties();
+
+        // Verify
+        assertNotNull(result, "Event properties should be discoverable from mappings");
+        assertTrue(result.stream().anyMatch(p -> p.getId().equals("properties.testProperty")), "Flat property should be present (properties.testProperty)");
+        assertTrue(result.stream().anyMatch(p -> p.getId().equals("properties.nestedProperty")), "Nested property should be present (properties.nestedProperty)");
+    }
+
+    @Test
+    public void testGetEventProperties_InvalidMapping() {
+        // Setup invalid property mapping
+        Map<String, Map<String, Object>> invalidMapping = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("type", "invalidType");
+        invalidMapping.put("invalidProperty", properties);
+        persistenceService.setPropertyMapping(new PropertyType(new Metadata("invalidProperty")), Event.ITEM_TYPE);
+
+        // Test
+        List<EventProperty> result = eventService.getEventProperties();
+
+        // Verify invalid mapping is handled
+        assertNotNull(result, "Event properties lookup should not fail on invalid mapping");
+        assertTrue(result.stream().anyMatch(p -> p.getId().equals("properties.invalidProperty")), "Invalid property mapping should still list id (properties.invalidProperty)");
+    }
+
+    @Test
+    public void testGetEventTypeIds() {
+        // Setup predefined event types
+        Set<String> predefinedTypes = new HashSet<>(Arrays.asList("type1", "type2"));
+        eventService.setPredefinedEventTypeIds(predefinedTypes);
+
+        // Create and save some events with different types
+        Event event1 = createTestEvent();
+        event1.setEventType("type3");
+        Event event2 = createTestEvent();
+        event2.setEventType("type4");
+        persistenceService.save(event1);
+        persistenceService.save(event2);
+
+        // Test - retry until events are available for aggregation (handles refresh delay)
+        Set<String> result = TestHelper.retryUntil(
+            () -> eventService.getEventTypeIds(),
+            r -> r != null && r.size() >= 4 && r.containsAll(Arrays.asList("type1", "type2", "type3", "type4"))
+        );
+
+        // Verify
+        assertNotNull(result, "Event type ids should include predefined and persisted types");
+        assertEquals(4, result.size(), "All four event types should be returned (type1,type2,type3,type4)");
+        assertTrue(result.containsAll(Arrays.asList("type1", "type2", "type3", "type4")), "Returned set should contain expected types");
+    }
+
+    // ========= Event Search and Query Tests =========
+
+    @Test
+    public void testSearchEvents_WithCondition() {
+        // Create and save test event
+        Event event = createTestEvent();
+        persistenceService.save(event);
+
+        // Create search condition
+        Condition condition = new Condition();
+        condition.setConditionType(definitionsService.getConditionType("eventPropertyCondition"));
+        condition.setParameter("propertyName", "eventType");
+        condition.setParameter("comparisonOperator", "equals");
+        condition.setParameter("propertyValue", "test");
+
+        // Test - retry until event is available (handles refresh delay)
+        PartialList<Event> result = TestHelper.retryQueryUntilAvailable(
+            () -> eventService.searchEvents(condition, 0, 10),
+            1
+        );
+
+        // Verify
+        assertNotNull(result, "Search should return results for matching condition");
+        assertEquals(1, result.size(), "Exactly one event should match condition");
+        assertEquals(event.getItemId(), result.get(0).getItemId(), "Returned event id should match saved event");
+    }
+
+    @Test
+    public void testSearchEvents_BySessionId() {
+        // Create test event
+        Event event = createTestEvent();
+        event.getSession().setItemId("test-session");
+        event.setSessionId("test-session");
+        persistenceService.save(event);
+
+        // Test - retry until event is available (handles refresh delay)
+        PartialList<Event> result = TestHelper.retryQueryUntilAvailable(
+            () -> eventService.searchEvents("test-session", new String[]{"test"}, "", 0, 10, "timeStamp"),
+            1
+        );
+
+        // Verify
+        assertNotNull(result, "Search by session should return results (sessionId=test-session)");
+        assertEquals(1, result.size(), "Exactly one event should match session id");
+        assertEquals(event.getItemId(), result.get(0).getItemId(), "Returned event id should match saved event");
+    }
+
+    @Test
+    public void testSearch_WithQuery() {
+        // Create test event
+        Event event = createTestEvent();
+        persistenceService.save(event);
+
+        // Create query
+        Query query = new Query();
+        query.setText("match");
+        query.setLimit(10);
+
+        // Test
+        PartialList<Event> result = eventService.search(query);
+
+        // Verify
+        assertNotNull(result, "Search should return a PartialList even when no text matches");
+        assertTrue(result.getList().isEmpty(), "No events should match full-text 'match'");
+    }
+
+    @Test
+    public void testSearch_WithScrollQuery() {
+        // Create and save test event
+        Event event = createTestEvent();
+        persistenceService.save(event);
+
+        // Create scroll query
+        Query query = new Query();
+        query.setScrollTimeValidity("1000");
+
+        // Test - retry until event is available (handles refresh delay)
+        PartialList<Event> result = TestHelper.retryQueryUntilAvailable(
+            () -> eventService.search(query),
+            1
+        );
+
+        // Verify
+        assertNotNull(result, "Scroll search should initialize a cursor and return results");
+        assertEquals(1, result.size(), "Exactly one event should be returned by scroll search");
+        assertEquals(event.getItemId(), result.get(0).getItemId(), "Returned event id should match saved event");
+    }
+
+    @Test
+    public void testSearch_WithFullTextAndCondition() {
+        // Create and save test event
+        Event event = createTestEvent();
+        persistenceService.save(event);
+
+        // Create query with condition and text
+        Query query = new Query();
+        query.setText("test");
+        Condition condition = new Condition(definitionsService.getConditionType("eventPropertyCondition"));
+        condition.setParameter("propertyName", "eventType");
+        condition.setParameter("comparisonOperator", "equals");
+        condition.setParameter("propertyValue", "test");
+        query.setCondition(condition);
+
+        // Test - retry until event is available (handles refresh delay)
+        PartialList<Event> result = TestHelper.retryQueryUntilAvailable(
+            () -> eventService.search(query),
+            1
+        );
+
+        // Verify
+        assertNotNull(result, "Combined full-text and condition search should return results");
+        assertEquals(1, result.size(), "Exactly one event should match combined criteria");
+        assertEquals(event.getItemId(), result.get(0).getItemId(), "Returned event id should match saved event");
+    }
+
+    @Test
+    public void testSearch_EdgeCases() {
+        // Test with null query
+        Query nullQuery = new Query();
+        PartialList<Event> result = eventService.search(nullQuery);
+        assertNotNull(result, "Null query should yield an empty PartialList, not null");
+
+        // Test with empty condition
+        Query emptyConditionQuery = new Query();
+        emptyConditionQuery.setCondition(new Condition());
+        result = eventService.search(emptyConditionQuery);
+        assertNotNull(result, "Empty condition should yield an empty PartialList, not null");
+
+        // Test with invalid scroll identifier
+        Query invalidScrollQuery = new Query();
+        invalidScrollQuery.setScrollIdentifier("invalid");
+        result = eventService.search(invalidScrollQuery);
+        assertNotNull(result, "Invalid scroll id should return an empty PartialList, not null");
+    }
+
+    // ========= Event Duplicate Detection Tests =========
+
+    @Test
+    public void testHasEventAlreadyBeenRaised() {
+        // Create and save test event
+        Event event = createTestEvent();
+        event.setItemId("test-event");
+        event.setSessionId("test-session");
+        event.setProfileId("test-profile");
+        persistenceService.save(event);
+
+        // Test
+        boolean result = eventService.hasEventAlreadyBeenRaised(event);
+
+        // Verify
+        assertTrue(result, "Duplicate check should return true for already saved event (eventId=test-event)");
+    }
+
+    @Test
+    public void testHasEventAlreadyBeenRaised_WithSession() {
+        // Create and save test event
+        Event event = createTestEvent();
+        TestItem target = new TestItem();
+        target.setItemId("targetId");
+        target.setItemType("targetType");
+        event.setTarget(target);
+        persistenceService.save(event);
+
+        // Test with session parameter - retry until event is available for query (handles refresh delay)
+        boolean result = TestHelper.retryUntil(
+            () -> eventService.hasEventAlreadyBeenRaised(event, true),
+            r -> r == true
+        );
+
+        // Verify
+        assertTrue(result, "Duplicate check should respect session scoping when requested");
+    }
+
+    // ========= Profile Event Management Tests =========
+
+    @Test
+    public void testRemoveProfileEvents() {
+        // Create and save test events
+        Event event1 = createTestEvent();
+        event1.setProfileId("test-profile");
+        event1.getProfile().setItemId("test-profile");
+        Event event2 = createTestEvent();
+        event2.setProfileId("test-profile");
+        event2.getProfile().setItemId("test-profile");
+        persistenceService.save(event1);
+        persistenceService.save(event2);
+
+        // Test
+        eventService.removeProfileEvents("test-profile");
+
+        // Verify
+        assertNull(persistenceService.load(event1.getItemId(), Event.class), "Profile events should be removed (profileId=test-profile)");
+        assertNull(persistenceService.load(event2.getItemId(), Event.class), "Profile events should be removed (profileId=test-profile)");
+    }
+
+    // ========= Event Service Lifecycle Tests =========
+
+    @Test
+    public void testBindUnbind() {
+        // Create mock service reference and event listener
+        ServiceReference<EventListenerService> serviceReference = mock(ServiceReference.class);
+        EventListenerService eventListener = mock(EventListenerService.class);
+        when(bundleContext.getService(serviceReference)).thenReturn(eventListener);
+
+        // Test bind
+        eventService.bind(serviceReference);
+
+        // Create and send test event to verify listener was bound
+        Event event = createTestEvent();
+        when(eventListener.canHandle(event)).thenReturn(true);
+        eventService.send(event);
+        verify(eventListener).onEvent(event);
+
+        // Test unbind
+        eventService.unbind(serviceReference);
+
+        // Create and send another event to verify listener was unbound
+        Event event2 = createTestEvent();
+        eventService.send(event2);
+        verify(eventListener, times(1)).onEvent(any(Event.class)); // Should still be 1 from before
+    }
+
+    // ========= Tenant Event Authorization Tests =========
+
+    @Test
+    public void testIsEventAllowedForTenant_RestrictedEvent() {
+        // Setup restricted event types
+        Set<String> restrictedTypes = new HashSet<>(Arrays.asList("restricted"));
+        eventService.setRestrictedEventTypeIds(restrictedTypes);
+
+        // Setup tenant with restricted event types and authorized IPs
+        Tenant tenant = new Tenant();
+        tenant.setItemId(TENANT_1);
+        tenant.setRestrictedEventTypes(new HashSet<>(Arrays.asList("restricted")));
+        tenant.setAuthorizedIPs(new HashSet<>(Arrays.asList("127.0.0.1")));
+        tenantService.saveTenant(tenant);
+
+        // Create test event
+        Event event = createTestEvent();
+        event.setEventType("restricted");
+
+        // Test
+        boolean result = eventService.isEventAllowedForTenant(event, TENANT_1, "127.0.0.1");
+
+        // Verify
+        assertTrue(result);
+    }
+
+    @Test
+    public void testEventAllowed() {
+        String tenantId = "test_tenant";
+        String allowedSourceIP = "127.0.0.1";
+        String unallowedSourceIP = "127.0.0.2";
+
+        // Create test tenant with restricted event types and authorized IPs
+        Tenant tenant = new Tenant();
+        tenant.setItemId(tenantId);
+        Set<String> restrictedTypes = new HashSet<>(Arrays.asList("test1", "test2", "test4"));
+        tenant.setRestrictedEventTypes(restrictedTypes);
+        Set<String> ips = new HashSet<>(Arrays.asList(allowedSourceIP));
+        tenant.setAuthorizedIPs(ips);
+        tenantService.saveTenant(tenant);
+
+        // Test with initial restrictions
+        // Restricted events should be checked against IP
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()), tenantId, allowedSourceIP), "Restricted event should be allowed from authorized IPv4 (tenant=" + tenantId + ")");
+        assertFalse(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()), tenantId, unallowedSourceIP), "Restricted event should be blocked from unauthorized IPv4 (tenant=" + tenantId + ")");
+
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test2", null, new Profile(), null, null, null, new Date()), tenantId, allowedSourceIP), "Restricted event should be allowed from authorized IPv4 (tenant=" + tenantId + ")");
+        assertFalse(eventService.isEventAllowedForTenant(new Event("test2", null, new Profile(), null, null, null, new Date()), tenantId, unallowedSourceIP), "Restricted event should be blocked from unauthorized IPv4 (tenant=" + tenantId + ")");
+
+        // Unrestricted events should be allowed regardless of IP
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test3", null, new Profile(), null, null, null, new Date()), tenantId, allowedSourceIP), "Unrestricted event should be allowed regardless of IP");
+
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test4", null, new Profile(), null, null, null, new Date()), tenantId, allowedSourceIP), "Restricted event should be allowed from authorized IPv4 (tenant=" + tenantId + ")");
+
+        // Update tenant restrictions to only restrict test4
+        restrictedTypes = new HashSet<>(Arrays.asList("test4"));
+        tenant.setRestrictedEventTypes(restrictedTypes);
+        tenantService.saveTenant(tenant);
+
+        // Test with updated restrictions
+        // test4 should be IP checked
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test4", null, new Profile(), null, null, null, new Date()), tenantId, allowedSourceIP), "Restricted event should be allowed from authorized IPv4 after update");
+        assertFalse(eventService.isEventAllowedForTenant(new Event("test4", null, new Profile(), null, null, null, new Date()), tenantId, unallowedSourceIP), "Restricted event should be blocked from unauthorized IPv4 after update");
+
+        // All other events should be allowed, regardless of IP since they are not restricted
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()), tenantId, unallowedSourceIP), "Unrestricted event should be allowed (IPv4, tenant=" + tenantId + ")");
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test2", null, new Profile(), null, null, null, new Date()), tenantId, unallowedSourceIP), "Unrestricted event should be allowed (IPv4, tenant=" + tenantId + ")");
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test3", null, new Profile(), null, null, null, new Date()), tenantId, unallowedSourceIP), "Unrestricted event should be allowed (IPv4, tenant=" + tenantId + ")");
+    }
+
+    @Test
+    public void testIsEventAllowedForTenant_TenantAndGlobalRestrictions() {
+        // Setup global restricted event types
+        Set<String> globalRestrictedTypes = new HashSet<>(Arrays.asList("globalRestricted1", "globalRestricted2"));
+        eventService.setRestrictedEventTypeIds(globalRestrictedTypes);
+
+        // Setup tenant with its own restricted event types
+        Tenant tenant = new Tenant();
+        tenant.setItemId(TENANT_1);
+        tenant.setRestrictedEventTypes(new HashSet<>(Arrays.asList("tenantRestricted1", "tenantRestricted2")));
+        tenant.setAuthorizedIPs(new HashSet<>(Arrays.asList("127.0.0.1")));
+        tenantService.saveTenant(tenant);
+
+        // Test cases
+        // 1. Event restricted by tenant - should check IP
+        Event tenantRestrictedEvent = createTestEvent();
+        tenantRestrictedEvent.setEventType("tenantRestricted1");
+        assertTrue(eventService.isEventAllowedForTenant(tenantRestrictedEvent, TENANT_1, "127.0.0.1"), "Tenant-restricted event should be allowed from authorized IP");
+        assertFalse(eventService.isEventAllowedForTenant(tenantRestrictedEvent, TENANT_1, "192.168.1.1"), "Tenant-restricted event should be blocked from unauthorized IP");
+
+        // 2. Event restricted globally - should check IP
+        Event globalRestrictedEvent = createTestEvent();
+        globalRestrictedEvent.setEventType("globalRestricted1");
+        assertTrue(eventService.isEventAllowedForTenant(globalRestrictedEvent, TENANT_1, "127.0.0.1"), "Globally restricted event should be allowed from authorized IP");
+        assertFalse(eventService.isEventAllowedForTenant(globalRestrictedEvent, TENANT_1, "192.168.1.1"), "Globally restricted event should be blocked from unauthorized IP");
+
+        // 3. Event not restricted by either - should be accepted without IP check
+        Event unrestrictedEvent = createTestEvent();
+        unrestrictedEvent.setEventType("unrestricted");
+        assertTrue(eventService.isEventAllowedForTenant(unrestrictedEvent, TENANT_1, "127.0.0.1"), "Unrestricted event should be allowed regardless of IP");
+        assertTrue(eventService.isEventAllowedForTenant(unrestrictedEvent, TENANT_1, "192.168.1.1"), "Unrestricted event should be allowed regardless of IP");
+
+        // 4. Test with another tenant that doesn't have any restrictions
+        Tenant tenant2 = new Tenant();
+        tenant2.setItemId(TENANT_2);
+        tenant2.setRestrictedEventTypes(new HashSet<>());
+        tenant2.setAuthorizedIPs(new HashSet<>(Arrays.asList("127.0.0.1")));
+        tenantService.saveTenant(tenant2);
+
+        // Should still check IP for global-restricted events even if tenant doesn't have local restrictions
+        assertTrue(eventService.isEventAllowedForTenant(globalRestrictedEvent, TENANT_2, "127.0.0.1"), "Global restriction applies across tenants (allowed IP)");
+        assertFalse(eventService.isEventAllowedForTenant(globalRestrictedEvent, TENANT_2, "192.168.1.1"), "Global restriction applies across tenants (unauthorized IP)");
+    }
+
+    @Test
+    public void testIsEventAllowedForTenant_NoTenantRestrictions() {
+        // Setup global restricted event types
+        Set<String> globalRestrictedTypes = new HashSet<>(Arrays.asList("globalRestricted"));
+        eventService.setRestrictedEventTypeIds(globalRestrictedTypes);
+
+        // Setup tenant with no event type restrictions
+        Tenant tenant = new Tenant();
+        tenant.setItemId(TENANT_1);
+        tenant.setAuthorizedIPs(new HashSet<>(Arrays.asList("127.0.0.1")));
+        tenantService.saveTenant(tenant);
+
+        // 1. Event restricted globally - should check IP
+        Event globalRestrictedEvent = createTestEvent();
+        globalRestrictedEvent.setEventType("globalRestricted");
+        assertTrue(eventService.isEventAllowedForTenant(globalRestrictedEvent, TENANT_1, "127.0.0.1")); // Allowed IP
+        assertFalse(eventService.isEventAllowedForTenant(globalRestrictedEvent, TENANT_1, "192.168.1.1")); // Unauthorized IP
+
+        // 2. Event not restricted - should be accepted without IP check
+        Event unrestrictedEvent = createTestEvent();
+        unrestrictedEvent.setEventType("unrestricted");
+        assertTrue(eventService.isEventAllowedForTenant(unrestrictedEvent, TENANT_1, "127.0.0.1")); // Any IP should work
+        assertTrue(eventService.isEventAllowedForTenant(unrestrictedEvent, TENANT_1, "192.168.1.1")); // Any IP should work
+    }
+
+    // ========= IP Authorization Tests =========
+
+    @Test
+    public void testIPv6EventAllowed() {
+        String tenantId = "test_tenant";
+
+        // Create test tenant with IPv6 restrictions and event types
+        Tenant tenant = new Tenant();
+        tenant.setItemId(tenantId);
+        Set<String> restrictedTypes = new HashSet<>(Arrays.asList("test1", "test2", "test4"));
+        tenant.setRestrictedEventTypes(restrictedTypes);
+        Set<String> ips = new HashSet<>(Arrays.asList(
+            "2001:db8::/32",                  // IPv6 CIDR block
+            "::1",                            // IPv6 localhost
+            "2001:db8::1",                    // Single IPv6 address
+            "2001:db8:3:4:5:6:7:8"           // Full IPv6 address
+        ));
+        tenant.setAuthorizedIPs(ips);
+        tenantService.saveTenant(tenant);
+
+        // Test IPv6 addresses with square brackets (as returned by HttpServletRequest.getRemoteAddr)
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "[2001:db8::1]"), "IPv6 in brackets should be accepted when authorized (tenant=" + tenantId + ")");
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "[2001:db8:1:2:3:4:5:6]"), "IPv6 full form in brackets should be accepted when authorized");
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "[::1]"), "IPv6 localhost in brackets should be accepted");
+
+        // Test IPv6 addresses without square brackets
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "2001:db8::1"), "IPv6 without brackets should be accepted when authorized");
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "2001:db8:3:4:5:6:7:8"), "Full IPv6 should be accepted when authorized");
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "::1"), "IPv6 localhost should be accepted");
+
+        // Test unauthorized IPv6 addresses
+        assertFalse(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "[2001:db9::1]"), "IPv6 with different prefix should be rejected (brackets)");
+        assertFalse(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "2001:db9::1"), "IPv6 with different prefix should be rejected");
+    }
+
+    @Test
+    public void testMixedIPv4AndIPv6EventAllowed() {
+        String tenantId = "test_tenant";
+
+        // Create test tenant with mixed IPv4 and IPv6 addresses and restricted event types
+        Tenant tenant = new Tenant();
+        tenant.setItemId(tenantId);
+        Set<String> restrictedTypes = new HashSet<>(Arrays.asList("test1"));
+        tenant.setRestrictedEventTypes(restrictedTypes);
+        Set<String> ips = new HashSet<>(Arrays.asList(
+            "127.0.0.1",                      // IPv4 localhost
+            "192.168.1.0/24",                 // IPv4 CIDR block
+            "2001:db8::/32",                  // IPv6 CIDR block
+            "::1"                             // IPv6 localhost
+        ));
+        tenant.setAuthorizedIPs(ips);
+        tenantService.saveTenant(tenant);
+
+        // Test IPv4 addresses for restricted events
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "127.0.0.1"), "IPv4 localhost should be accepted for restricted event");
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "192.168.1.100"), "IPv4 in allowed CIDR should be accepted for restricted event");
+
+        // Test IPv6 addresses with and without brackets for restricted events
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "[::1]"), "IPv6 localhost in brackets should be accepted for restricted event");
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "::1"), "IPv6 localhost should be accepted for restricted event");
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "[2001:db8::1]"), "IPv6 address in allowed CIDR (brackets) should be accepted");
+        assertTrue(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "2001:db8::1"), "IPv6 address in allowed CIDR should be accepted");
+
+        // Test unauthorized IPs
+        assertFalse(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "192.168.2.1"), "IPv4 outside allowed range should be rejected for restricted event");
+        assertFalse(eventService.isEventAllowedForTenant(new Event("test1", null, new Profile(), null, null, null, new Date()),
+            tenantId, "[2001:db9::1]"), "IPv6 outside allowed CIDR should be rejected for restricted event");
+    }
+
+    // ========= Critical Edge Cases Tests =========
+
+    @Test
+    public void testTenantStateChange() {
+        // Setup initial tenant state
+        Tenant tenant = new Tenant();
+        tenant.setItemId(TENANT_1);
+        tenant.setRestrictedEventTypes(new HashSet<>(Arrays.asList("restricted")));
+        tenant.setAuthorizedIPs(new HashSet<>(Arrays.asList("127.0.0.1")));
+        tenantService.saveTenant(tenant);
+
+        // Create test event
+        Event event = createTestEvent();
+        event.setEventType("restricted");
+
+        // Verify initial state
+        assertTrue(eventService.isEventAllowedForTenant(event, TENANT_1, "127.0.0.1"), "Restricted event should be allowed initially (tenant=" + TENANT_1 + ")");
+
+        // Simulate tenant being disabled/deleted
+        tenantService.deleteTenant(TENANT_1);
+
+        // Verify behavior with missing tenant
+        assertFalse(eventService.isEventAllowedForTenant(event, TENANT_1, "127.0.0.1"), "Event should be rejected when tenant is deleted (tenant=" + TENANT_1 + ")");
+    }
+
+    @Test
+    public void testMalformedEventProperties() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create event with malformed properties
+            Event event = createTestEvent();
+            Map<String, Object> properties = new HashMap<>();
+            properties.put("validKey", "validValue");
+            properties.put("nullKey", null);
+            properties.put("nestedNull", Collections.singletonMap("key", null));
+            event.setProperties(properties);
+            event.setPersistent(true);
+
+            // Test
+            int result = eventService.send(event);
+
+            // Verify the event is handled gracefully
+            assertEquals(EventService.NO_CHANGE, result, "Malformed properties should not break event processing");
+            Event savedEvent = persistenceService.load(event.getItemId(), Event.class);
+            assertNotNull(savedEvent, "Event should be persisted despite malformed properties (eventId=" + event.getItemId() + ")");
+            assertNotNull(savedEvent.getProperties().get("validKey"), "Valid property should be preserved in persistence (key=validKey)");
+        });
+    }
+
+    // ========= Helper Classes =========
+
+    public static class TestItem extends Item {
+        public static final String ITEM_TYPE = "testItem";
+        private static final long serialVersionUID = 1L;
+    }
+
+    // ========= Helper Methods =========
+
+    private Event createTestEvent() {
+        Date timeStamp = new Date();
+        Event event = new Event();
+        event.setTimeStamp(timeStamp);
+        event.setEventType("test");
+        event.setScope("testScope");
+        event.setItemId(UUID.randomUUID().toString());
+        event.setActionPostExecutors(new ArrayList<>());
+        event.setAttributes(Collections.emptyMap());
+
+        Profile profile = new Profile(executionContextManager.getCurrentContext().getTenantId());
+        profile.setItemId("test-profile");
+        event.setProfile(profile);
+        event.setProfileId(profile.getItemId());
+
+        Session session = new Session("test-session", profile, timeStamp, "test");
+        event.setSession(session);
+        event.setSessionId(session.getItemId());
+
+        return event;
+    }
+}

--- a/services/src/test/java/org/apache/unomi/services/impl/goals/GoalsServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/goals/GoalsServiceImplTest.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.services.impl.goals;
+
+import org.apache.unomi.api.Metadata;
+import org.apache.unomi.api.actions.ActionType;
+import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.api.goals.Goal;
+import org.apache.unomi.api.services.ConditionValidationService;
+import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.api.services.RulesService;
+import org.apache.unomi.api.services.SchedulerService;
+import org.apache.unomi.persistence.spi.PersistenceService;
+import org.apache.unomi.persistence.spi.conditions.evaluator.ConditionEvaluatorDispatcher;
+import org.apache.unomi.services.TestHelper;
+import org.apache.unomi.services.common.security.ExecutionContextManagerImpl;
+import org.apache.unomi.services.common.security.KarafSecurityService;
+import org.apache.unomi.services.impl.InMemoryPersistenceServiceImpl;
+import org.apache.unomi.services.impl.TestConditionEvaluators;
+import org.apache.unomi.services.impl.TestEventAdmin;
+import org.apache.unomi.services.impl.TestTenantService;
+import org.apache.unomi.services.impl.cache.MultiTypeCacheServiceImpl;
+import org.apache.unomi.services.impl.definitions.DefinitionsServiceImpl;
+import org.apache.unomi.services.impl.events.EventServiceImpl;
+import org.apache.unomi.services.impl.rules.TestActionExecutorDispatcher;
+import org.apache.unomi.services.impl.scheduler.SchedulerServiceImpl;
+import org.apache.unomi.tracing.api.TracerService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.osgi.framework.BundleContext;
+
+import java.io.IOException;
+import java.util.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class GoalsServiceImplTest {
+
+    private TestTenantService tenantService;
+    private KarafSecurityService securityService;
+    private ExecutionContextManagerImpl executionContextManager;
+    private GoalsServiceImpl goalsService;
+    private PersistenceService persistenceService;
+    private DefinitionsServiceImpl definitionsService;
+    private RulesService rulesService;
+    private EventServiceImpl eventService;
+    private SchedulerService schedulerService;
+    private MultiTypeCacheServiceImpl multiTypeCacheService;
+    @Mock
+    private BundleContext bundleContext;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+
+        TracerService tracerService = TestHelper.createTracerService();
+        tenantService = new TestTenantService();
+        tenantService.setCurrentTenantId("test-tenant");
+        ConditionEvaluatorDispatcher conditionEvaluatorDispatcher = TestConditionEvaluators.createDispatcher();
+        securityService = TestHelper.createSecurityService();
+        executionContextManager = TestHelper.createExecutionContextManager(securityService);
+        persistenceService = new InMemoryPersistenceServiceImpl(executionContextManager, conditionEvaluatorDispatcher);
+        // Mock bundle context
+        bundleContext = TestHelper.createMockBundleContext();
+        schedulerService = TestHelper.createSchedulerService("goals-service-scheduler-node", persistenceService, executionContextManager, bundleContext, null, -1, true, true);
+        // Create scheduler service using TestHelper
+        multiTypeCacheService = new MultiTypeCacheServiceImpl();
+
+        // Initialize mocked services using TestHelper with EventAdmin
+        java.util.Map.Entry<DefinitionsServiceImpl, TestEventAdmin> servicePair =
+            TestHelper.createDefinitionServiceWithEventAdmin(persistenceService, bundleContext, schedulerService,
+                multiTypeCacheService, executionContextManager, tenantService);
+        definitionsService = servicePair.getKey();
+        TestEventAdmin testEventAdmin = servicePair.getValue();
+
+        // Inject definitionsService into the dispatcher
+        TestHelper.injectDefinitionsServiceIntoDispatcher(conditionEvaluatorDispatcher, definitionsService);
+        TestConditionEvaluators.getConditionTypes().forEach((key, value) -> definitionsService.setConditionType(value));
+        ActionType setPropertyAction = TestHelper.createActionType("setPropertyAction", "setPropertyActionExecutor");
+        definitionsService.setActionType(setPropertyAction);
+        ActionType sendEventAction = TestHelper.createActionType("sendEventAction", "sendEventActionExecutor");
+        definitionsService.setActionType(sendEventAction);
+        TestActionExecutorDispatcher actionExecutorDispatcher = new TestActionExecutorDispatcher(definitionsService, persistenceService);
+        actionExecutorDispatcher.setDefaultReturnValue(EventService.PROFILE_UPDATED);
+        eventService = TestHelper.createEventService(persistenceService, bundleContext, definitionsService, tenantService, tracerService);
+        rulesService = TestHelper.createRulesService(persistenceService, bundleContext, schedulerService, definitionsService, eventService, executionContextManager, tenantService, multiTypeCacheService, actionExecutorDispatcher, testEventAdmin);
+
+        // Set the services
+        goalsService = new GoalsServiceImpl();
+        goalsService.setPersistenceService(persistenceService);
+        goalsService.setDefinitionsService(definitionsService);
+        goalsService.setRulesService(rulesService);
+        goalsService.setTracerService(tracerService);
+        goalsService.setCacheService(multiTypeCacheService);
+        goalsService.setContextManager(executionContextManager);
+
+
+        // Mock action type for goal rules
+        ActionType goalActionType = new ActionType() {
+            private Metadata metadata = new Metadata();
+            @Override
+            public String getItemId() {
+                return "goalMatchedAction";
+            }
+            @Override
+            public String getItemType() {
+                return "actionType";
+            }
+            @Override
+            public Metadata getMetadata() {
+                return metadata;
+            }
+            @Override
+            public void setMetadata(Metadata metadata) {
+                this.metadata = metadata;
+            }
+            @Override
+            public Long getVersion() {
+                return 1L;
+            }
+        };
+        goalActionType.getMetadata().setId("goalMatchedAction");
+        definitionsService.setActionType(goalActionType);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        // Shutdown TestEventAdmin if it exists (created via createDefinitionServiceWithEventAdmin)
+        // Note: TestEventAdmin is created internally by createDefinitionService, but we only have access
+        // to it when using createDefinitionServiceWithEventAdmin. For now, we rely on JVM cleanup.
+
+        // Stop scheduler service
+        if (schedulerService != null && schedulerService instanceof SchedulerServiceImpl) {
+            ((SchedulerServiceImpl) schedulerService).preDestroy();
+        }
+
+        // Clear cache by clearing each tenant
+        if (multiTypeCacheService != null) {
+            multiTypeCacheService.clear("test-tenant");
+            multiTypeCacheService.clear("system");
+        }
+
+        // Clear persistence service data if possible
+        if (persistenceService != null && persistenceService instanceof InMemoryPersistenceServiceImpl) {
+            // For test cleanup, we'll pass null which is accepted by the implementation for purging all data
+            ((InMemoryPersistenceServiceImpl) persistenceService).purge((Date)null);
+        }
+
+        // Reset tenant context
+        if (tenantService != null) {
+            tenantService.setCurrentTenantId(null);
+        }
+
+        // Null out references to help with garbage collection
+        tenantService = null;
+        securityService = null;
+        executionContextManager = null;
+        goalsService = null;
+        persistenceService = null;
+        definitionsService = null;
+        rulesService = null;
+        eventService = null;
+        schedulerService = null;
+        multiTypeCacheService = null;
+        bundleContext = null;
+    }
+
+    @Test
+    public void testSetGoalWithInvalidStartEvent() {
+        // Create a goal with invalid start event
+        Goal goal = new Goal();
+        goal.setMetadata(new Metadata());
+        goal.getMetadata().setId("testGoal");
+        goal.getMetadata().setEnabled(true);
+
+        Condition startEvent = new Condition();
+        goal.setStartEvent(startEvent);
+
+        // Mock validation to return errors with enhanced context
+        List<ConditionValidationService.ValidationError> errors = new ArrayList<>();
+        Map<String, Object> context = new HashMap<>();
+        context.put("location", "startEvent");
+        context.put("parameterType", "string");
+        context.put("actualValue", 123);
+        errors.add(new ConditionValidationService.ValidationError(
+            "testParam",
+            "Invalid parameter value",
+            ConditionValidationService.ValidationErrorType.INVALID_VALUE,
+            "testGoal",
+            "startEvent",
+            context,
+            null
+        ));
+
+        // Should throw IllegalArgumentException with detailed message
+        org.junit.jupiter.api.Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> goalsService.setGoal(goal),
+            "Setting goal with invalid startEvent should fail validation (goalId=testGoal, location=startEvent)"
+        );
+    }
+
+    @Test
+    public void testSetGoalWithInvalidTargetEvent() {
+        // Create a goal with invalid target event
+        Goal goal = new Goal();
+        goal.setMetadata(new Metadata());
+        goal.getMetadata().setId("testGoal");
+        goal.getMetadata().setEnabled(true);
+
+        Condition targetEvent = new Condition();
+        goal.setTargetEvent(targetEvent);
+
+        // Mock validation to return errors with enhanced context
+        List<ConditionValidationService.ValidationError> errors = new ArrayList<>();
+        Map<String, Object> context = new HashMap<>();
+        context.put("location", "targetEvent");
+        context.put("parameterType", "integer");
+        context.put("actualValue", "not a number");
+        errors.add(new ConditionValidationService.ValidationError(
+            "testParam",
+            "Invalid parameter value",
+            ConditionValidationService.ValidationErrorType.INVALID_VALUE,
+            "testGoal",
+            "targetEvent",
+            context,
+            null
+        ));
+        // Should throw IllegalArgumentException with detailed message
+        org.junit.jupiter.api.Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> goalsService.setGoal(goal),
+            "Setting goal with invalid targetEvent should fail validation (goalId=testGoal, location=targetEvent)"
+        );
+    }
+
+    @Test
+    public void testSetGoalWithValidEvents() {
+        // Create a goal with valid events
+        Goal goal = new Goal();
+        goal.setMetadata(new Metadata());
+        goal.getMetadata().setId("testGoal");
+        goal.getMetadata().setEnabled(true);
+
+        Condition startEvent = new Condition();
+        startEvent.setConditionType(definitionsService.getConditionType("profilePropertyCondition"));
+        startEvent.setParameter("propertyName", "profileProperty");
+        startEvent.setParameter("comparisonOperator", "exists");
+        Condition targetEvent = new Condition();
+        targetEvent.setConditionType(definitionsService.getConditionType("profilePropertyCondition"));
+        targetEvent.setParameter("propertyName", "profileProperty");
+        targetEvent.setParameter("comparisonOperator", "exists");
+        goal.setStartEvent(startEvent);
+        goal.setTargetEvent(targetEvent);
+
+        // Should not throw any exceptions
+        goalsService.setGoal(goal);
+    }
+
+    @Test
+    public void testSetGoalWithNestedConditions() {
+        // Create a goal with nested conditions
+        Goal goal = new Goal();
+        goal.setMetadata(new Metadata());
+        goal.getMetadata().setId("testGoal");
+        goal.getMetadata().setEnabled(true);
+
+        // Create parent condition
+        Condition parentCondition = new Condition();
+        parentCondition.setConditionTypeId("booleanCondition");
+        parentCondition.setConditionType(definitionsService.getConditionType("booleanCondition"));
+        parentCondition.setParameter("operator", "and");
+
+        // Create child condition
+        Condition childCondition = new Condition();
+        childCondition.setConditionTypeId("profilePropertyCondition");
+        childCondition.setConditionType(definitionsService.getConditionType("profilePropertyCondition"));
+        childCondition.setParameter("propertyName", "profileProperty");
+        childCondition.setParameter("comparisonOperator", "exists");
+
+        // Set up nested structure
+        List<Condition> subConditions = new ArrayList<>();
+        subConditions.add(childCondition);
+        parentCondition.setParameter("subConditions", subConditions);
+
+        goal.setStartEvent(parentCondition);
+
+        // Should not throw any exceptions
+        goalsService.setGoal(goal);
+    }
+}

--- a/services/src/test/java/org/apache/unomi/services/impl/goals/GoalsServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/goals/GoalsServiceImplTest.java
@@ -195,22 +195,6 @@ public class GoalsServiceImplTest {
         Condition startEvent = new Condition();
         goal.setStartEvent(startEvent);
 
-        // Mock validation to return errors with enhanced context
-        List<ConditionValidationService.ValidationError> errors = new ArrayList<>();
-        Map<String, Object> context = new HashMap<>();
-        context.put("location", "startEvent");
-        context.put("parameterType", "string");
-        context.put("actualValue", 123);
-        errors.add(new ConditionValidationService.ValidationError(
-            "testParam",
-            "Invalid parameter value",
-            ConditionValidationService.ValidationErrorType.INVALID_VALUE,
-            "testGoal",
-            "startEvent",
-            context,
-            null
-        ));
-
         // Should throw IllegalArgumentException with detailed message
         org.junit.jupiter.api.Assertions.assertThrows(
             IllegalArgumentException.class,
@@ -230,21 +214,6 @@ public class GoalsServiceImplTest {
         Condition targetEvent = new Condition();
         goal.setTargetEvent(targetEvent);
 
-        // Mock validation to return errors with enhanced context
-        List<ConditionValidationService.ValidationError> errors = new ArrayList<>();
-        Map<String, Object> context = new HashMap<>();
-        context.put("location", "targetEvent");
-        context.put("parameterType", "integer");
-        context.put("actualValue", "not a number");
-        errors.add(new ConditionValidationService.ValidationError(
-            "testParam",
-            "Invalid parameter value",
-            ConditionValidationService.ValidationErrorType.INVALID_VALUE,
-            "testGoal",
-            "targetEvent",
-            context,
-            null
-        ));
         // Should throw IllegalArgumentException with detailed message
         org.junit.jupiter.api.Assertions.assertThrows(
             IllegalArgumentException.class,

--- a/services/src/test/java/org/apache/unomi/services/impl/rules/RulesServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/rules/RulesServiceImplTest.java
@@ -1,0 +1,2155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.services.impl.rules;
+
+import org.apache.unomi.api.*;
+import org.apache.unomi.api.actions.Action;
+import org.apache.unomi.api.actions.ActionType;
+import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.api.conditions.ConditionType;
+import org.apache.unomi.api.rules.Rule;
+import org.apache.unomi.api.rules.RuleStatistics;
+import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.api.services.RuleListenerService;
+import org.apache.unomi.api.services.SchedulerService;
+import org.apache.unomi.persistence.spi.PersistenceService;
+import org.apache.unomi.persistence.spi.conditions.evaluator.ConditionEvaluatorDispatcher;
+import org.apache.unomi.services.TestHelper;
+import org.apache.unomi.services.common.security.AuditServiceImpl;
+import org.apache.unomi.services.common.security.ExecutionContextManagerImpl;
+import org.apache.unomi.services.common.security.KarafSecurityService;
+import org.apache.unomi.services.impl.*;
+import org.apache.unomi.services.impl.cache.MultiTypeCacheServiceImpl;
+import org.apache.unomi.services.impl.definitions.DefinitionsServiceImpl;
+import org.apache.unomi.tracing.api.RequestTracer;
+import org.apache.unomi.tracing.api.TracerService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class RulesServiceImplTest {
+
+    private RulesServiceImpl rulesService;
+    private TestTenantService tenantService;
+    private PersistenceService persistenceService;
+    private DefinitionsServiceImpl definitionsService;
+    private MultiTypeCacheServiceImpl multiTypeCacheService;
+    private ExecutionContextManagerImpl executionContextManager;
+    private KarafSecurityService securityService;
+    private AuditServiceImpl auditService;
+
+    @Mock
+    private BundleContext bundleContext;
+    private EventService eventService;
+    private TracerService tracerService;
+    private RequestTracer requestTracer;
+
+    private TestActionExecutorDispatcher actionExecutorDispatcher;
+    private SchedulerService schedulerService;
+    private TestEventAdmin testEventAdmin;
+
+    private static final String TENANT_1 = "tenant1";
+    private static final String TENANT_2 = "tenant2";
+    private static final String SYSTEM_TENANT = "system";
+
+    @BeforeEach
+    public void setUp() throws Exception {
+
+        tracerService = TestHelper.createTracerService();
+        tenantService = new TestTenantService();
+
+        // Create tenants using TestHelper
+        TestHelper.setupCommonTestData(tenantService);
+
+        securityService = TestHelper.createSecurityService();
+        executionContextManager = TestHelper.createExecutionContextManager(securityService);
+
+        // Set up condition evaluator dispatcher
+        ConditionEvaluatorDispatcher conditionEvaluatorDispatcher = TestConditionEvaluators.createDispatcher();
+
+        // Set up bundle context using TestHelper
+        bundleContext = TestHelper.createMockBundleContext();
+
+        multiTypeCacheService = new MultiTypeCacheServiceImpl();
+
+        persistenceService = new InMemoryPersistenceServiceImpl(executionContextManager, conditionEvaluatorDispatcher);
+
+        // Create scheduler service using TestHelper
+        schedulerService = TestHelper.createSchedulerService("rule-scheduler-node", persistenceService, executionContextManager, bundleContext, null, -1, true, true);
+
+        // Create definitions service with TestEventAdmin
+        java.util.Map.Entry<DefinitionsServiceImpl, TestEventAdmin> servicePair =
+            TestHelper.createDefinitionServiceWithEventAdmin(persistenceService, bundleContext, schedulerService,
+                multiTypeCacheService, executionContextManager, tenantService);
+        definitionsService = servicePair.getKey();
+        testEventAdmin = servicePair.getValue();
+
+        // Inject definitionsService into the dispatcher
+        TestHelper.injectDefinitionsServiceIntoDispatcher(conditionEvaluatorDispatcher, definitionsService);
+        TestConditionEvaluators.getConditionTypes().forEach((key, value) -> definitionsService.setConditionType(value));
+
+        eventService = TestHelper.createEventService(persistenceService, bundleContext, definitionsService, tenantService, tracerService);
+
+        rulesService = new RulesServiceImpl();
+
+        // Set up action executor dispatcher
+        actionExecutorDispatcher = new TestActionExecutorDispatcher(definitionsService, persistenceService);
+        actionExecutorDispatcher.setDefaultReturnValue(EventService.PROFILE_UPDATED);
+
+        // Set up tracing
+        TestRequestTracer tracer = new TestRequestTracer(true);
+        actionExecutorDispatcher.setTracer(tracer);
+
+        rulesService.setBundleContext(bundleContext);
+        rulesService.setPersistenceService(persistenceService);
+        rulesService.setDefinitionsService(definitionsService);
+        rulesService.setEventService(eventService);
+        rulesService.setActionExecutorDispatcher(actionExecutorDispatcher);
+        rulesService.setTenantService(tenantService);
+        rulesService.setSchedulerService(schedulerService);
+        rulesService.setContextManager(executionContextManager);
+        rulesService.setTracerService(tracerService);
+        rulesService.setCacheService(multiTypeCacheService);
+
+
+        // Set up condition types
+        setupActionTypes();
+
+        // Initialize rule caches
+        rulesService.postConstruct();
+
+        // Register RulesServiceImpl as an EventHandler with TestEventAdmin
+        // In real OSGi, this would be done via service registry, but for tests we register manually
+        if (testEventAdmin != null) {
+            testEventAdmin.registerHandler(rulesService, "org/apache/unomi/definitions/**");
+        }
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    public void tearDown() {
+        if (testEventAdmin != null) {
+            testEventAdmin.shutdown();
+        }
+        if (rulesService != null) {
+            rulesService.preDestroy();
+        }
+    }
+
+    private void setupActionTypes() {
+        // Create and register test action type using TestHelper
+        ActionType testActionType = TestHelper.createActionType("test", "test");
+        definitionsService.setActionType(testActionType);
+    }
+
+    private Rule createTestRule() {
+        Rule rule = new Rule();
+        rule.setItemId("test-rule");
+        rule.setTenantId(executionContextManager.getCurrentContext().getTenantId());
+
+        Metadata metadata = new Metadata();
+        metadata.setId("test-rule");
+        metadata.setScope("systemscope");
+        metadata.setEnabled(true);
+        rule.setMetadata(metadata);
+
+        // Create a simple condition
+        Condition condition = createEventTypeCondition("test");
+        rule.setCondition(condition);
+
+        // Create a simple action
+        Action action = createTestAction();
+        rule.setActions(Collections.singletonList(action));
+
+        return rule;
+    }
+
+    private Condition createEventTypeCondition(String eventType) {
+        Condition condition = new Condition();
+        condition.setConditionType(definitionsService.getConditionType("eventTypeCondition"));
+        condition.setParameter("eventTypeId", eventType);
+        return condition;
+    }
+
+    private Condition createProfilePropertyCondition(String propertyName, String comparisonOperator, String propertyValue) {
+        Condition condition = new Condition();
+        condition.setConditionType(definitionsService.getConditionType("profilePropertyCondition"));
+        condition.setParameter("propertyName", propertyName);
+        condition.setParameter("comparisonOperator", comparisonOperator);
+        condition.setParameter("propertyValue", propertyValue);
+        return condition;
+    }
+
+    private Condition createSessionPropertyCondition(String propertyName, String comparisonOperator, String propertyValue) {
+        Condition condition = new Condition();
+        condition.setConditionType(definitionsService.getConditionType("sessionPropertyCondition"));
+        condition.setParameter("propertyName", propertyName);
+        condition.setParameter("comparisonOperator", comparisonOperator);
+        condition.setParameter("propertyValue", propertyValue);
+        return condition;
+    }
+
+    private Condition createBooleanCondition(String operator, List<Condition> subConditions) {
+        Condition condition = new Condition();
+        condition.setConditionType(definitionsService.getConditionType("booleanCondition"));
+        condition.setParameter("operator", operator);
+        condition.setParameter("subConditions", subConditions);
+        return condition;
+    }
+
+    private Action createTestAction() {
+        Action action = new Action();
+        action.setActionType(definitionsService.getActionType("test"));
+        return action;
+    }
+
+    private Event createTestEvent() {
+        Event event = new Event();
+        event.setEventType("test");
+        String currentTenant = executionContextManager.getCurrentContext().getTenantId();
+
+        Profile profile = new Profile(currentTenant);
+        profile.setProperty("testProperty", "testValue"); // Add test property for profile condition
+        event.setProfile(profile);
+        event.setProfileId(profile.getItemId());
+
+        Session session = new Session();
+        session.setItemId(currentTenant);
+        session.setProfile(profile);
+        session.setTenantId(currentTenant);
+        session.setProperty("testProperty", "testValue"); // Add test property for session condition
+        event.setSession(session);
+        event.setSessionId(currentTenant);
+
+        event.setTenantId(currentTenant);
+        event.setAttributes(new HashMap<>());
+        event.setActionPostExecutors(new ArrayList<>());
+
+        Item target = new CustomItem();
+        target.setItemId("targetItemId");
+        event.setTarget(target);
+
+        return event;
+    }
+
+    private Rule createRuleWithUnavailableConditionType(String conditionTypeId) {
+        Rule rule = new Rule();
+        rule.setMetadata(new Metadata());
+        rule.getMetadata().setId("testRule");
+        rule.getMetadata().setEnabled(true);
+        rule.setScope("systemscope");
+
+        Condition condition = new Condition();
+        condition.setConditionTypeId(conditionTypeId);
+        condition.setParameter("propertyName", "testProperty");
+        condition.setParameter("comparisonOperator", "equals");
+        condition.setParameter("propertyValue", "testValue");
+        rule.setCondition(condition);
+
+        Action action = createTestAction();
+        rule.setActions(List.of(action));
+
+        return rule;
+    }
+
+    private ConditionType createTestConditionType(String id) {
+        ConditionType conditionType = new ConditionType();
+        Metadata metadata = new Metadata();
+        metadata.setId(id);
+        metadata.setEnabled(true);
+        conditionType.setMetadata(metadata);
+        conditionType.setConditionEvaluator(id + "Evaluator");
+        conditionType.setQueryBuilder(id + "QueryBuilder");
+        return conditionType;
+    }
+
+    @Test
+    public void testGetMatchingRules_NoRules() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Event event = createTestEvent();
+            Set<Rule> matchedRules = rulesService.getMatchingRules(event);
+            assertTrue(matchedRules.isEmpty(), "Should return empty set when no rules match");
+            return null;
+        });
+    }
+
+    @Test
+    public void testGetMatchingRules_WithMatchingRule() {
+        // Setup test data
+        Event event = createTestEvent();
+        Rule rule = createTestRule();
+        rule.setTenantId(TENANT_1);
+        rulesService.setRule(rule);
+
+        // Execute test
+        Set<Rule> matchedRules = rulesService.getMatchingRules(event);
+
+        // Verify results
+        assertFalse(matchedRules.isEmpty(), "Should return non-empty set when rule matches");
+        assertEquals(1, matchedRules.size(), "Should return one matching rule");
+        assertTrue(matchedRules.contains(rule), "Should contain the matching rule");
+    }
+
+    @Test
+    public void testRuleInheritanceFromSystemTenant() {
+        // Create a rule in system tenant
+        executionContextManager.executeAsSystem(() -> {
+            Rule systemRule = createTestRule();
+            systemRule.setItemId("system-rule");
+            rulesService.setRule(systemRule);
+            return null;
+        });
+
+        // Create a rule in tenant1
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Rule tenantRule = createTestRule();
+            tenantRule.setItemId("tenant-rule");
+            rulesService.setRule(tenantRule);
+
+            // Test that tenant1 can see both rules
+            Set<Rule> allRules = new HashSet<>(rulesService.getAllRules());
+            assertEquals(2, allRules.size(), "Should see both system and tenant rules");
+            assertTrue(allRules.stream().anyMatch(r -> r.getItemId().equals("system-rule")), "Should contain system rule");
+            assertTrue(allRules.stream().anyMatch(r -> r.getItemId().equals("tenant-rule")), "Should contain tenant rule");
+            return null;
+        });
+
+
+        // Test that tenant2 can only see system rule
+        executionContextManager.executeAsTenant(TENANT_2, () -> {
+            Set<Rule> tenant2Rules = new HashSet<>(rulesService.getAllRules());
+            assertEquals(1, tenant2Rules.size(), "Should only see system rule");
+            assertTrue(tenant2Rules.stream().anyMatch(r -> r.getItemId().equals("system-rule")), "Should contain system rule");
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleStatisticsAreTenantSpecific() {
+        // Setup rules in different tenants
+        final Rule[] tenant1Rule = new Rule[1];
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            tenant1Rule[0] = createTestRule();
+            tenant1Rule[0].setItemId("tenant1-rule");
+            tenant1Rule[0].setTenantId(TENANT_1);
+            rulesService.setRule(tenant1Rule[0]);
+            return null;
+        });
+
+        final Rule[] tenant2Rule = new Rule[1];
+        executionContextManager.executeAsTenant(TENANT_2, () -> {
+            tenant2Rule[0] = createTestRule();
+            tenant2Rule[0].setItemId("tenant2-rule");
+            tenant2Rule[0].setTenantId(TENANT_2);
+            rulesService.setRule(tenant2Rule[0]);
+            return null;
+        });
+
+        // Test statistics for tenant1
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Event event1 = createTestEvent();
+            rulesService.getMatchingRules(event1);
+            RuleStatistics stats1 = rulesService.getRuleStatistics(tenant1Rule[0].getItemId());
+            assertNotNull(stats1, "Tenant1 rule statistics should exist");
+            return null;
+        });
+
+        // Test statistics for tenant2
+        executionContextManager.executeAsTenant(TENANT_2, () -> {
+            Event event2 = createTestEvent();
+            rulesService.getMatchingRules(event2);
+            RuleStatistics stats2 = rulesService.getRuleStatistics(tenant2Rule[0].getItemId());
+            assertNotNull(stats2, "Tenant2 rule statistics should exist");
+
+            // Verify tenant isolation
+            assertNull(rulesService.getRuleStatistics(tenant1Rule[0].getItemId()),
+                "Tenant2 should not see tenant1's rule statistics");
+            return null;
+        });
+    }
+
+    @Test
+    public void testOnEvent_ExecutesActions() {
+        // Setup test data
+        Event event = createTestEvent();
+        Rule rule = createTestRule();
+        rule.setTenantId(TENANT_1);
+        rulesService.setRule(rule);
+
+        // Execute test
+        int result = rulesService.onEvent(event);
+
+        // Verify results
+        assertEquals(EventService.PROFILE_UPDATED, result, "Should return PROFILE_UPDATED flag");
+    }
+
+    @Test
+    public void testRuleStatistics() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Setup test data
+            Event event = createTestEvent();
+            Rule rule = createTestRule();
+            rule.setTenantId(TENANT_1);
+            rulesService.setRule(rule);
+
+            rulesService.refreshRules();
+
+            // Execute test - retry until event is available for rule matching (handles refresh delay)
+            Set<Rule> matchingRules = TestHelper.retryUntil(
+                () -> rulesService.getMatchingRules(event),
+                r -> r != null && !r.isEmpty()
+            );
+            assertNotNull(matchingRules, "Matching rules should exist");
+            assertTrue(!matchingRules.isEmpty(), "Matching rules should not be empty");
+
+            // Verify statistics were updated
+            RuleStatistics stats = rulesService.getRuleStatistics(rule.getItemId());
+            assertNotNull(stats, "Rule statistics should be created");
+            assertEquals(TENANT_1, stats.getTenantId(), "Statistics should have correct tenant ID");
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleListener() {
+        // Setup test data
+        Event event = createTestEvent();
+        Rule rule = createTestRule();
+        rulesService.setRule(rule);
+
+        // Create and register mock listener
+        RuleListenerService listener = mock(RuleListenerService.class);
+        ServiceReference<RuleListenerService> serviceRef = mock(ServiceReference.class);
+        when(bundleContext.getService(serviceRef)).thenReturn(listener);
+
+        rulesService.bind(serviceRef);
+
+        // Execute test
+        rulesService.fireEvaluate(rule, event);
+
+        // Verify listener was called
+        verify(listener, times(1)).onEvaluate(eq(rule), eq(event));
+    }
+
+    @Test
+    public void testSetRule() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Setup
+            Rule rule = createTestRule();
+            rule.setTenantId(TENANT_1);
+
+            // Execute
+            rulesService.setRule(rule);
+
+            // Verify
+            Rule savedRule = persistenceService.load(rule.getItemId(), Rule.class);
+            assertNotNull(savedRule, "Rule should be saved");
+            assertEquals(TENANT_1, savedRule.getTenantId(), "Rule should have correct tenant");
+            assertEquals("systemscope", savedRule.getMetadata().getScope(), "Rule should have correct scope");
+            return null;
+        });
+    }
+
+    @Test
+    public void testRemoveRule() {
+        // Setup
+        Rule rule = createTestRule();
+        rule.setTenantId(TENANT_1);
+        rulesService.setRule(rule);
+
+        // Execute
+        rulesService.removeRule(rule.getItemId());
+
+        // Verify
+        assertNull(persistenceService.load(rule.getItemId(), Rule.class), "Rule should be removed");
+    }
+
+    @Test
+    public void testGetRule() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Setup
+            Rule rule = createTestRule();
+            rule.setItemId("test-rule-id");
+            rule.setTenantId(TENANT_1);
+            rulesService.setRule(rule);
+
+            // Execute
+            Rule result = rulesService.getRule(rule.getItemId());
+
+            // Verify
+            assertNotNull(result, "Should return the rule");
+            assertEquals(rule.getItemId(), result.getItemId(), "Should return the correct rule");
+            assertEquals(TENANT_1, result.getTenantId(), "Should have correct tenant");
+            return null;
+        });
+    }
+
+    @Test
+    public void testGetRuleStatistics() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Rule rule = createTestRule();
+            rule.setTenantId(TENANT_1);
+            rulesService.setRule(rule);
+
+            // Execute
+            rulesService.resetAllRuleStatistics();
+            // Execute test
+            rulesService.refreshRules();
+
+            // Verify
+            RuleStatistics stats = rulesService.getRuleStatistics(rule.getItemId());
+            assertNull(stats, "Statistics should be reset");
+            return null;
+        });
+    }
+
+    @Test
+    public void testEventRaisedOnlyOnce() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create and send initial event
+            Event event = createTestEvent();
+            eventService.send(event);
+
+            // Create rule that should only fire once
+            Rule rule = createTestRule();
+            rule.setRaiseEventOnlyOnce(true);
+            rulesService.setRule(rule);
+
+            // Create new event with same ID to test if rule matches
+            Event sameEvent = createTestEvent();
+            sameEvent.setItemId(event.getItemId());
+            Set<Rule> matchedRules = rulesService.getMatchingRules(sameEvent);
+
+            // Verify
+        assertTrue(matchedRules.isEmpty(), "Should not match rule when event already raised");
+            return null;
+        });
+    }
+
+    @Test
+    public void testEventRaisedOnlyOnceForProfile() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create and send initial event
+            Event event = createTestEvent();
+            eventService.send(event);
+
+            // Create rule that should only fire once per profile
+            Rule rule = createTestRule();
+            rule.setRaiseEventOnlyOnceForProfile(true);
+            rulesService.setRule(rule);
+
+            // Create new event with same profile to test if rule matches
+            Event sameProfileEvent = createTestEvent();
+            sameProfileEvent.setProfile(event.getProfile());
+            sameProfileEvent.setTarget(event.getTarget());
+            // Retry until event is available for query (handles refresh delay)
+            // The rule should not match because the event was already raised for this profile
+            Set<Rule> matchedRules = TestHelper.retryUntil(
+                () -> rulesService.getMatchingRules(sameProfileEvent),
+                r -> r != null && r.isEmpty()
+            );
+
+            // Verify
+            assertTrue(matchedRules.isEmpty(), "Should not match rule when event already raised for profile");
+            return null;
+        });
+    }
+
+    @Test
+    public void testProfileConditionMatching() {
+        // Setup
+        Event event = createTestEvent();
+        Rule rule = createTestRule();
+        rule.setTenantId(TENANT_1);
+
+        Condition eventCondition = createEventTypeCondition("test");
+        Condition profileCondition = createProfilePropertyCondition("properties.testProperty", "equals", "testValue");
+        Condition booleanCondition = createBooleanCondition("and", Arrays.asList(eventCondition, profileCondition));
+
+        rule.setCondition(booleanCondition);
+        rulesService.setRule(rule);
+
+        // Set the profile property to match
+        Profile profile = event.getProfile();
+        profile.setProperty("testProperty", "testValue");
+        event.setProfile(profile);
+
+        // Execute
+        Set<Rule> matchedRules = rulesService.getMatchingRules(event);
+
+        // Verify
+        assertFalse(matchedRules.isEmpty(), "Should match rule when both event and profile conditions match");
+    }
+
+    @Test
+    public void testSessionConditionMatching() {
+        // Setup
+        Event event = createTestEvent();
+        Rule rule = createTestRule();
+        rule.setTenantId(TENANT_1);
+
+        Condition eventCondition = createEventTypeCondition("test");
+        Condition sessionCondition = createSessionPropertyCondition("properties.testProperty", "equals", "testValue");
+        Condition booleanCondition = createBooleanCondition("and", Arrays.asList(eventCondition, sessionCondition));
+
+        rule.setCondition(booleanCondition);
+        rulesService.setRule(rule);
+
+        // Set the session property to match
+        Session session = event.getSession();
+        session.setProperty("testProperty", "testValue");
+        event.setSession(session);
+
+        // Execute
+        Set<Rule> matchedRules = rulesService.getMatchingRules(event);
+
+        // Verify
+        assertFalse(matchedRules.isEmpty(), "Should match rule when both event and session conditions match");
+    }
+
+    @Test
+    public void testRefreshRulesHandlesAllTenants() {
+        // Setup rules in different tenants
+        executionContextManager.executeAsSystem(() -> {
+            Rule systemRule = createTestRule();
+            systemRule.setItemId("system-rule");
+            rulesService.setRule(systemRule);
+            return null;
+        });
+
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Rule tenant1Rule = createTestRule();
+            tenant1Rule.setItemId("tenant1-rule");
+            rulesService.setRule(tenant1Rule);
+            return null;
+        });
+
+        executionContextManager.executeAsTenant(TENANT_2, () -> {
+            Rule tenant2Rule = createTestRule();
+            tenant2Rule.setItemId("tenant2-rule");
+            rulesService.setRule(tenant2Rule);
+            return null;
+        });
+
+        // Execute refresh
+        rulesService.refreshRules();
+
+        // Verify rules are loaded for all tenants
+        executionContextManager.executeAsSystem(() -> {
+            assertNotNull(rulesService.getRule("system-rule"), "System rule should be loaded");
+            return null;
+        });
+
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            assertNotNull(rulesService.getRule("tenant1-rule"), "Tenant1 rule should be loaded");
+            return null;
+        });
+
+        executionContextManager.executeAsTenant(TENANT_2, () -> {
+            assertNotNull(rulesService.getRule("tenant2-rule"), "Tenant2 rule should be loaded");
+            return null;
+        });
+    }
+
+    @Test
+    public void testSetRuleWithInvalidCondition() {
+        // Create a rule with invalid condition
+        Rule rule = new Rule();
+        rule.setMetadata(new Metadata());
+        rule.getMetadata().setId("testRule");
+        rule.getMetadata().setEnabled(true);
+
+        Condition condition = new Condition();
+        rule.setCondition(condition);
+
+        // Should throw IllegalArgumentException with detailed message
+        org.junit.jupiter.api.Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> rulesService.setRule(rule),
+            "Setting rule with empty condition should fail validation (ruleId=testRule)"
+        );
+    }
+
+    @Test
+    public void testSetRuleWithValidCondition() {
+        // Create a rule with valid condition
+        Rule rule = new Rule();
+        rule.setMetadata(new Metadata());
+        rule.getMetadata().setId("testRule");
+        rule.getMetadata().setEnabled(true);
+
+        Condition condition = createProfilePropertyCondition("testProperty", "exists", null);
+        rule.setCondition(condition);
+
+        // Should not throw any exceptions
+        rulesService.setRule(rule);
+    }
+
+    @Test
+    public void testSetRuleWithNestedConditions() {
+        Rule rule = new Rule();
+        rule.setMetadata(new Metadata());
+        rule.getMetadata().setId("testRule");
+        rule.getMetadata().setEnabled(true);
+
+        // Create parent condition
+        Condition parentCondition = new Condition();
+        parentCondition.setConditionType(definitionsService.getConditionType("booleanCondition"));
+        parentCondition.setParameter("operator", "and");
+
+        // Create child condition with proper ConditionType set
+        // Note: propertyCondition is an alias, we need to use the actual condition type
+        // For a minimal valid condition, we'll use profilePropertyCondition with minimal required params
+        Condition childCondition = new Condition();
+        childCondition.setConditionType(definitionsService.getConditionType("profilePropertyCondition"));
+        childCondition.setParameter("propertyName", "testProperty");
+        childCondition.setParameter("comparisonOperator", "exists");
+
+        // Set up nested structure
+        List<Condition> subConditions = new ArrayList<>();
+        subConditions.add(childCondition);
+        parentCondition.setParameter("subConditions", subConditions);
+
+        rule.setCondition(parentCondition);
+
+        // Should not throw any exceptions
+        rulesService.setRule(rule);
+    }
+
+    @Test
+    public void testSetRuleWithInvalidNestedCondition() {
+        // Create a rule with nested conditions where child is invalid
+        Rule rule = new Rule();
+        rule.setMetadata(new Metadata());
+        rule.getMetadata().setId("testRule");
+        rule.getMetadata().setEnabled(true);
+
+        // Create parent condition
+        Condition parentCondition = new Condition();
+        parentCondition.setConditionTypeId("booleanCondition");
+
+        // Create invalid child condition
+        Condition childCondition = new Condition();
+        childCondition.setConditionTypeId("propertyCondition");
+
+        // Set up nested structure
+        List<Condition> subConditions = new ArrayList<>();
+        subConditions.add(childCondition);
+        parentCondition.setParameter("subConditions", subConditions);
+
+        rule.setCondition(parentCondition);
+
+        // Should throw IllegalArgumentException with detailed message
+        org.junit.jupiter.api.Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> rulesService.setRule(rule),
+            "Setting rule with invalid nested child condition should fail (ruleId=testRule)"
+        );
+    }
+
+    @Test
+    public void testRuleExecutionWithValidCondition() {
+        // Create a rule with valid condition
+        Rule rule = new Rule();
+        rule.setMetadata(new Metadata());
+        rule.getMetadata().setId("testRule");
+        rule.getMetadata().setEnabled(true);
+        rule.setScope("systemscope");
+
+        Condition condition = new Condition();
+        rule.setCondition(condition);
+
+        // Create test event
+        Event event = new Event();
+        event.setEventType("testEvent");
+        event.setScope("systemscope");
+        event.setProfile(new Profile("testProfile"));
+
+        // Add test action
+        Action action = new Action();
+        ActionType actionType = new ActionType();
+        actionType.setActionExecutor("test");
+        action.setActionType(actionType);
+        rule.setActions(List.of(action));
+
+        // Execute rule
+        rulesService.onEvent(event);
+    }
+
+    @Test
+    public void testSetRuleWithUnavailableConditionType() {
+        Rule rule = createRuleWithUnavailableConditionType("unavailableConditionType");
+
+        rulesService.setRule(rule, true);
+
+        Rule savedRule = persistenceService.load(rule.getItemId(), Rule.class);
+        assertNotNull(savedRule, "Rule should be saved when deployed from bundle");
+        assertNull(definitionsService.getConditionType("unavailableConditionType"), "Condition type should not be available yet");
+
+        ConditionType conditionType = createTestConditionType("unavailableConditionType");
+        definitionsService.setConditionType(conditionType);
+
+        // Refresh persistence to ensure rule is available for querying
+        persistenceService.refresh();
+        rulesService.refreshRules();
+
+        Rule refreshedRule = rulesService.getRule(rule.getItemId());
+        assertNotNull(definitionsService.getConditionType("unavailableConditionType"), "Condition type should be available after being set");
+        assertNotNull(refreshedRule, "Refreshed rule should not be null");
+        // Condition type is resolved on-demand, not automatically on load
+        // Resolve it explicitly for the test using the test's typeResolutionService
+        TypeResolutionServiceImpl testTypeResolutionService = new TypeResolutionServiceImpl(definitionsService);
+        testTypeResolutionService.resolveConditionType(refreshedRule.getCondition(), "test rule condition");
+        assertNotNull(refreshedRule.getCondition().getConditionType(), "Rule condition type should be resolved");
+    }
+
+    @Test
+    public void testSetRuleWithUnavailableConditionTypeNonBundle() {
+        Rule rule = createRuleWithUnavailableConditionType("unavailableConditionType");
+        org.junit.jupiter.api.Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> rulesService.setRule(rule, false),
+            "Non-bundle rule with unavailable condition type should be rejected (conditionTypeId=unavailableConditionType)"
+        );
+    }
+
+    @Test
+    public void testSetRuleWithMissingPluginsFlag() {
+        Rule rule = createRuleWithUnavailableConditionType("unavailableConditionType");
+        rule.getMetadata().setMissingPlugins(true);
+
+        rulesService.setRule(rule, false);
+
+        Rule savedRule = persistenceService.load(rule.getItemId(), Rule.class);
+        assertNotNull(savedRule, "Rule should be saved when missingPlugins is true");
+        assertNull(definitionsService.getConditionType("unavailableConditionType"), "Condition type should not be available yet");
+        assertTrue(savedRule.getMetadata().isMissingPlugins(), "Rule should still be marked as having missing plugins");
+
+        ConditionType conditionType = createTestConditionType("unavailableConditionType");
+        definitionsService.setConditionType(conditionType);
+
+        // Refresh persistence to ensure rule is available for querying
+        persistenceService.refresh();
+        rulesService.refreshRules();
+
+        Rule refreshedRule = rulesService.getRule(rule.getItemId());
+        assertNotNull(definitionsService.getConditionType("unavailableConditionType"), "Condition type should be available after being set");
+        assertNotNull(refreshedRule, "Refreshed rule should not be null");
+        // Condition type is resolved on-demand, not automatically on load
+        // Resolve it explicitly for the test using the test's typeResolutionService
+        TypeResolutionServiceImpl testTypeResolutionService = new TypeResolutionServiceImpl(definitionsService);
+        testTypeResolutionService.resolveConditionType(refreshedRule.getCondition(), "test rule condition");
+        assertNotNull(refreshedRule.getCondition().getConditionType(), "Rule condition type should be resolved");
+    }
+
+    // ==================== Loop Detection Tests ====================
+
+    /**
+     * Helper to create a wildcard rule that matches all events (including ruleFired).
+     */
+    private Rule createWildcardRule(String ruleId) {
+        Rule rule = createTestRule();
+        rule.setItemId(ruleId);
+        rule.setTenantId(TENANT_1);
+        Condition wildcardCondition = new Condition();
+        wildcardCondition.setConditionType(definitionsService.getConditionType("eventTypeCondition"));
+        wildcardCondition.setParameter("eventTypeId", "*");
+        rule.setCondition(wildcardCondition);
+        rule.setActions(Collections.singletonList(createTestAction()));
+        return rule;
+    }
+
+    @Test
+    public void testRuleFiredEventLoopDetection() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Wildcard rule matches ruleFired events, creating a loop
+            Rule wildcardRule = createWildcardRule("wildcard-rule");
+            rulesService.setRule(wildcardRule);
+            rulesService.refreshRules();
+
+            Event event = createTestEvent();
+            event.setEventType("view");
+            event.setItemId("test-event-123"); // Set explicit ID for proper loop detection
+
+            // First event should process normally (triggers rule, which sends ruleFired)
+            // The ruleFired event should be detected as a loop and prevented
+            int result = rulesService.onEvent(event);
+            assertNotNull(result, "Event should return a result without infinite loop");
+
+            // Verify rule was processed (ruleFired was sent but loop was detected)
+            // The key is that processing completes without hanging
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleFiredEventLoopDetectionWithProperIds() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a rule that matches ruleFired events
+            Rule rule = createWildcardRule("rule-matching-ruleFired");
+            rulesService.setRule(rule);
+            rulesService.refreshRules();
+
+            // Create an event with a proper ID
+            Event originalEvent = createTestEvent();
+            originalEvent.setEventType("view");
+            originalEvent.setItemId("original-event-456");
+
+            // Process the event - this will trigger ruleFired
+            // The ruleFired event should use proper ID (source event + rule ID)
+            // and be detected as a loop when it tries to process again
+            int result = rulesService.onEvent(originalEvent);
+            assertNotNull(result, "Should return without infinite loop");
+
+            // Verify the event was processed (but loop was prevented)
+            // The key is that it returns without hanging
+            return null;
+        });
+    }
+
+    @Test
+    public void testGenericEventLoopDetection() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Action executor that sends the same event type with same ID
+            Event loopEvent = createTestEvent();
+            loopEvent.setEventType("customEvent");
+            loopEvent.setItemId("loop-event-789");
+
+            actionExecutorDispatcher.addExecutor("test", (action, evt) -> {
+                // Send the same event (same ID) to create a loop
+                Event newEvent = new Event("customEvent", evt.getSession(), evt.getProfile(),
+                    evt.getScope(), evt, evt.getTarget(), evt.getTimeStamp());
+                newEvent.setItemId("loop-event-789"); // Same ID to trigger loop detection
+                newEvent.setPersistent(false);
+                eventService.send(newEvent);
+                return EventService.NO_CHANGE;
+            });
+
+            Rule rule = createTestRule();
+            rule.setItemId("loop-rule");
+            rule.setTenantId(TENANT_1);
+            rule.setCondition(createEventTypeCondition("customEvent"));
+            Action action = new Action();
+            action.setActionType(definitionsService.getActionType("test"));
+            rule.setActions(Collections.singletonList(action));
+
+            rulesService.setRule(rule);
+            rulesService.refreshRules();
+
+            // Should detect loop when same event ID is processed again
+            int result = rulesService.onEvent(loopEvent);
+            assertNotNull(result, "Should return without infinite loop");
+            return null;
+        });
+    }
+
+    @Test
+    public void testMaximumDepthDetection() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Register action types for this test
+            ActionType testActionType1 = TestHelper.createActionType("test1", "test1");
+            definitionsService.setActionType(testActionType1);
+            ActionType testActionType2 = TestHelper.createActionType("test2", "test2");
+            definitionsService.setActionType(testActionType2);
+
+            // Create a chain of rules that trigger each other (but not a loop)
+            // This should hit maximum depth limit
+
+            // Rule 1: matches eventA, sends eventB
+            actionExecutorDispatcher.addExecutor("test1", (action, evt) -> {
+                Event newEvent = new Event("eventB", evt.getSession(), evt.getProfile(),
+                    evt.getScope(), evt, evt.getTarget(), evt.getTimeStamp());
+                newEvent.setItemId("event-b-" + System.currentTimeMillis()); // Different ID each time
+                newEvent.setPersistent(false);
+                eventService.send(newEvent);
+                return EventService.NO_CHANGE;
+            });
+
+            Rule rule1 = createTestRule();
+            rule1.setItemId("rule-eventA");
+            rule1.setTenantId(TENANT_1);
+            rule1.setCondition(createEventTypeCondition("eventA"));
+            Action action1 = new Action();
+            action1.setActionType(definitionsService.getActionType("test1"));
+            rule1.setActions(Collections.singletonList(action1));
+
+            // Rule 2: matches eventB, sends eventA (creates deep nesting)
+            actionExecutorDispatcher.addExecutor("test2", (action, evt) -> {
+                Event newEvent = new Event("eventA", evt.getSession(), evt.getProfile(),
+                    evt.getScope(), evt, evt.getTarget(), evt.getTimeStamp());
+                newEvent.setItemId("event-a-" + System.currentTimeMillis()); // Different ID each time
+                newEvent.setPersistent(false);
+                eventService.send(newEvent);
+                return EventService.NO_CHANGE;
+            });
+
+            Rule rule2 = createTestRule();
+            rule2.setItemId("rule-eventB");
+            rule2.setTenantId(TENANT_1);
+            rule2.setCondition(createEventTypeCondition("eventB"));
+            Action action2 = new Action();
+            action2.setActionType(definitionsService.getActionType("test2"));
+            rule2.setActions(Collections.singletonList(action2));
+
+            rulesService.setRule(rule1);
+            rulesService.setRule(rule2);
+            rulesService.refreshRules();
+
+            // Start with eventA - this will create deep nesting
+            Event startEvent = createTestEvent();
+            startEvent.setEventType("eventA");
+            startEvent.setItemId("start-event");
+
+            // Should hit maximum depth and return (not hang)
+            // Depth protection is now handled by EventServiceImpl.MAX_RECURSION_DEPTH
+            // RulesServiceImpl only handles loop detection (same event key seen twice)
+            int result = rulesService.onEvent(startEvent);
+            assertNotNull(result, "Should return when maximum depth is reached by EventServiceImpl");
+
+            // Verify that processing can continue after depth limit (ThreadLocal was cleaned up)
+            Event nextEvent = createTestEvent();
+            nextEvent.setEventType("view");
+            nextEvent.setItemId("next-event");
+            int nextResult = rulesService.onEvent(nextEvent);
+            assertNotNull(nextResult, "Should be able to process new events after depth limit");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testNullEventHandling() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            assertEquals(EventService.NO_CHANGE, rulesService.onEvent(null),
+                "Null event should return NO_CHANGE");
+            return null;
+        });
+    }
+
+    @Test
+    public void testEventWithoutId() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Event event = createTestEvent();
+            event.setItemId(null);
+            // Event without ID should still generate a key and be processed
+            assertNotNull(rulesService.onEvent(event), "Event without ID should be processed");
+            return null;
+        });
+    }
+
+    @Test
+    public void testMultipleRulesInLoop() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Multiple wildcard rules should all be caught by loop detection
+            rulesService.setRule(createWildcardRule("rule1"));
+            rulesService.setRule(createWildcardRule("rule2"));
+            rulesService.refreshRules();
+
+            Event event = createTestEvent();
+            event.setEventType("view");
+            event.setItemId("test-event-multi");
+
+            assertNotNull(rulesService.onEvent(event), "Should handle multiple rules in loop");
+            return null;
+        });
+    }
+
+    @Test
+    public void testSameEventIdLoopDetection() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Test that the same event ID is properly detected as a loop
+            Event event = createTestEvent();
+            event.setEventType("testEvent");
+            event.setItemId("same-event-id");
+
+            // Create a rule that sends the same event back
+            actionExecutorDispatcher.addExecutor("test", (action, evt) -> {
+                Event newEvent = new Event("testEvent", evt.getSession(), evt.getProfile(),
+                    evt.getScope(), evt, evt.getTarget(), evt.getTimeStamp());
+                newEvent.setItemId("same-event-id"); // Same ID - should trigger loop detection
+                newEvent.setPersistent(false);
+                eventService.send(newEvent);
+                return EventService.NO_CHANGE;
+            });
+
+            Rule rule = createTestRule();
+            rule.setItemId("loop-back-rule");
+            rule.setTenantId(TENANT_1);
+            rule.setCondition(createEventTypeCondition("testEvent"));
+            Action action = new Action();
+            action.setActionType(definitionsService.getActionType("test"));
+            rule.setActions(Collections.singletonList(action));
+
+            rulesService.setRule(rule);
+            rulesService.refreshRules();
+
+            // Should detect loop when same event ID is processed again
+            int result = rulesService.onEvent(event);
+            assertNotNull(result, "Should detect loop and return");
+            return null;
+        });
+    }
+
+    @Test
+    public void testProcessingContextReuseAfterCleanup() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Verify that ProcessingContext is properly cleaned up and recreated
+            Rule rule = createTestRule();
+            rule.setItemId("reuse-test-rule");
+            rule.setTenantId(TENANT_1);
+            rule.setActions(Collections.singletonList(createTestAction()));
+            rulesService.setRule(rule);
+            rulesService.refreshRules();
+
+            // Process first event - should create ProcessingContext
+            Event event1 = createTestEvent();
+            event1.setItemId("event-1");
+            int result1 = rulesService.onEvent(event1);
+            assertNotNull(result1, "First event should process successfully");
+
+            // Process second event - should reuse ProcessingContext (but different event key, so no loop)
+            Event event2 = createTestEvent();
+            event2.setItemId("event-2");
+            int result2 = rulesService.onEvent(event2);
+            assertNotNull(result2, "Second event should process successfully");
+
+            // Process third event - verify context is still working
+            Event event3 = createTestEvent();
+            event3.setItemId("event-3");
+            int result3 = rulesService.onEvent(event3);
+            assertNotNull(result3, "Third event should process successfully");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testHistoryTrackingWithMultipleRules() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create multiple rules that all match the same event type "test"
+            Rule rule1 = createTestRule();
+            rule1.setItemId("history-rule-1");
+            rule1.setTenantId(TENANT_1);
+            rule1.setCondition(createEventTypeCondition("test")); // Explicitly set to match "test" events
+            rule1.setActions(Collections.singletonList(createTestAction()));
+
+            Rule rule2 = createTestRule();
+            rule2.setItemId("history-rule-2");
+            rule2.setTenantId(TENANT_1);
+            rule2.setCondition(createEventTypeCondition("test")); // Explicitly set to match "test" events
+            rule2.setActions(Collections.singletonList(createTestAction()));
+
+            Rule rule3 = createTestRule();
+            rule3.setItemId("history-rule-3");
+            rule3.setTenantId(TENANT_1);
+            rule3.setCondition(createEventTypeCondition("test")); // Explicitly set to match "test" events
+            rule3.setActions(Collections.singletonList(createTestAction()));
+
+            rulesService.setRule(rule1);
+            rulesService.setRule(rule2);
+            rulesService.setRule(rule3);
+            rulesService.refreshRules();
+
+            // Verify rules are saved and can be retrieved
+            Rule savedRule1 = rulesService.getRule("history-rule-1");
+            Rule savedRule2 = rulesService.getRule("history-rule-2");
+            Rule savedRule3 = rulesService.getRule("history-rule-3");
+            assertNotNull(savedRule1, "Rule 1 should be saved");
+            assertNotNull(savedRule2, "Rule 2 should be saved");
+            assertNotNull(savedRule3, "Rule 3 should be saved");
+
+            // Process event that matches all three rules
+            Event event = createTestEvent();
+            event.setItemId("history-test-event");
+
+            // Verify rules match before processing (with retry to handle indexing delays)
+            Set<Rule> matchingRulesBefore = TestHelper.retryUntil(
+                () -> rulesService.getMatchingRules(event),
+                rules -> rules != null && rules.size() >= 3
+            );
+            assertTrue(matchingRulesBefore.size() >= 3,
+                "Should match at least 3 rules before processing. Found: " + matchingRulesBefore.size());
+
+            // All three rules should fire and be recorded in history
+            int result = rulesService.onEvent(event);
+            assertNotNull(result, "Event should process all matching rules");
+
+            // Verify rules were processed (history tracking happens in processEvent)
+            Set<Rule> matchingRules = rulesService.getMatchingRules(event);
+            assertTrue(matchingRules.size() >= 3,
+                "Should match at least 3 rules after processing. Found: " + matchingRules.size());
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleFiredEventWithNullSource() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Test ruleFired event handling when source is null or malformed
+            Rule rule = createTestRule();
+            rule.setItemId("rule-fired-null-test");
+            rule.setTenantId(TENANT_1);
+            rule.setActions(Collections.singletonList(createTestAction()));
+            rulesService.setRule(rule);
+            rulesService.refreshRules();
+
+            // Create event without ID to test fallback key generation
+            Event event = createTestEvent();
+            event.setItemId(null);
+            event.setEventType("testEvent");
+
+            // Should process without error (generateEventKey handles null IDs)
+            int result = rulesService.onEvent(event);
+            assertNotNull(result, "Event without ID should still process");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testMultipleLoopsInSequence() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Test that multiple different loops can be detected in sequence
+            Event loopEvent1 = createTestEvent();
+            loopEvent1.setEventType("loopEvent1");
+            loopEvent1.setItemId("loop-1");
+
+            actionExecutorDispatcher.addExecutor("test", (action, evt) -> {
+                if ("loopEvent1".equals(evt.getEventType())) {
+                    Event newEvent = new Event("loopEvent1", evt.getSession(), evt.getProfile(),
+                        evt.getScope(), evt, evt.getTarget(), evt.getTimeStamp());
+                    newEvent.setItemId("loop-1");
+                    newEvent.setPersistent(false);
+                    eventService.send(newEvent);
+                }
+                return EventService.NO_CHANGE;
+            });
+
+            Rule rule1 = createTestRule();
+            rule1.setItemId("loop-rule-1");
+            rule1.setTenantId(TENANT_1);
+            rule1.setCondition(createEventTypeCondition("loopEvent1"));
+            Action action1 = new Action();
+            action1.setActionType(definitionsService.getActionType("test"));
+            rule1.setActions(Collections.singletonList(action1));
+
+            rulesService.setRule(rule1);
+            rulesService.refreshRules();
+
+            // First loop should be detected
+            int result1 = rulesService.onEvent(loopEvent1);
+            assertNotNull(result1, "First loop should be detected");
+
+            // Process a different event to reset context
+            Event normalEvent = createTestEvent();
+            normalEvent.setEventType("normal");
+            normalEvent.setItemId("normal-event");
+            rulesService.onEvent(normalEvent);
+
+            // Second loop with different event should also be detected
+            Event loopEvent2 = createTestEvent();
+            loopEvent2.setEventType("loopEvent1");
+            loopEvent2.setItemId("loop-1");
+            int result2 = rulesService.onEvent(loopEvent2);
+            assertNotNull(result2, "Second loop should also be detected");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testDepthTrackingAccuracy() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Test that nested event processing works correctly
+            // Note: Depth protection is now handled by EventServiceImpl.MAX_RECURSION_DEPTH
+            // This test verifies that nested events can be processed without issues
+            ActionType testActionType = TestHelper.createActionType("depthTest", "depthTest");
+            definitionsService.setActionType(testActionType);
+
+            // Verify action type is properly set up
+            ActionType retrievedActionType = definitionsService.getActionType("depthTest");
+            assertNotNull(retrievedActionType, "Action type should be available");
+
+            final int[] depthCounter = {0};
+            actionExecutorDispatcher.addExecutor("depthTest", (action, evt) -> {
+                depthCounter[0]++;
+                if (depthCounter[0] < 5) {
+                    Event newEvent = new Event("depthTestEvent", evt.getSession(), evt.getProfile(),
+                        evt.getScope(), evt, evt.getTarget(), evt.getTimeStamp());
+                    newEvent.setItemId("depth-event-" + depthCounter[0]);
+                    newEvent.setPersistent(false);
+                    eventService.send(newEvent);
+                }
+                return EventService.NO_CHANGE;
+            });
+
+            Rule rule = createTestRule();
+            rule.setItemId("depth-test-rule");
+            rule.setTenantId(TENANT_1);
+            rule.setCondition(createEventTypeCondition("depthTestEvent"));
+            Action action = new Action();
+            action.setActionType(retrievedActionType);
+            rule.setActions(Collections.singletonList(action));
+
+            rulesService.setRule(rule);
+            rulesService.refreshRules();
+
+            // Verify rule is saved and matches the event type
+            Rule savedRule = rulesService.getRule("depth-test-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+
+            Event startEvent = createTestEvent();
+            startEvent.setEventType("depthTestEvent");
+            startEvent.setItemId("depth-start");
+
+            // Verify rule matches before processing (with retry to handle indexing delays)
+            Set<Rule> matchingRules = TestHelper.retryUntil(
+                () -> rulesService.getMatchingRules(startEvent),
+                rules -> rules != null && !rules.isEmpty() &&
+                    rules.stream().anyMatch(r -> r.getItemId().equals("depth-test-rule"))
+            );
+            assertFalse(matchingRules.isEmpty(), "Rule should match depthTestEvent");
+            assertTrue(matchingRules.stream().anyMatch(r -> r.getItemId().equals("depth-test-rule")),
+                "Matching rules should include depth-test-rule");
+
+            // Should process without hitting depth limit (we only go 5 levels deep)
+            // Depth protection is handled by EventServiceImpl.MAX_RECURSION_DEPTH (20)
+            int result = rulesService.onEvent(startEvent);
+            assertNotNull(result, "Should process nested events without hitting depth limit");
+
+            // Verify nested events were processed (we should have processed multiple levels)
+            // The action executor should be called at least once for the initial event
+            // Note: The counter increments when the action executor is called, which happens
+            // when a rule fires. Even if nested events aren't processed due to depth limits,
+            // the initial event should trigger the action at least once.
+            assertTrue(depthCounter[0] > 0,
+                "Should have processed nested events. Action executor was called " + depthCounter[0] + " times. " +
+                "This means the rule matched and the action was executed.");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testThreadLocalCleanupAfterException() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Action executor that throws exception
+            actionExecutorDispatcher.addExecutor("test",
+                (action, event) -> { throw new RuntimeException("Test exception"); });
+
+            Rule rule = createTestRule();
+            rule.setItemId("exception-rule");
+            rule.setTenantId(TENANT_1);
+            rule.setActions(Collections.singletonList(createTestAction()));
+            rulesService.setRule(rule);
+
+            // Ensure rule is saved and available before refreshing
+            Rule savedRule = persistenceService.load(rule.getItemId(), Rule.class);
+            assertNotNull(savedRule, "Rule should be saved");
+
+            // Refresh rules to load and cache them
+            rulesService.refreshRules();
+
+            // Verify rule is loaded and cached by checking it can be retrieved
+            Rule retrievedRule = rulesService.getRule(rule.getItemId());
+            assertNotNull(retrievedRule, "Rule should be retrievable after refreshRules");
+
+            // Ensure rule matches the event (with refresh delay disabled, this should be immediate)
+            Event testEvent = createTestEvent();
+            testEvent.setItemId("exception-test-event");
+            Set<Rule> matchingRules = TestHelper.retryUntil(
+                () -> rulesService.getMatchingRules(testEvent),
+                r -> r != null && !r.isEmpty() && r.stream().anyMatch(rl -> rl.getItemId().equals("exception-rule"))
+            );
+            assertFalse(matchingRules.isEmpty(), "Rule should be available and match the event");
+            assertTrue(matchingRules.stream().anyMatch(rl -> rl.getItemId().equals("exception-rule")),
+                "Matching rules should include the exception-rule");
+
+            // Exception should not prevent ThreadLocal cleanup (finally block should execute)
+            assertThrows(RuntimeException.class, () -> rulesService.onEvent(testEvent),
+                "Exception should propagate but ThreadLocal should be cleaned up");
+
+            // Should still be able to process events after exception (cleanup worked)
+            // This verifies that ProcessingContext was properly cleaned up
+            Event event2 = createTestEvent();
+            event2.setEventType("anotherEvent");
+            event2.setItemId("after-exception-event");
+            int result = rulesService.onEvent(event2);
+            assertNotNull(result, "Should process events after exception - ThreadLocal cleanup verified");
+
+            // Verify we can process multiple events in sequence (ThreadLocal is recreated properly)
+            Event event3 = createTestEvent();
+            event3.setEventType("thirdEvent");
+            event3.setItemId("third-event");
+            assertNotNull(rulesService.onEvent(event3), "Should process multiple events sequentially");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleWithUnresolvedConditionTypeShouldNotBeIndexedAsWildcard() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a rule with a condition type that doesn't exist (not deployed)
+            Rule rule = new Rule();
+            rule.setItemId("unresolved-condition-rule");
+            rule.setTenantId(TENANT_1);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("unresolved-condition-rule");
+            metadata.setEnabled(true);
+            metadata.setScope("systemscope");
+            rule.setMetadata(metadata);
+
+            // Create condition with unresolved condition type (no eventTypeCondition, so would default to wildcard)
+            Condition condition = new Condition();
+            condition.setConditionTypeId("nonExistentConditionType");
+            condition.setParameter("propertyName", "testProperty");
+            rule.setCondition(condition);
+
+            // Add a valid action so the rule structure is complete
+            rule.setActions(Collections.singletonList(createTestAction()));
+
+            // Set rule with allowInvalidRules=true (simulating a rule loaded from bundle before condition type is deployed)
+            rulesService.setRule(rule, true);
+
+            // Refresh rules to ensure indexing happens - this is where the bug would manifest
+            // The rule should be excluded, not indexed as wildcard
+            rulesService.refreshRules();
+
+            // Verify rule is saved
+            Rule savedRule = rulesService.getRule("unresolved-condition-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+
+            // Verify rule has missingPlugins flag set (indicating unresolved condition type)
+            assertTrue(savedRule.getMetadata().isMissingPlugins(),
+                "Rule should be marked as having missing plugins when condition type is unresolved");
+
+            // Create an event that would match if the rule was indexed as wildcard
+            Event testEvent = createTestEvent();
+            testEvent.setEventType("anyEventType");
+            testEvent.setItemId("test-event-unresolved");
+
+            // The rule should NOT match because it should be excluded from indexing, not indexed as wildcard
+            Set<Rule> matchingRules = rulesService.getMatchingRules(testEvent);
+            assertFalse(matchingRules.contains(savedRule),
+                "Rule with unresolved condition type should not match events (should be deactivated, not wildcard). " +
+                "Rule ID: unresolved-condition-rule, Event type: anyEventType, Matching rules: " +
+                matchingRules.stream().map(r -> r.getItemId()).collect(java.util.stream.Collectors.toList()));
+
+            // Verify the rule is not in the wildcard index by checking it doesn't match any event type
+            Event anotherEvent = createTestEvent();
+            anotherEvent.setEventType("anotherEventType");
+            anotherEvent.setItemId("test-event-another");
+            Set<Rule> matchingRules2 = rulesService.getMatchingRules(anotherEvent);
+            assertFalse(matchingRules2.contains(savedRule),
+                "Rule with unresolved condition type should not match any event type (should be deactivated). " +
+                "Rule ID: unresolved-condition-rule, Event type: anotherEventType, Matching rules: " +
+                matchingRules2.stream().map(r -> r.getItemId()).collect(java.util.stream.Collectors.toList()));
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleWithUnresolvedConditionTypeInNestedCondition() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a rule with unresolved condition type in nested subConditions
+            Rule rule = new Rule();
+            rule.setItemId("nested-unresolved-rule");
+            rule.setTenantId(TENANT_1);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("nested-unresolved-rule");
+            metadata.setEnabled(true);
+            metadata.setScope("systemscope");
+            rule.setMetadata(metadata);
+
+            // Create parent condition with valid type
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionType(definitionsService.getConditionType("booleanCondition"));
+            parentCondition.setParameter("operator", "and");
+
+            // Create child condition with unresolved type
+            Condition childCondition = new Condition();
+            childCondition.setConditionTypeId("nonExistentNestedConditionType");
+            childCondition.setParameter("propertyName", "testProperty");
+
+            // Set up nested structure
+            List<Condition> subConditions = new ArrayList<>();
+            subConditions.add(childCondition);
+            parentCondition.setParameter("subConditions", subConditions);
+
+            rule.setCondition(parentCondition);
+            rule.setActions(Collections.singletonList(createTestAction()));
+
+            // Set rule with allowInvalidRules=true
+            rulesService.setRule(rule, true);
+            rulesService.refreshRules();
+
+            Rule savedRule = rulesService.getRule("nested-unresolved-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+            assertTrue(savedRule.getMetadata().isMissingPlugins(),
+                "Rule should be marked as having missing plugins when nested condition type is unresolved");
+
+            // Rule should not match any events
+            Event testEvent = createTestEvent();
+            testEvent.setEventType("anyEventType");
+            testEvent.setItemId("test-event-nested");
+
+            Set<Rule> matchingRules = rulesService.getMatchingRules(testEvent);
+            assertFalse(matchingRules.contains(savedRule),
+                "Rule with unresolved nested condition type should not match events. " +
+                "Rule ID: nested-unresolved-rule");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleWithMixedResolvedAndUnresolvedConditionTypes() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a rule with both resolved and unresolved condition types
+            Rule rule = new Rule();
+            rule.setItemId("mixed-condition-rule");
+            rule.setTenantId(TENANT_1);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("mixed-condition-rule");
+            metadata.setEnabled(true);
+            metadata.setScope("systemscope");
+            rule.setMetadata(metadata);
+
+            // Create parent condition with valid type
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionType(definitionsService.getConditionType("booleanCondition"));
+            parentCondition.setParameter("operator", "and");
+
+            // Create one resolved child condition
+            Condition resolvedChild = createProfilePropertyCondition("testProperty", "equals", "testValue");
+
+            // Create one unresolved child condition
+            Condition unresolvedChild = new Condition();
+            unresolvedChild.setConditionTypeId("nonExistentConditionType2");
+            unresolvedChild.setParameter("propertyName", "testProperty");
+
+            // Set up nested structure with both
+            List<Condition> subConditions = new ArrayList<>();
+            subConditions.add(resolvedChild);
+            subConditions.add(unresolvedChild);
+            parentCondition.setParameter("subConditions", subConditions);
+
+            rule.setCondition(parentCondition);
+            rule.setActions(Collections.singletonList(createTestAction()));
+
+            // Set rule with allowInvalidRules=true
+            rulesService.setRule(rule, true);
+            rulesService.refreshRules();
+
+            Rule savedRule = rulesService.getRule("mixed-condition-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+            assertTrue(savedRule.getMetadata().isMissingPlugins(),
+                "Rule should be marked as having missing plugins when any condition type is unresolved");
+
+            // Rule should not match any events (even if one condition is resolved)
+            Event testEvent = createTestEvent();
+            testEvent.setEventType("anyEventType");
+            testEvent.setItemId("test-event-mixed");
+
+            Set<Rule> matchingRules = rulesService.getMatchingRules(testEvent);
+            assertFalse(matchingRules.contains(savedRule),
+                "Rule with mixed resolved/unresolved condition types should not match events. " +
+                "Rule ID: mixed-condition-rule");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleWithUnresolvedConditionTypeThatGetsResolvedLater() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a rule with unresolved condition type
+            Rule rule = new Rule();
+            rule.setItemId("later-resolved-rule");
+            rule.setTenantId(TENANT_1);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("later-resolved-rule");
+            metadata.setEnabled(true);
+            metadata.setScope("systemscope");
+            rule.setMetadata(metadata);
+
+            Condition condition = new Condition();
+            condition.setConditionTypeId("laterDeployedConditionType");
+            condition.setParameter("propertyName", "testProperty");
+            rule.setCondition(condition);
+            rule.setActions(Collections.singletonList(createTestAction()));
+
+            // Set rule with allowInvalidRules=true (simulating bundle deployment)
+            rulesService.setRule(rule, true);
+            rulesService.refreshRules();
+
+            Rule savedRule = rulesService.getRule("later-resolved-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+            assertTrue(savedRule.getMetadata().isMissingPlugins(),
+                "Rule should be marked as having missing plugins initially");
+
+            // Rule should not match events initially
+            Event testEvent = createTestEvent();
+            testEvent.setEventType("test");
+            testEvent.setItemId("test-event-later");
+
+            Set<Rule> matchingRules1 = rulesService.getMatchingRules(testEvent);
+            assertFalse(matchingRules1.contains(savedRule),
+                "Rule with unresolved condition type should not match events initially");
+
+            // Now deploy the condition type
+            ConditionType conditionType = createTestConditionType("laterDeployedConditionType");
+            definitionsService.setConditionType(conditionType);
+
+            // Refresh persistence and rules
+            persistenceService.refresh();
+            rulesService.refreshRules();
+
+            // Rule should now be resolved and work
+            Rule refreshedRule = rulesService.getRule("later-resolved-rule");
+            assertNotNull(refreshedRule, "Refreshed rule should not be null");
+            // Note: missingPlugins might still be true until the rule is re-saved, but it should be resolvable now
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleWithUnresolvedActionTypes() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a rule with valid condition but unresolved action type
+            // Note: This test verifies that rules with unresolved action types are excluded
+            // The main fix is for condition types, but we verify action types are also handled
+            Rule rule = new Rule();
+            rule.setItemId("unresolved-action-rule");
+            rule.setTenantId(TENANT_1);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("unresolved-action-rule");
+            metadata.setEnabled(true);
+            metadata.setScope("systemscope");
+            rule.setMetadata(metadata);
+
+            // Valid condition
+            Condition condition = createEventTypeCondition("test");
+            rule.setCondition(condition);
+
+            // Unresolved action type
+            Action action = new Action();
+            action.setActionTypeId("nonExistentActionType");
+            rule.setActions(Collections.singletonList(action));
+
+            // Set rule with allowInvalidRules=true
+            rulesService.setRule(rule, true);
+            rulesService.refreshRules();
+
+            Rule savedRule = rulesService.getRule("unresolved-action-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+
+            // The key test: Rule should not match events (should be excluded)
+            // This is what matters - whether it's marked as invalid or missingPlugins is less important
+            Event testEvent = createTestEvent();
+            testEvent.setEventType("test");
+            testEvent.setItemId("test-event-action");
+
+            Set<Rule> matchingRules = rulesService.getMatchingRules(testEvent);
+            assertFalse(matchingRules.contains(savedRule),
+                "Rule with unresolved action type should not match events (should be excluded). " +
+                "Rule ID: unresolved-action-rule");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleWithUnresolvedTypesButDisabled() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a disabled rule with unresolved condition type
+            Rule rule = new Rule();
+            rule.setItemId("disabled-unresolved-rule");
+            rule.setTenantId(TENANT_1);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("disabled-unresolved-rule");
+            metadata.setEnabled(false); // Disabled
+            metadata.setScope("systemscope");
+            rule.setMetadata(metadata);
+
+            Condition condition = new Condition();
+            condition.setConditionTypeId("nonExistentConditionType3");
+            condition.setParameter("propertyName", "testProperty");
+            rule.setCondition(condition);
+            rule.setActions(Collections.singletonList(createTestAction()));
+
+            // Set rule with allowInvalidRules=true
+            rulesService.setRule(rule, true);
+            rulesService.refreshRules();
+
+            Rule savedRule = rulesService.getRule("disabled-unresolved-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+            assertFalse(savedRule.getMetadata().isEnabled(), "Rule should be disabled");
+
+            // Disabled rule should not match events (regardless of unresolved types)
+            Event testEvent = createTestEvent();
+            testEvent.setEventType("anyEventType");
+            testEvent.setItemId("test-event-disabled");
+
+            Set<Rule> matchingRules = rulesService.getMatchingRules(testEvent);
+            assertFalse(matchingRules.contains(savedRule),
+                "Disabled rule should not match events. " +
+                "Rule ID: disabled-unresolved-rule");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleWithMultipleUnresolvedTypesInDifferentBranches() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a rule with multiple unresolved condition types in different branches
+            Rule rule = new Rule();
+            rule.setItemId("multiple-unresolved-rule");
+            rule.setTenantId(TENANT_1);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("multiple-unresolved-rule");
+            metadata.setEnabled(true);
+            metadata.setScope("systemscope");
+            rule.setMetadata(metadata);
+
+            // Create parent condition
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionType(definitionsService.getConditionType("booleanCondition"));
+            parentCondition.setParameter("operator", "or");
+
+            // Create multiple child conditions with different unresolved types
+            Condition child1 = new Condition();
+            child1.setConditionTypeId("nonExistentType1");
+            child1.setParameter("propertyName", "prop1");
+
+            Condition child2 = new Condition();
+            child2.setConditionTypeId("nonExistentType2");
+            child2.setParameter("propertyName", "prop2");
+
+            List<Condition> subConditions = new ArrayList<>();
+            subConditions.add(child1);
+            subConditions.add(child2);
+            parentCondition.setParameter("subConditions", subConditions);
+
+            rule.setCondition(parentCondition);
+            rule.setActions(Collections.singletonList(createTestAction()));
+
+            // Set rule with allowInvalidRules=true
+            rulesService.setRule(rule, true);
+            rulesService.refreshRules();
+
+            Rule savedRule = rulesService.getRule("multiple-unresolved-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+            assertTrue(savedRule.getMetadata().isMissingPlugins(),
+                "Rule should be marked as having missing plugins when multiple condition types are unresolved");
+
+            // Rule should not match any events
+            Event testEvent = createTestEvent();
+            testEvent.setEventType("anyEventType");
+            testEvent.setItemId("test-event-multiple");
+
+            Set<Rule> matchingRules = rulesService.getMatchingRules(testEvent);
+            assertFalse(matchingRules.contains(savedRule),
+                "Rule with multiple unresolved condition types should not match events. " +
+                "Rule ID: multiple-unresolved-rule");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleWithUnresolvedTypeInListParameter() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a rule with unresolved condition type in a list parameter
+            // Some condition types might have list parameters containing conditions
+            Rule rule = new Rule();
+            rule.setItemId("list-parameter-unresolved-rule");
+            rule.setTenantId(TENANT_1);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("list-parameter-unresolved-rule");
+            metadata.setEnabled(true);
+            metadata.setScope("systemscope");
+            rule.setMetadata(metadata);
+
+            // Create parent condition
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionType(definitionsService.getConditionType("booleanCondition"));
+            parentCondition.setParameter("operator", "and");
+
+            // Create child with unresolved type in subConditions list
+            Condition unresolvedChild = new Condition();
+            unresolvedChild.setConditionTypeId("nonExistentListType");
+            unresolvedChild.setParameter("propertyName", "testProperty");
+
+            List<Condition> subConditions = new ArrayList<>();
+            subConditions.add(unresolvedChild);
+            parentCondition.setParameter("subConditions", subConditions);
+
+            rule.setCondition(parentCondition);
+            rule.setActions(Collections.singletonList(createTestAction()));
+
+            // Set rule with allowInvalidRules=true
+            rulesService.setRule(rule, true);
+            rulesService.refreshRules();
+
+            Rule savedRule = rulesService.getRule("list-parameter-unresolved-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+            assertTrue(savedRule.getMetadata().isMissingPlugins(),
+                "Rule should be marked as having missing plugins when condition type in list is unresolved");
+
+            // Rule should not match any events
+            Event testEvent = createTestEvent();
+            testEvent.setEventType("anyEventType");
+            testEvent.setItemId("test-event-list");
+
+            Set<Rule> matchingRules = rulesService.getMatchingRules(testEvent);
+            assertFalse(matchingRules.contains(savedRule),
+                "Rule with unresolved condition type in list parameter should not match events. " +
+                "Rule ID: list-parameter-unresolved-rule");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleWithDeeplyNestedUnresolvedType() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a rule with unresolved condition type deeply nested
+            Rule rule = new Rule();
+            rule.setItemId("deeply-nested-unresolved-rule");
+            rule.setTenantId(TENANT_1);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("deeply-nested-unresolved-rule");
+            metadata.setEnabled(true);
+            metadata.setScope("systemscope");
+            rule.setMetadata(metadata);
+
+            // Level 1: booleanCondition
+            Condition level1 = new Condition();
+            level1.setConditionType(definitionsService.getConditionType("booleanCondition"));
+            level1.setParameter("operator", "and");
+
+            // Level 2: another booleanCondition
+            Condition level2 = new Condition();
+            level2.setConditionType(definitionsService.getConditionType("booleanCondition"));
+            level2.setParameter("operator", "or");
+
+            // Level 3: unresolved condition type
+            Condition level3 = new Condition();
+            level3.setConditionTypeId("deeplyNestedUnresolvedType");
+            level3.setParameter("propertyName", "testProperty");
+
+            List<Condition> level3List = new ArrayList<>();
+            level3List.add(level3);
+            level2.setParameter("subConditions", level3List);
+
+            List<Condition> level2List = new ArrayList<>();
+            level2List.add(level2);
+            level1.setParameter("subConditions", level2List);
+
+            rule.setCondition(level1);
+            rule.setActions(Collections.singletonList(createTestAction()));
+
+            // Set rule with allowInvalidRules=true
+            rulesService.setRule(rule, true);
+            rulesService.refreshRules();
+
+            Rule savedRule = rulesService.getRule("deeply-nested-unresolved-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+            assertTrue(savedRule.getMetadata().isMissingPlugins(),
+                "Rule should be marked as having missing plugins when deeply nested condition type is unresolved");
+
+            // Rule should not match any events
+            Event testEvent = createTestEvent();
+            testEvent.setEventType("anyEventType");
+            testEvent.setItemId("test-event-deep");
+
+            Set<Rule> matchingRules = rulesService.getMatchingRules(testEvent);
+            assertFalse(matchingRules.contains(savedRule),
+                "Rule with deeply nested unresolved condition type should not match events. " +
+                "Rule ID: deeply-nested-unresolved-rule");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleWithConditionTypeHavingUnresolvedParentCondition() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a rule with a condition type that exists but has an unresolved parent condition
+            Rule rule = new Rule();
+            rule.setItemId("unresolved-parent-condition-rule");
+            rule.setTenantId(TENANT_1);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("unresolved-parent-condition-rule");
+            metadata.setEnabled(true);
+            metadata.setScope("systemscope");
+            rule.setMetadata(metadata);
+
+            // Create a condition type that exists but has a parent condition that doesn't exist
+            ConditionType childConditionType = createTestConditionType("childConditionWithParent");
+            Condition unresolvedParentCondition = new Condition();
+            unresolvedParentCondition.setConditionTypeId("nonExistentParentConditionType");
+            childConditionType.setParentCondition(unresolvedParentCondition);
+
+            // Register the child condition type (but not the parent)
+            definitionsService.setConditionType(childConditionType);
+
+            // Create condition using the child type
+            Condition condition = new Condition();
+            condition.setConditionTypeId("childConditionWithParent");
+            condition.setParameter("propertyName", "testProperty");
+            rule.setCondition(condition);
+            rule.setActions(Collections.singletonList(createTestAction()));
+
+            // Set rule with allowInvalidRules=true
+            rulesService.setRule(rule, true);
+
+            // Refresh rules to trigger resolution for indexing
+            rulesService.refreshRules();
+
+            Rule savedRule = rulesService.getRule("unresolved-parent-condition-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+
+            // Clear condition type to force re-resolution (simulates loading from persistence)
+            // This ensures the parent condition check happens
+            if (savedRule.getCondition() != null) {
+                savedRule.getCondition().setConditionType(null);
+            }
+
+            // Manually trigger resolution to ensure parent condition is checked
+            // This simulates what happens during refreshRules -> updateRulesByEventType -> ensureRuleResolvedForIndexing
+            TypeResolutionServiceImpl testTypeResolutionService = new TypeResolutionServiceImpl(definitionsService);
+            boolean resolved = testTypeResolutionService.resolveRule("rules", savedRule);
+
+            // Resolution should fail because parent condition doesn't exist
+            assertFalse(resolved, "Rule resolution should fail when parent condition type is unresolved");
+
+            // Check if rule is marked as invalid or has missing plugins
+            boolean hasMissingPlugins = savedRule.getMetadata().isMissingPlugins();
+            boolean isInvalid = testTypeResolutionService.isInvalid("rules", savedRule.getItemId());
+
+            // Verify the condition type was cleared due to unresolved parent
+            // When parent can't be resolved, TypeResolutionService sets condition type to null
+            boolean conditionTypeCleared = savedRule.getCondition() != null &&
+                savedRule.getCondition().getConditionType() == null &&
+                savedRule.getCondition().getConditionTypeId() != null;
+
+            assertTrue(hasMissingPlugins || isInvalid || conditionTypeCleared,
+                "Rule should be marked as having missing plugins, invalid, or have condition type cleared when parent condition type is unresolved. " +
+                "missingPlugins: " + hasMissingPlugins + ", isInvalid: " + isInvalid + ", conditionTypeCleared: " + conditionTypeCleared);
+
+            // Rule should not match any events (this is the most important check)
+            Event testEvent = createTestEvent();
+            testEvent.setEventType("anyEventType");
+            testEvent.setItemId("test-event-unresolved-parent");
+
+            Set<Rule> matchingRules = rulesService.getMatchingRules(testEvent);
+            assertFalse(matchingRules.contains(savedRule),
+                "Rule with condition type having unresolved parent condition should not match events. " +
+                "Rule ID: unresolved-parent-condition-rule, missingPlugins: " + hasMissingPlugins +
+                ", isInvalid: " + isInvalid);
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleWithConditionTypeHavingUnresolvedGrandparentInParentChain() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a rule with a condition type that has a parent chain where grandparent doesn't exist
+            // Chain: child -> parent -> grandparent (unresolved)
+            Rule rule = new Rule();
+            rule.setItemId("unresolved-grandparent-condition-rule");
+            rule.setTenantId(TENANT_1);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("unresolved-grandparent-condition-rule");
+            metadata.setEnabled(true);
+            metadata.setScope("systemscope");
+            rule.setMetadata(metadata);
+
+            // Create grandparent condition (unresolved - doesn't exist)
+            Condition unresolvedGrandparentCondition = new Condition();
+            unresolvedGrandparentCondition.setConditionTypeId("nonExistentGrandparentType");
+
+            // Create parent condition type that references the unresolved grandparent
+            ConditionType parentConditionType = createTestConditionType("parentConditionWithGrandparent");
+            parentConditionType.setParentCondition(unresolvedGrandparentCondition);
+
+            // Create child condition type that references the parent
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("parentConditionWithGrandparent");
+            ConditionType childConditionType = createTestConditionType("childConditionWithParentChain");
+            childConditionType.setParentCondition(parentCondition);
+
+            // Register parent and child condition types (but not grandparent)
+            definitionsService.setConditionType(parentConditionType);
+            definitionsService.setConditionType(childConditionType);
+
+            // Create condition using the child type
+            Condition condition = new Condition();
+            condition.setConditionTypeId("childConditionWithParentChain");
+            condition.setParameter("propertyName", "testProperty");
+            rule.setCondition(condition);
+            rule.setActions(Collections.singletonList(createTestAction()));
+
+            // Set rule with allowInvalidRules=true
+            rulesService.setRule(rule, true);
+            rulesService.refreshRules();
+
+            Rule savedRule = rulesService.getRule("unresolved-grandparent-condition-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+
+            // Clear condition type to force re-resolution (simulates loading from persistence)
+            if (savedRule.getCondition() != null) {
+                savedRule.getCondition().setConditionType(null);
+            }
+
+            // Manually trigger resolution to ensure parent chain is checked
+            TypeResolutionServiceImpl testTypeResolutionService = new TypeResolutionServiceImpl(definitionsService);
+            boolean resolved = testTypeResolutionService.resolveRule("rules", savedRule);
+
+            // Resolution should fail because grandparent condition doesn't exist
+            assertFalse(resolved, "Rule resolution should fail when grandparent condition type in parent chain is unresolved");
+
+            // Check if rule is marked as invalid or has missing plugins
+            boolean hasMissingPlugins = savedRule.getMetadata().isMissingPlugins();
+            boolean isInvalid = testTypeResolutionService.isInvalid("rules", savedRule.getItemId());
+
+            // Rule should not match any events (this is the most important check)
+            Event testEvent = createTestEvent();
+            testEvent.setEventType("anyEventType");
+            testEvent.setItemId("test-event-unresolved-grandparent");
+
+            Set<Rule> matchingRules = rulesService.getMatchingRules(testEvent);
+            assertFalse(matchingRules.contains(savedRule),
+                "Rule with condition type having unresolved grandparent in parent chain should not match events. " +
+                "Rule ID: unresolved-grandparent-condition-rule, missingPlugins: " + hasMissingPlugins +
+                ", isInvalid: " + isInvalid);
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testRuleWithUnresolvedSubConditionInParentCondition() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a rule where the condition type has a parent condition that contains
+            // an unresolved sub-condition in its subConditions parameter
+            Rule rule = new Rule();
+            rule.setItemId("unresolved-sub-in-parent-rule");
+            rule.setTenantId(TENANT_1);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("unresolved-sub-in-parent-rule");
+            metadata.setEnabled(true);
+            metadata.setScope("systemscope");
+            rule.setMetadata(metadata);
+
+            // Create parent condition with unresolved sub-condition
+            Condition unresolvedSubCondition = new Condition();
+            unresolvedSubCondition.setConditionTypeId("nonExistentSubConditionType");
+            unresolvedSubCondition.setParameter("propertyName", "testProperty");
+
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionType(definitionsService.getConditionType("booleanCondition"));
+            parentCondition.setParameter("operator", "and");
+            parentCondition.setParameter("subConditions", Collections.singletonList(unresolvedSubCondition));
+
+            // Create child condition type that uses this parent condition
+            ConditionType childConditionType = createTestConditionType("childConditionWithParentSub");
+            childConditionType.setParentCondition(parentCondition);
+
+            // Register the child condition type
+            definitionsService.setConditionType(childConditionType);
+
+            // Create condition using the child type
+            Condition condition = new Condition();
+            condition.setConditionTypeId("childConditionWithParentSub");
+            condition.setParameter("propertyName", "testProperty");
+            rule.setCondition(condition);
+            rule.setActions(Collections.singletonList(createTestAction()));
+
+            // Set rule with allowInvalidRules=true
+            rulesService.setRule(rule, true);
+            rulesService.refreshRules();
+
+            Rule savedRule = rulesService.getRule("unresolved-sub-in-parent-rule");
+            assertNotNull(savedRule, "Rule should be saved");
+
+            // Clear condition type to force re-resolution (simulates loading from persistence)
+            if (savedRule.getCondition() != null) {
+                savedRule.getCondition().setConditionType(null);
+            }
+
+            // Manually trigger resolution to ensure parent condition's sub-conditions are checked
+            TypeResolutionServiceImpl testTypeResolutionService = new TypeResolutionServiceImpl(definitionsService);
+            boolean resolved = testTypeResolutionService.resolveRule("rules", savedRule);
+
+            // Resolution should fail because parent condition has unresolved sub-condition
+            assertFalse(resolved, "Rule resolution should fail when parent condition has unresolved sub-condition");
+
+            // Check if rule is marked as invalid or has missing plugins
+            boolean hasMissingPlugins = savedRule.getMetadata().isMissingPlugins();
+            boolean isInvalid = testTypeResolutionService.isInvalid("rules", savedRule.getItemId());
+
+            // Rule should not match any events (this is the most important check)
+            Event testEvent = createTestEvent();
+            testEvent.setEventType("anyEventType");
+            testEvent.setItemId("test-event-unresolved-sub-in-parent");
+
+            Set<Rule> matchingRules = rulesService.getMatchingRules(testEvent);
+            assertFalse(matchingRules.contains(savedRule),
+                "Rule with condition type having parent condition with unresolved sub-condition should not match events. " +
+                "Rule ID: unresolved-sub-in-parent-rule, missingPlugins: " + hasMissingPlugins +
+                ", isInvalid: " + isInvalid);
+
+            return null;
+        });
+    }
+
+}

--- a/services/src/test/java/org/apache/unomi/services/impl/rules/RulesServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/rules/RulesServiceImplTest.java
@@ -25,7 +25,7 @@ import org.apache.unomi.api.rules.Rule;
 import org.apache.unomi.api.rules.RuleStatistics;
 import org.apache.unomi.api.services.EventService;
 import org.apache.unomi.api.services.RuleListenerService;
-import org.apache.unomi.api.services.SchedulerService;
+import org.apache.unomi.services.impl.scheduler.SchedulerServiceImpl;
 import org.apache.unomi.persistence.spi.PersistenceService;
 import org.apache.unomi.persistence.spi.conditions.evaluator.ConditionEvaluatorDispatcher;
 import org.apache.unomi.services.TestHelper;
@@ -35,8 +35,10 @@ import org.apache.unomi.services.common.security.KarafSecurityService;
 import org.apache.unomi.services.impl.*;
 import org.apache.unomi.services.impl.cache.MultiTypeCacheServiceImpl;
 import org.apache.unomi.services.impl.definitions.DefinitionsServiceImpl;
+import org.apache.unomi.services.impl.events.EventServiceImpl;
 import org.apache.unomi.tracing.api.RequestTracer;
 import org.apache.unomi.tracing.api.TracerService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,12 +71,12 @@ public class RulesServiceImplTest {
 
     @Mock
     private BundleContext bundleContext;
-    private EventService eventService;
+    private EventServiceImpl eventService;
     private TracerService tracerService;
     private RequestTracer requestTracer;
 
     private TestActionExecutorDispatcher actionExecutorDispatcher;
-    private SchedulerService schedulerService;
+    private SchedulerServiceImpl schedulerService;
     private TestEventAdmin testEventAdmin;
 
     private static final String TENANT_1 = "tenant1";
@@ -146,6 +148,7 @@ public class RulesServiceImplTest {
 
         // Initialize rule caches
         rulesService.postConstruct();
+        eventService.addEventListenerService(rulesService);
 
         // Register RulesServiceImpl as an EventHandler with TestEventAdmin
         // In real OSGi, this would be done via service registry, but for tests we register manually
@@ -154,13 +157,19 @@ public class RulesServiceImplTest {
         }
     }
 
-    @org.junit.jupiter.api.AfterEach
+    @AfterEach
     public void tearDown() {
         if (testEventAdmin != null) {
             testEventAdmin.shutdown();
         }
         if (rulesService != null) {
             rulesService.preDestroy();
+        }
+        if (eventService != null && rulesService != null) {
+            eventService.removeEventListenerService(rulesService);
+        }
+        if (schedulerService != null) {
+            schedulerService.preDestroy();
         }
     }
 
@@ -258,6 +267,13 @@ public class RulesServiceImplTest {
         event.setTarget(target);
 
         return event;
+    }
+
+    private Set<Rule> waitForMatchingRules(Event event, int expectedCount) {
+        return TestHelper.retryUntil(
+            () -> rulesService.getMatchingRules(event),
+            rules -> rules != null && rules.size() >= expectedCount
+        );
     }
 
     private Rule createRuleWithUnavailableConditionType(String conditionTypeId) {
@@ -776,32 +792,27 @@ public class RulesServiceImplTest {
     }
 
     @Test
-    public void testRuleExecutionWithValidCondition() {
-        // Create a rule with valid condition
-        Rule rule = new Rule();
-        rule.setMetadata(new Metadata());
-        rule.getMetadata().setId("testRule");
-        rule.getMetadata().setEnabled(true);
-        rule.setScope("systemscope");
+    public void testRuleExecutionWithMatchingCondition() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Rule rule = createTestRule();
+            rule.setItemId("testRule");
+            rule.setTenantId(TENANT_1);
+            rule.setCondition(createEventTypeCondition("testEvent"));
+            rule.setActions(Collections.singletonList(createTestAction()));
 
-        Condition condition = new Condition();
-        rule.setCondition(condition);
+            rulesService.setRule(rule);
+            rulesService.refreshRules();
 
-        // Create test event
-        Event event = new Event();
-        event.setEventType("testEvent");
-        event.setScope("systemscope");
-        event.setProfile(new Profile("testProfile"));
+            Event event = createTestEvent();
+            event.setEventType("testEvent");
+            event.setItemId("test-event");
 
-        // Add test action
-        Action action = new Action();
-        ActionType actionType = new ActionType();
-        actionType.setActionExecutor("test");
-        action.setActionType(actionType);
-        rule.setActions(List.of(action));
-
-        // Execute rule
-        rulesService.onEvent(event);
+            Set<Rule> matchingRules = waitForMatchingRules(event, 1);
+            assertEquals(1, matchingRules.size(), "The test rule should match the event before execution");
+            assertEquals(EventService.PROFILE_UPDATED, rulesService.onEvent(event),
+                "A matching rule should execute its configured action");
+            return null;
+        });
     }
 
     @Test
@@ -879,10 +890,7 @@ public class RulesServiceImplTest {
         Rule rule = createTestRule();
         rule.setItemId(ruleId);
         rule.setTenantId(TENANT_1);
-        Condition wildcardCondition = new Condition();
-        wildcardCondition.setConditionType(definitionsService.getConditionType("eventTypeCondition"));
-        wildcardCondition.setParameter("eventTypeId", "*");
-        rule.setCondition(wildcardCondition);
+        rule.setCondition(new Condition(definitionsService.getConditionType("matchAllCondition")));
         rule.setActions(Collections.singletonList(createTestAction()));
         return rule;
     }
@@ -890,22 +898,29 @@ public class RulesServiceImplTest {
     @Test
     public void testRuleFiredEventLoopDetection() {
         executionContextManager.executeAsTenant(TENANT_1, () -> {
-            // Wildcard rule matches ruleFired events, creating a loop
-            Rule wildcardRule = createWildcardRule("wildcard-rule");
-            rulesService.setRule(wildcardRule);
+            Rule triggerRule = createTestRule();
+            triggerRule.setItemId("event-trigger-rule");
+            triggerRule.setTenantId(TENANT_1);
+            triggerRule.setCondition(createEventTypeCondition("test"));
+            triggerRule.setActions(Collections.singletonList(createTestAction()));
+
+            Rule ruleFiredRule = createTestRule();
+            ruleFiredRule.setItemId("rule-fired-loop-rule");
+            ruleFiredRule.setTenantId(TENANT_1);
+            ruleFiredRule.setCondition(createEventTypeCondition("ruleFired"));
+            ruleFiredRule.setActions(Collections.singletonList(createTestAction()));
+
+            rulesService.setRule(triggerRule);
+            rulesService.setRule(ruleFiredRule);
             rulesService.refreshRules();
 
             Event event = createTestEvent();
-            event.setEventType("view");
             event.setItemId("test-event-123"); // Set explicit ID for proper loop detection
 
-            // First event should process normally (triggers rule, which sends ruleFired)
-            // The ruleFired event should be detected as a loop and prevented
             int result = rulesService.onEvent(event);
-            assertNotNull(result, "Event should return a result without infinite loop");
+            assertEquals(EventService.NO_CHANGE, result,
+                "The recursive ruleFired path should terminate without reporting net changes");
 
-            // Verify rule was processed (ruleFired was sent but loop was detected)
-            // The key is that processing completes without hanging
             return null;
         });
     }
@@ -913,24 +928,28 @@ public class RulesServiceImplTest {
     @Test
     public void testRuleFiredEventLoopDetectionWithProperIds() {
         executionContextManager.executeAsTenant(TENANT_1, () -> {
-            // Create a rule that matches ruleFired events
-            Rule rule = createWildcardRule("rule-matching-ruleFired");
-            rulesService.setRule(rule);
+            Rule triggerRule = createTestRule();
+            triggerRule.setItemId("proper-id-trigger-rule");
+            triggerRule.setTenantId(TENANT_1);
+            triggerRule.setCondition(createEventTypeCondition("test"));
+            triggerRule.setActions(Collections.singletonList(createTestAction()));
+
+            Rule ruleFiredRule = createTestRule();
+            ruleFiredRule.setItemId("proper-id-ruleFired-rule");
+            ruleFiredRule.setTenantId(TENANT_1);
+            ruleFiredRule.setCondition(createEventTypeCondition("ruleFired"));
+            ruleFiredRule.setActions(Collections.singletonList(createTestAction()));
+
+            rulesService.setRule(triggerRule);
+            rulesService.setRule(ruleFiredRule);
             rulesService.refreshRules();
 
-            // Create an event with a proper ID
             Event originalEvent = createTestEvent();
-            originalEvent.setEventType("view");
             originalEvent.setItemId("original-event-456");
 
-            // Process the event - this will trigger ruleFired
-            // The ruleFired event should use proper ID (source event + rule ID)
-            // and be detected as a loop when it tries to process again
             int result = rulesService.onEvent(originalEvent);
-            assertNotNull(result, "Should return without infinite loop");
-
-            // Verify the event was processed (but loop was prevented)
-            // The key is that it returns without hanging
+            assertEquals(EventService.NO_CHANGE, result,
+                "The recursive ruleFired path should terminate without reporting net changes");
             return null;
         });
     }
@@ -966,7 +985,8 @@ public class RulesServiceImplTest {
 
             // Should detect loop when same event ID is processed again
             int result = rulesService.onEvent(loopEvent);
-            assertNotNull(result, "Should return without infinite loop");
+            assertEquals(EventService.NO_CHANGE, result,
+                "Loop detection should prevent the re-sent event from reporting any changes");
             return null;
         });
     }
@@ -1032,14 +1052,16 @@ public class RulesServiceImplTest {
             // Depth protection is now handled by EventServiceImpl.MAX_RECURSION_DEPTH
             // RulesServiceImpl only handles loop detection (same event key seen twice)
             int result = rulesService.onEvent(startEvent);
-            assertNotNull(result, "Should return when maximum depth is reached by EventServiceImpl");
+            assertEquals(EventService.NO_CHANGE, result,
+                "The depth-protection scenario should stop without reporting any state changes");
 
             // Verify that processing can continue after depth limit (ThreadLocal was cleaned up)
             Event nextEvent = createTestEvent();
             nextEvent.setEventType("view");
             nextEvent.setItemId("next-event");
             int nextResult = rulesService.onEvent(nextEvent);
-            assertNotNull(nextResult, "Should be able to process new events after depth limit");
+            assertEquals(EventService.NO_CHANGE, nextResult,
+                "Processing should recover cleanly after the depth limit is reached");
 
             return null;
         });
@@ -1060,7 +1082,8 @@ public class RulesServiceImplTest {
             Event event = createTestEvent();
             event.setItemId(null);
             // Event without ID should still generate a key and be processed
-            assertNotNull(rulesService.onEvent(event), "Event without ID should be processed");
+            assertEquals(EventService.NO_CHANGE, rulesService.onEvent(event),
+                "Events without IDs should still be processed and return the expected default result");
             return null;
         });
     }
@@ -1068,16 +1091,34 @@ public class RulesServiceImplTest {
     @Test
     public void testMultipleRulesInLoop() {
         executionContextManager.executeAsTenant(TENANT_1, () -> {
-            // Multiple wildcard rules should all be caught by loop detection
-            rulesService.setRule(createWildcardRule("rule1"));
-            rulesService.setRule(createWildcardRule("rule2"));
+            Rule triggerRule = createTestRule();
+            triggerRule.setItemId("multi-loop-trigger");
+            triggerRule.setTenantId(TENANT_1);
+            triggerRule.setCondition(createEventTypeCondition("test"));
+            triggerRule.setActions(Collections.singletonList(createTestAction()));
+
+            Rule rule1 = createTestRule();
+            rule1.setItemId("rule1");
+            rule1.setTenantId(TENANT_1);
+            rule1.setCondition(createEventTypeCondition("ruleFired"));
+            rule1.setActions(Collections.singletonList(createTestAction()));
+
+            Rule rule2 = createTestRule();
+            rule2.setItemId("rule2");
+            rule2.setTenantId(TENANT_1);
+            rule2.setCondition(createEventTypeCondition("ruleFired"));
+            rule2.setActions(Collections.singletonList(createTestAction()));
+
+            rulesService.setRule(triggerRule);
+            rulesService.setRule(rule1);
+            rulesService.setRule(rule2);
             rulesService.refreshRules();
 
             Event event = createTestEvent();
-            event.setEventType("view");
             event.setItemId("test-event-multi");
 
-            assertNotNull(rulesService.onEvent(event), "Should handle multiple rules in loop");
+            assertEquals(EventService.NO_CHANGE, rulesService.onEvent(event),
+                "Processing multiple ruleFired rules should terminate without reporting net changes");
             return null;
         });
     }
@@ -1113,7 +1154,8 @@ public class RulesServiceImplTest {
 
             // Should detect loop when same event ID is processed again
             int result = rulesService.onEvent(event);
-            assertNotNull(result, "Should detect loop and return");
+            assertEquals(EventService.NO_CHANGE, result,
+                "Loop detection should stop the same event ID from producing duplicate changes");
             return null;
         });
     }
@@ -1132,20 +1174,23 @@ public class RulesServiceImplTest {
             // Process first event - should create ProcessingContext
             Event event1 = createTestEvent();
             event1.setItemId("event-1");
+            waitForMatchingRules(event1, 1);
             int result1 = rulesService.onEvent(event1);
-            assertNotNull(result1, "First event should process successfully");
+            assertEquals(EventService.PROFILE_UPDATED, result1, "First event should process successfully");
 
             // Process second event - should reuse ProcessingContext (but different event key, so no loop)
             Event event2 = createTestEvent();
             event2.setItemId("event-2");
+            waitForMatchingRules(event2, 1);
             int result2 = rulesService.onEvent(event2);
-            assertNotNull(result2, "Second event should process successfully");
+            assertEquals(EventService.PROFILE_UPDATED, result2, "Second event should process successfully");
 
             // Process third event - verify context is still working
             Event event3 = createTestEvent();
             event3.setItemId("event-3");
+            waitForMatchingRules(event3, 1);
             int result3 = rulesService.onEvent(event3);
-            assertNotNull(result3, "Third event should process successfully");
+            assertEquals(EventService.PROFILE_UPDATED, result3, "Third event should process successfully");
 
             return null;
         });
@@ -1200,12 +1245,17 @@ public class RulesServiceImplTest {
 
             // All three rules should fire and be recorded in history
             int result = rulesService.onEvent(event);
-            assertNotNull(result, "Event should process all matching rules");
+            assertEquals(EventService.PROFILE_UPDATED, result, "Event should process all matching rules");
 
-            // Verify rules were processed (history tracking happens in processEvent)
-            Set<Rule> matchingRules = rulesService.getMatchingRules(event);
-            assertTrue(matchingRules.size() >= 3,
-                "Should match at least 3 rules after processing. Found: " + matchingRules.size());
+            RuleStatistics stats1 = rulesService.getRuleStatistics("history-rule-1");
+            RuleStatistics stats2 = rulesService.getRuleStatistics("history-rule-2");
+            RuleStatistics stats3 = rulesService.getRuleStatistics("history-rule-3");
+            assertNotNull(stats1, "Rule 1 statistics should be available");
+            assertNotNull(stats2, "Rule 2 statistics should be available");
+            assertNotNull(stats3, "Rule 3 statistics should be available");
+            assertEquals(1, stats1.getLocalExecutionCount(), "Rule 1 should execute exactly once");
+            assertEquals(1, stats2.getLocalExecutionCount(), "Rule 2 should execute exactly once");
+            assertEquals(1, stats3.getLocalExecutionCount(), "Rule 3 should execute exactly once");
 
             return null;
         });
@@ -1218,6 +1268,7 @@ public class RulesServiceImplTest {
             Rule rule = createTestRule();
             rule.setItemId("rule-fired-null-test");
             rule.setTenantId(TENANT_1);
+            rule.setCondition(createEventTypeCondition("testEvent"));
             rule.setActions(Collections.singletonList(createTestAction()));
             rulesService.setRule(rule);
             rulesService.refreshRules();
@@ -1226,10 +1277,11 @@ public class RulesServiceImplTest {
             Event event = createTestEvent();
             event.setItemId(null);
             event.setEventType("testEvent");
+            waitForMatchingRules(event, 1);
 
             // Should process without error (generateEventKey handles null IDs)
             int result = rulesService.onEvent(event);
-            assertNotNull(result, "Event without ID should still process");
+            assertEquals(EventService.PROFILE_UPDATED, result, "Event without ID should still process");
 
             return null;
         });
@@ -1267,7 +1319,7 @@ public class RulesServiceImplTest {
 
             // First loop should be detected
             int result1 = rulesService.onEvent(loopEvent1);
-            assertNotNull(result1, "First loop should be detected");
+            assertEquals(EventService.NO_CHANGE, result1, "First loop should be detected");
 
             // Process a different event to reset context
             Event normalEvent = createTestEvent();
@@ -1280,7 +1332,7 @@ public class RulesServiceImplTest {
             loopEvent2.setEventType("loopEvent1");
             loopEvent2.setItemId("loop-1");
             int result2 = rulesService.onEvent(loopEvent2);
-            assertNotNull(result2, "Second loop should also be detected");
+            assertEquals(EventService.NO_CHANGE, result2, "Second loop should also be detected");
 
             return null;
         });
@@ -1344,16 +1396,16 @@ public class RulesServiceImplTest {
             // Should process without hitting depth limit (we only go 5 levels deep)
             // Depth protection is handled by EventServiceImpl.MAX_RECURSION_DEPTH (20)
             int result = rulesService.onEvent(startEvent);
-            assertNotNull(result, "Should process nested events without hitting depth limit");
+            assertEquals(EventService.NO_CHANGE, result,
+                "Nested events below the recursion limit should complete without reporting changes");
 
             // Verify nested events were processed (we should have processed multiple levels)
             // The action executor should be called at least once for the initial event
             // Note: The counter increments when the action executor is called, which happens
             // when a rule fires. Even if nested events aren't processed due to depth limits,
             // the initial event should trigger the action at least once.
-            assertTrue(depthCounter[0] > 0,
-                "Should have processed nested events. Action executor was called " + depthCounter[0] + " times. " +
-                "This means the rule matched and the action was executed.");
+            assertEquals(5, depthCounter[0],
+                "Nested events should execute exactly five times before the chain stops");
 
             return null;
         });
@@ -1404,13 +1456,15 @@ public class RulesServiceImplTest {
             event2.setEventType("anotherEvent");
             event2.setItemId("after-exception-event");
             int result = rulesService.onEvent(event2);
-            assertNotNull(result, "Should process events after exception - ThreadLocal cleanup verified");
+            assertEquals(EventService.NO_CHANGE, result,
+                "ThreadLocal cleanup should allow a later non-matching event to be processed normally");
 
             // Verify we can process multiple events in sequence (ThreadLocal is recreated properly)
             Event event3 = createTestEvent();
             event3.setEventType("thirdEvent");
             event3.setItemId("third-event");
-            assertNotNull(rulesService.onEvent(event3), "Should process multiple events sequentially");
+            assertEquals(EventService.NO_CHANGE, rulesService.onEvent(event3),
+                "Subsequent sequential events should still be processed after the cleanup");
 
             return null;
         });

--- a/services/src/test/java/org/apache/unomi/services/impl/rules/TestActionExecutorDispatcher.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/rules/TestActionExecutorDispatcher.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.services.impl.rules;
+
+import org.apache.unomi.api.Event;
+import org.apache.unomi.api.actions.Action;
+import org.apache.unomi.api.actions.ActionExecutor;
+import org.apache.unomi.api.services.DefinitionsService;
+import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.persistence.spi.PersistenceService;
+import org.apache.unomi.services.actions.ActionExecutorDispatcher;
+import org.apache.unomi.tracing.api.RequestTracer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestActionExecutorDispatcher implements ActionExecutorDispatcher {
+    private final DefinitionsService definitionsService;
+    private final PersistenceService persistenceService;
+    private int defaultReturnValue = EventService.NO_CHANGE;
+    private Map<String, ActionExecutor> executors = new HashMap<>();
+    private RequestTracer tracer;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestActionExecutorDispatcher.class.getName());
+
+    public TestActionExecutorDispatcher(DefinitionsService definitionsService, PersistenceService persistenceService) {
+        this.definitionsService = definitionsService;
+        this.persistenceService = persistenceService;
+    }
+
+    public void setTracer(RequestTracer tracer) {
+        this.tracer = tracer;
+    }
+
+    public void setDefaultReturnValue(int defaultReturnValue) {
+        this.defaultReturnValue = defaultReturnValue;
+    }
+
+    public void addExecutor(String actionId, ActionExecutor executor) {
+        executors.put(actionId, executor);
+    }
+
+    @Override
+    public int execute(Action action, Event event) {
+        if (action == null || action.getActionType() == null) {
+            if (tracer != null && tracer.isEnabled()) {
+                tracer.trace("Action or action type is null, returning default value: " + defaultReturnValue, action);
+            }
+            LOGGER.warn("Action or action type is null");
+            return defaultReturnValue;
+        }
+
+        String actionId = action.getActionType().getActionExecutor();
+        if (tracer != null && tracer.isEnabled()) {
+            tracer.startOperation("action-execution", "Executing action: " + actionId, action);
+        }
+
+        ActionExecutor executor = executors.get(actionId);
+        if (executor != null) {
+            int result = executor.execute(action, event);
+            if (tracer != null && tracer.isEnabled()) {
+                tracer.endOperation(result != EventService.NO_CHANGE,
+                    "Action execution completed with result: " + result);
+            }
+            return result;
+        } else {
+            LOGGER.warn("Missing action executor for actionTypeId={}", actionId);
+        }
+
+        if (tracer != null && tracer.isEnabled()) {
+            tracer.endOperation(false,
+                "No executor found for action: " + actionId + ", returning default value: " + defaultReturnValue);
+        }
+        return defaultReturnValue;
+    }
+}

--- a/services/src/test/java/org/apache/unomi/services/impl/rules/TestSetEventOccurrenceCountAction.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/rules/TestSetEventOccurrenceCountAction.java
@@ -32,7 +32,7 @@ import java.util.*;
 
 /**
  * Test implementation of the SetEventOccurrenceCountAction.
- * TODO: This is a duplicate of the SetEventOccurrenceCountAction in the unomi-plugins-base project to avoid introducing a dependency on it but should be cleaned up.
+ * @TODO This is a duplicate of the SetEventOccurrenceCountAction in the unomi-plugins-base project to avoid introducing a depending to it but should be cleaned up.
  */
 public class TestSetEventOccurrenceCountAction implements ActionExecutor {
 

--- a/services/src/test/java/org/apache/unomi/services/impl/rules/TestSetEventOccurrenceCountAction.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/rules/TestSetEventOccurrenceCountAction.java
@@ -32,7 +32,7 @@ import java.util.*;
 
 /**
  * Test implementation of the SetEventOccurrenceCountAction.
- * @TODO This is a duplicate of the SetEventOccurrenceCountAction in the unomi-plugins-base project to avoid introducing a depending to it but should be cleaned up.
+ * TODO: This is a duplicate of the SetEventOccurrenceCountAction in the unomi-plugins-base project to avoid introducing a dependency on it but should be cleaned up.
  */
 public class TestSetEventOccurrenceCountAction implements ActionExecutor {
 

--- a/services/src/test/java/org/apache/unomi/services/impl/scheduler/SchedulerServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/scheduler/SchedulerServiceImplTest.java
@@ -1338,15 +1338,12 @@ public class SchedulerServiceImplTest {
                 node2.simulateCrash();
             }
 
-            // Wait for lock to expire: TEST_LOCK_TIMEOUT plus buffer for the surviving node to detect it
-            Thread.sleep(TEST_LOCK_TIMEOUT * 2);
-
-            // Trigger recovery on surviving node
-            if (originalNode.equals("node1")) {
-                node2.recoverCrashedTasks();
-            } else {
-                node1.recoverCrashedTasks();
-            }
+            // Retry triggering recovery until the lock expires and the task is actually recovered
+            SchedulerServiceImpl survivingNode = originalNode.equals("node1") ? node2 : node1;
+            TestHelper.retryUntil(
+                () -> { survivingNode.recoverCrashedTasks(); return taskRecovered.get(); },
+                recovered -> recovered
+            );
 
             assertTrue(completionLatch.await(TEST_TIMEOUT, TEST_TIME_UNIT), "Task should be recovered");
             assertTrue(taskRecovered.get(), "Task should be recovered by other node");

--- a/services/src/test/java/org/apache/unomi/services/impl/segments/SegmentServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/segments/SegmentServiceImplTest.java
@@ -38,6 +38,7 @@ import org.apache.unomi.services.common.security.KarafSecurityService;
 import org.apache.unomi.services.impl.InMemoryPersistenceServiceImpl;
 import org.apache.unomi.services.impl.TestConditionEvaluators;
 import org.apache.unomi.services.impl.TestEventAdmin;
+import org.apache.unomi.services.impl.TestRequestTracer;
 import org.apache.unomi.services.impl.TestTenantService;
 import org.apache.unomi.services.impl.cache.MultiTypeCacheServiceImpl;
 import org.apache.unomi.services.impl.definitions.DefinitionsServiceImpl;
@@ -96,7 +97,8 @@ public class SegmentServiceImplTest {
         tenantService = new TestTenantService();
         securityService = TestHelper.createSecurityService();
         executionContextManager = TestHelper.createExecutionContextManager(securityService);
-        TracerService tracerService = TestHelper.createTracerService();
+        tracerService = TestHelper.createTracerService();
+        requestTracer = new TestRequestTracer(true);
 
         // Create tenants using TestHelper
         TestHelper.setupCommonTestData(tenantService);
@@ -162,9 +164,6 @@ public class SegmentServiceImplTest {
         // Initialize services
         segmentService.postConstruct();
 
-        // Initialize rule caches
-        rulesService.postConstruct();
-
         // Create and deploy the system rule for segment evaluation
         executionContextManager.executeAsSystem(() -> {
             Rule segmentEvaluationRule = new Rule();
@@ -196,6 +195,8 @@ public class SegmentServiceImplTest {
 
     @AfterEach
     public void tearDown() throws Exception {
+        TestConditionEvaluators.setEventService(null);
+
         // Use the common tearDown method from TestHelper
         TestHelper.tearDown(
             schedulerService,
@@ -885,6 +886,7 @@ public class SegmentServiceImplTest {
             segmentService.recalculatePastEventConditions();
 
             // Verify profile is in segment
+            profile = persistenceService.load(profile.getItemId(), Profile.class);
             assertTrue(profile.getSegments().contains("test-segment"), "Profile should be in segment");
 
             return null;

--- a/services/src/test/java/org/apache/unomi/services/impl/segments/SegmentServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/segments/SegmentServiceImplTest.java
@@ -1,0 +1,1163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.services.impl.segments;
+
+import org.apache.unomi.api.Event;
+import org.apache.unomi.api.Metadata;
+import org.apache.unomi.api.PartialList;
+import org.apache.unomi.api.Profile;
+import org.apache.unomi.api.actions.Action;
+import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.api.conditions.ConditionType;
+import org.apache.unomi.api.exceptions.BadSegmentConditionException;
+import org.apache.unomi.api.rules.Rule;
+import org.apache.unomi.api.segments.Segment;
+import org.apache.unomi.api.segments.SegmentsAndScores;
+import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.api.services.SchedulerService;
+import org.apache.unomi.api.services.cache.CacheableTypeConfig;
+import org.apache.unomi.persistence.spi.PersistenceService;
+import org.apache.unomi.persistence.spi.conditions.evaluator.ConditionEvaluatorDispatcher;
+import org.apache.unomi.services.TestHelper;
+import org.apache.unomi.services.common.security.ExecutionContextManagerImpl;
+import org.apache.unomi.services.common.security.KarafSecurityService;
+import org.apache.unomi.services.impl.InMemoryPersistenceServiceImpl;
+import org.apache.unomi.services.impl.TestConditionEvaluators;
+import org.apache.unomi.services.impl.TestEventAdmin;
+import org.apache.unomi.services.impl.TestTenantService;
+import org.apache.unomi.services.impl.cache.MultiTypeCacheServiceImpl;
+import org.apache.unomi.services.impl.definitions.DefinitionsServiceImpl;
+import org.apache.unomi.services.impl.events.EventServiceImpl;
+import org.apache.unomi.services.impl.rules.RulesServiceImpl;
+import org.apache.unomi.services.impl.rules.TestActionExecutorDispatcher;
+import org.apache.unomi.services.impl.rules.TestEvaluateProfileSegmentsAction;
+import org.apache.unomi.services.impl.rules.TestSetEventOccurrenceCountAction;
+import org.apache.unomi.tracing.api.RequestTracer;
+import org.apache.unomi.tracing.api.TracerService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.osgi.framework.BundleContext;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class SegmentServiceImplTest {
+
+    private SegmentServiceImpl segmentService;
+    private EventServiceImpl eventService;
+    private TestTenantService tenantService;
+    private PersistenceService persistenceService;
+    private DefinitionsServiceImpl definitionsService;
+    private MultiTypeCacheServiceImpl multiTypeCacheService;
+    private ExecutionContextManagerImpl executionContextManager;
+    private KarafSecurityService securityService;
+    private RulesServiceImpl rulesService;
+    private TestActionExecutorDispatcher actionExecutorDispatcher;
+
+    private BundleContext bundleContext;
+    private TracerService tracerService;
+    private RequestTracer requestTracer;
+
+    private SchedulerService schedulerService;
+
+    private static final String TENANT_1 = "tenant1";
+    private static final String TENANT_2 = "tenant2";
+    private static final String SYSTEM_TENANT = "system";
+
+    @BeforeEach
+    public void setUp() throws IOException {
+
+        tenantService = new TestTenantService();
+        securityService = TestHelper.createSecurityService();
+        executionContextManager = TestHelper.createExecutionContextManager(securityService);
+        TracerService tracerService = TestHelper.createTracerService();
+
+        // Create tenants using TestHelper
+        TestHelper.setupCommonTestData(tenantService);
+
+        ConditionEvaluatorDispatcher conditionEvaluatorDispatcher = TestConditionEvaluators.createDispatcher();
+
+        // Set up bundle context using TestHelper
+        bundleContext = TestHelper.createMockBundleContext();
+
+        persistenceService = new InMemoryPersistenceServiceImpl(executionContextManager, conditionEvaluatorDispatcher);
+
+        // Create scheduler service using TestHelper
+        schedulerService = TestHelper.createSchedulerService("segment-service-scheduler-node", persistenceService, executionContextManager, bundleContext, null, -1, true, true);
+
+        multiTypeCacheService = new MultiTypeCacheServiceImpl();
+
+        // Create definitions service with EventAdmin
+        java.util.Map.Entry<DefinitionsServiceImpl, TestEventAdmin> servicePair =
+            TestHelper.createDefinitionServiceWithEventAdmin(persistenceService, bundleContext, schedulerService,
+                multiTypeCacheService, executionContextManager, tenantService);
+        definitionsService = servicePair.getKey();
+        TestEventAdmin testEventAdmin = servicePair.getValue();
+
+        // Inject definitionsService into the dispatcher
+        TestHelper.injectDefinitionsServiceIntoDispatcher(conditionEvaluatorDispatcher, definitionsService);
+
+        TestConditionEvaluators.getConditionTypes().forEach((key, value) -> definitionsService.setConditionType(value));
+
+        // Set up event service using TestHelper
+        eventService = TestHelper.createEventService(persistenceService, bundleContext, definitionsService, tenantService, tracerService);
+        TestConditionEvaluators.setEventService(eventService);
+
+        // Set up action executor dispatcher
+        actionExecutorDispatcher = new TestActionExecutorDispatcher(definitionsService, persistenceService);
+        actionExecutorDispatcher.setDefaultReturnValue(EventService.PROFILE_UPDATED);
+        actionExecutorDispatcher.setTracer(requestTracer);
+
+        // Set up rules service using TestHelper with EventAdmin
+        rulesService = TestHelper.createRulesService(persistenceService, bundleContext, schedulerService, definitionsService, eventService, executionContextManager, tenantService, multiTypeCacheService, actionExecutorDispatcher, testEventAdmin);
+        rulesService.setTracerService(tracerService);
+
+        // Set up segment service
+        segmentService = new SegmentServiceImpl();
+        segmentService.setBundleContext(bundleContext);
+        segmentService.setPersistenceService(persistenceService);
+        segmentService.setDefinitionsService(definitionsService);
+        segmentService.setRulesService(rulesService);
+        segmentService.setEventService(eventService);
+        segmentService.setContextManager(executionContextManager);
+        segmentService.setSchedulerService(schedulerService);
+        segmentService.setCacheService(multiTypeCacheService);
+        segmentService.setTenantService(tenantService);
+        segmentService.setTracerService(tracerService);
+
+        actionExecutorDispatcher.addExecutor("setEventOccurenceCountAction",
+                new TestSetEventOccurrenceCountAction(definitionsService, persistenceService));
+        actionExecutorDispatcher.addExecutor("evaluateProfileSegments",
+                new TestEvaluateProfileSegmentsAction(segmentService));
+
+        // Register TestEvaluateProfileSegmentsAction
+        actionExecutorDispatcher.addExecutor("evaluateProfileSegments", new TestEvaluateProfileSegmentsAction(segmentService));
+
+        // Set up action types
+        TestHelper.setupSegmentActionTypes(definitionsService);
+
+        // Initialize services
+        segmentService.postConstruct();
+
+        // Initialize rule caches
+        rulesService.postConstruct();
+
+        // Create and deploy the system rule for segment evaluation
+        executionContextManager.executeAsSystem(() -> {
+            Rule segmentEvaluationRule = new Rule();
+            segmentEvaluationRule.setItemId("evaluateProfileSegments");
+            segmentEvaluationRule.setTenantId(SYSTEM_TENANT);
+
+            Metadata metadata = new Metadata();
+            metadata.setId("evaluateProfileSegments");
+            metadata.setName("Evaluate segments");
+            metadata.setDescription("Evaluate segments when a profile is modified");
+            metadata.setReadOnly(true);
+            segmentEvaluationRule.setMetadata(metadata);
+
+            // Create profile updated condition
+            Condition condition = new Condition();
+            condition.setConditionTypeId("profileUpdatedEventCondition");
+            segmentEvaluationRule.setCondition(condition);
+
+            // Create evaluate segments action
+            Action action = new Action();
+            action.setActionType(definitionsService.getActionType("evaluateProfileSegmentsAction"));
+            action.setActionTypeId("evaluateProfileSegmentsAction");
+            segmentEvaluationRule.setActions(Collections.singletonList(action));
+
+            rulesService.setRule(segmentEvaluationRule);
+            return null;
+        });
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        // Use the common tearDown method from TestHelper
+        TestHelper.tearDown(
+            schedulerService,
+            multiTypeCacheService,
+            persistenceService,
+            tenantService,
+            TENANT_1, TENANT_2, SYSTEM_TENANT
+        );
+
+        // Clean up references using the helper method
+        TestHelper.cleanupReferences(
+            tenantService, securityService, executionContextManager, segmentService,
+            eventService, persistenceService, definitionsService, schedulerService,
+            multiTypeCacheService, bundleContext,
+            rulesService, actionExecutorDispatcher, tracerService, requestTracer
+        );
+    }
+
+    private Segment createTestSegment(String segmentId, String name) {
+        Segment segment = new Segment();
+        segment.setItemId(segmentId);
+        segment.setTenantId(executionContextManager.getCurrentContext().getTenantId());
+
+        Metadata metadata = new Metadata();
+        metadata.setId(segmentId);
+        metadata.setName(name);
+        metadata.setScope("systemscope");
+        metadata.setEnabled(true);
+        segment.setMetadata(metadata);
+
+        // Create a simple condition
+        Condition condition = new Condition();
+        condition.setConditionType(definitionsService.getConditionType("profilePropertyCondition"));
+        condition.setConditionTypeId("profilePropertyCondition");
+        condition.setParameter("propertyName", "properties.testProperty");
+        condition.setParameter("comparisonOperator", "equals");
+        condition.setParameter("propertyValue", "testValue");
+        segment.setCondition(condition);
+
+        return segment;
+    }
+
+    private Segment createPastEventSegment(String segmentId, String name, String eventType, int numberOfDays) {
+        Segment segment = new Segment();
+        segment.setItemId(segmentId);
+        segment.setTenantId(executionContextManager.getCurrentContext().getTenantId());
+
+        Metadata metadata = new Metadata();
+        metadata.setId(segmentId);
+        metadata.setName(name);
+        metadata.setScope("systemscope");
+        metadata.setEnabled(true);
+        segment.setMetadata(metadata);
+
+        // Create event condition
+        Condition eventCondition = new Condition();
+        eventCondition.setConditionType(definitionsService.getConditionType("eventTypeCondition"));
+        eventCondition.setConditionTypeId("eventTypeCondition");
+        eventCondition.setParameter("eventTypeId", eventType);
+
+        // Create past event condition
+        Condition pastEventCondition = new Condition();
+        pastEventCondition.setConditionType(definitionsService.getConditionType("pastEventCondition"));
+        pastEventCondition.setConditionTypeId("pastEventCondition");
+        pastEventCondition.setParameter("eventCondition", eventCondition);
+        if (numberOfDays > 0) {
+            pastEventCondition.setParameter("numberOfDays", numberOfDays);
+        }
+        pastEventCondition.setParameter("operator", "eventsOccurred");
+        segment.setCondition(pastEventCondition);
+
+        return segment;
+    }
+
+    private Profile createTestProfile() {
+        String currentTenant = executionContextManager.getCurrentContext().getTenantId();
+        Profile profile = new Profile(currentTenant);
+        profile.setProperty("testProperty", "testValue");
+        return profile;
+    }
+
+    private Event createTestEvent(Profile profile, String eventType) {
+        Event event = new Event();
+        event.setEventType(eventType);
+        event.setProfile(profile);
+        event.setProfileId(profile.getItemId());
+        event.setTenantId(profile.getTenantId());
+        event.setTimeStamp(new Date());
+        event.setActionPostExecutors(new ArrayList<>());
+        event.setAttributes(Collections.<String, Object>emptyMap());
+        event.setPersistent(true);
+        return event;
+    }
+
+    private void addEventToProfile(Profile profile, Event event) {
+        Map<String, Object> systemProperties = profile.getSystemProperties();
+        @SuppressWarnings("unchecked")
+        List<Event> pastEvents = (List<Event>) systemProperties.get("pastEvents");
+        if (pastEvents == null) {
+            pastEvents = new ArrayList<>();
+            systemProperties.put("pastEvents", pastEvents);
+        }
+        pastEvents.add(event);
+        persistenceService.save(profile);
+    }
+
+    @Test
+    public void testSetAndGetSegmentDefinition() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create and set segment
+            Segment segment = createTestSegment("test-segment", "Test Segment");
+            segmentService.setSegmentDefinition(segment);
+
+            // Get and verify
+            Segment retrieved = segmentService.getSegmentDefinition("test-segment");
+            assertNotNull(retrieved, "Should retrieve segment");
+            assertEquals("test-segment", retrieved.getItemId(), "Should have correct ID");
+            assertEquals("Test Segment", retrieved.getMetadata().getName(), "Should have correct name");
+            assertEquals(TENANT_1, retrieved.getTenantId(), "Should have correct tenant");
+            return null;
+        });
+    }
+
+    @Test
+    public void testIsProfileInSegment() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create and set segment
+            Segment segment = createTestSegment("test-segment", "Test Segment");
+            segmentService.setSegmentDefinition(segment);
+
+            // Create matching profile
+            Profile profile = createTestProfile();
+
+            // Test matching
+            Boolean isInSegment = segmentService.isProfileInSegment(profile, "test-segment");
+            assertTrue(isInSegment, "Profile should match segment");
+
+            // Test non-matching
+            profile.setProperty("testProperty", "differentValue");
+            isInSegment = segmentService.isProfileInSegment(profile, "test-segment");
+            assertFalse(isInSegment, "Profile should not match segment");
+            return null;
+        });
+    }
+
+    @Test
+    public void testGetSegmentsAndScoresForProfile() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create and set multiple segments
+            Segment segment1 = createTestSegment("segment1", "Segment 1");
+            Segment segment2 = createTestSegment("segment2", "Segment 2");
+            segmentService.setSegmentDefinition(segment1);
+            segmentService.setSegmentDefinition(segment2);
+
+            // Force a reload and an update of the caches
+            CacheableTypeConfig<Segment> segmentConfig = CacheableTypeConfig.<Segment>builder(
+                Segment.class,
+                Segment.ITEM_TYPE,
+                "segments")
+                .withInheritFromSystemTenant(true)
+                .withRequiresRefresh(true)
+                .withRefreshInterval(1000L)
+                .withIdExtractor(s -> s.getMetadata().getId())
+                .build();
+            multiTypeCacheService.refreshTypeCache(segmentConfig);
+
+            // Create profile that matches both segments
+            Profile profile = createTestProfile();
+
+            // Get segments and verify
+            SegmentsAndScores segmentsAndScores = segmentService.getSegmentsAndScoresForProfile(profile);
+            assertNotNull(segmentsAndScores, "Should return segments and scores");
+            assertTrue(segmentsAndScores.getSegments().contains("segment1"), "Should contain segment1");
+            assertTrue(segmentsAndScores.getSegments().contains("segment2"), "Should contain segment2");
+            return null;
+        });
+    }
+
+    @Test
+    public void testGetSegmentsAndScoresForProfileTenantInheritance() {
+        // Create segments in system tenant
+        executionContextManager.executeAsSystem(() -> {
+            Segment systemSegment = createTestSegment("system-segment", "System Segment");
+            segmentService.setSegmentDefinition(systemSegment);
+            return null;
+        });
+
+        // Create segments in tenant1
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create tenant segment
+            Segment tenantSegment = createTestSegment("tenant-segment", "Tenant Segment");
+            segmentService.setSegmentDefinition(tenantSegment);
+
+            // Create profile that matches both segments
+            Profile profile = createTestProfile();
+
+            // Get segments and verify
+            SegmentsAndScores segmentsAndScores = segmentService.getSegmentsAndScoresForProfile(profile);
+            assertNotNull(segmentsAndScores, "Should return segments and scores");
+            assertTrue(segmentsAndScores.getSegments().contains("system-segment"), "Should contain system segment");
+            assertTrue(segmentsAndScores.getSegments().contains("tenant-segment"), "Should contain tenant segment");
+
+            // Create tenant segment with same ID as system segment to test override
+            Segment overrideSegment = createTestSegment("system-segment", "Override Segment");
+            // Change condition to match the profile but with a different value
+            overrideSegment.getCondition().setParameter("propertyValue", "testValue");
+            segmentService.setSegmentDefinition(overrideSegment);
+
+            // Update profile to match only tenant segment condition
+            profile.setProperty("testProperty", "testValue");
+
+            // Verify tenant segment overrides system segment
+            segmentsAndScores = segmentService.getSegmentsAndScoresForProfile(profile);
+            assertTrue(segmentsAndScores.getSegments().contains("system-segment"), "Should contain tenant segment");
+            assertEquals(1,
+                segmentsAndScores.getSegments().stream().filter(s -> s.equals("system-segment")).count(),
+                "Should only contain one instance of the segment");
+
+            return null;
+        });
+
+        // Verify tenant2 only sees system segment
+        executionContextManager.executeAsTenant(TENANT_2, () -> {
+            Profile profile = createTestProfile();
+            SegmentsAndScores segmentsAndScores = segmentService.getSegmentsAndScoresForProfile(profile);
+            assertTrue(segmentsAndScores.getSegments().contains("system-segment"), "Should contain system segment");
+            assertFalse(segmentsAndScores.getSegments().contains("tenant-segment"), "Should not contain tenant1 segment");
+            return null;
+        });
+    }
+
+    @Test
+    public void testSegmentInheritanceFromSystemTenant() {
+        // Create a segment in system tenant
+        executionContextManager.executeAsSystem(() -> {
+            Segment systemSegment = createTestSegment("system-segment", "System Segment");
+            segmentService.setSegmentDefinition(systemSegment);
+            return null;
+        });
+
+        // Create a segment in tenant1
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Segment tenantSegment = createTestSegment("tenant-segment", "Tenant Segment");
+            segmentService.setSegmentDefinition(tenantSegment);
+
+            // Test that tenant1 can see both segments
+            Profile profile = createTestProfile();
+            SegmentsAndScores segmentsAndScores = segmentService.getSegmentsAndScoresForProfile(profile);
+            assertTrue(segmentsAndScores.getSegments().contains("system-segment"), "Should contain system segment");
+            assertTrue(segmentsAndScores.getSegments().contains("tenant-segment"), "Should contain tenant segment");
+            return null;
+        });
+
+        // Test that tenant2 can only see system segment
+        executionContextManager.executeAsTenant(TENANT_2, () -> {
+            Profile profile = createTestProfile();
+            SegmentsAndScores segmentsAndScores = segmentService.getSegmentsAndScoresForProfile(profile);
+            assertTrue(segmentsAndScores.getSegments().contains("system-segment"), "Should contain system segment");
+            assertFalse(segmentsAndScores.getSegments().contains("tenant-segment"), "Should not contain tenant1 segment");
+            return null;
+        });
+    }
+
+    @Test
+    public void testRemoveSegmentDefinition() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create and set segment
+            Segment segment = createTestSegment("test-segment", "Test Segment");
+            segmentService.setSegmentDefinition(segment);
+
+            // Remove segment
+            segmentService.removeSegmentDefinition("test-segment", true);
+
+            // Verify removal
+            Segment removed = segmentService.getSegmentDefinition("test-segment");
+            assertNull(removed, "Segment should be removed");
+
+            // Verify profile is no longer in segment
+            Profile profile = createTestProfile();
+            Boolean isInSegment = segmentService.isProfileInSegment(profile, "test-segment");
+            assertFalse(isInSegment, "Profile should not be in removed segment");
+            return null;
+        });
+    }
+
+    @Test
+    public void testPastEventSegment() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create profile
+            Profile profile = createTestProfile();
+            persistenceService.save(profile);
+
+            // Create past event segment (last 30 days)
+            Segment segment = createPastEventSegment("past-event-segment", "Past Event Segment", "test-event", 30);
+            segmentService.setSegmentDefinition(segment);
+
+            // Create and save some events
+            Event event1 = createTestEvent(profile, "test-event");
+            Event event2 = createTestEvent(profile, "test-event");
+            eventService.send(event1);
+            eventService.send(event2);
+
+            // Refresh persistence to ensure events are available for aggregation (handles refresh delay)
+            persistenceService.refresh();
+
+            // Force recalculation of past event conditions
+            segmentService.recalculatePastEventConditions();
+
+            // Verify profile is in segment - retry until segment is updated (handles refresh delay)
+            TestHelper.retryUntil(
+                () -> profile.getSegments().contains("past-event-segment"),
+                r -> r == true
+            );
+            assertTrue(profile.getSegments().contains("past-event-segment"), "Profile should be in past event segment");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testPastEventSegmentWithDateRange() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create profile
+            Profile profile = createTestProfile();
+            persistenceService.save(profile);
+
+            // Create past event segment with date range
+            Segment segment = createPastEventSegment("date-range-segment", "Date Range Segment", "test-event", 0);
+            Condition condition = segment.getCondition();
+            condition.setParameter("fromDate", "2024-01-01T00:00:00Z");
+            condition.setParameter("toDate", "2024-12-31T23:59:59Z");
+            condition.setParameter("operator", "eventsOccurred");
+            segmentService.setSegmentDefinition(segment);
+
+            // Create and save event within date range
+            Event event = createTestEvent(profile, "test-event");
+            Calendar cal = Calendar.getInstance();
+            cal.set(2024, Calendar.JUNE, 1);
+            event.setTimeStamp(cal.getTime());
+            eventService.send(event);
+
+            // Refresh persistence to ensure events are available for aggregation (handles refresh delay)
+            persistenceService.refresh();
+
+            // Force recalculation of past event conditions
+            segmentService.recalculatePastEventConditions();
+
+            // Retry until segment is updated (handles refresh delay)
+            TestHelper.retryUntil(
+                () -> profile.getSegments().contains("date-range-segment"),
+                r -> r == true
+            );
+            assertTrue(profile.getSegments().contains("date-range-segment"), "Profile should be in date range segment");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testPastEventSegmentOutsideDateRange() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create profile
+            Profile profile = createTestProfile();
+            persistenceService.save(profile);
+
+            // Create past event segment with date range
+            Segment segment = createPastEventSegment("date-range-segment", "Date Range Segment", "test-event", 0);
+            Condition condition = segment.getCondition();
+            condition.setParameter("fromDate", "2024-01-01T00:00:00Z");
+            condition.setParameter("toDate", "2024-12-31T23:59:59Z");
+            segmentService.setSegmentDefinition(segment);
+
+            // Create and save event outside date range
+            Event event = createTestEvent(profile, "test-event");
+            Calendar cal = Calendar.getInstance();
+            cal.set(2023, Calendar.DECEMBER, 31); // Event before date range
+            event.setTimeStamp(cal.getTime());
+            eventService.send(event);
+
+            assertFalse(profile.getSegments().contains("date-range-segment"), "Profile should not be in date range segment");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testPastEventSegmentWithDifferentEventType() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create profile
+            Profile profile = createTestProfile();
+            persistenceService.save(profile);
+
+            // Create past event segment for specific event type
+            Segment segment = createPastEventSegment("past-event-segment", "Past Event Segment", "target-event", 30);
+            segmentService.setSegmentDefinition(segment);
+
+            // Create and save event with different type
+            Event event = createTestEvent(profile, "different-event");
+            eventService.send(event);
+
+            // Verify profile is not in segment
+            Boolean isInSegment = segmentService.isProfileInSegment(profile, "past-event-segment");
+            assertFalse(isInSegment, "Profile should not be in segment due to different event type");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testSystemTenantInheritance() {
+        // Create a segment in system tenant
+        executionContextManager.executeAsSystem(() -> {
+            Segment systemSegment = createTestSegment("system-segment", "System Segment");
+            segmentService.setSegmentDefinition(systemSegment);
+            return null;
+        });
+
+        // Test that tenant1 can see the system segment
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Segment segment = segmentService.getSegmentDefinition("system-segment");
+            assertNotNull(segment, "Tenant should see system segment");
+            assertEquals("system-segment", segment.getItemId(), "Should have correct ID");
+            assertEquals("System Segment", segment.getMetadata().getName(), "Should have correct name");
+            return null;
+        });
+
+        // Test that tenant2 can also see the system segment
+        executionContextManager.executeAsTenant(TENANT_2, () -> {
+            Segment segment = segmentService.getSegmentDefinition("system-segment");
+            assertNotNull(segment, "Tenant should see system segment");
+            assertEquals("system-segment", segment.getItemId(), "Should have correct ID");
+            assertEquals("System Segment", segment.getMetadata().getName(), "Should have correct name");
+            return null;
+        });
+    }
+
+    @Test
+    public void testTenantIsolation() {
+        // Create a segment in tenant1
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Segment tenant1Segment = createTestSegment("tenant1-segment", "Tenant 1 Segment");
+            segmentService.setSegmentDefinition(tenant1Segment);
+            return null;
+        });
+
+        // Test that tenant2 cannot see tenant1's segment
+        executionContextManager.executeAsTenant(TENANT_2, () -> {
+            Segment segment = segmentService.getSegmentDefinition("tenant1-segment");
+            assertNull(segment, "Tenant2 should not see tenant1's segment");
+            return null;
+        });
+    }
+
+    @Test
+    public void testCacheRefresh() {
+        // Create a segment in tenant1
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Segment segment = createTestSegment("test-segment", "Test Segment");
+            segmentService.setSegmentDefinition(segment);
+
+            // Verify it's in the cache
+            Map<String, Segment> cache = multiTypeCacheService.getTenantCache(TENANT_1, Segment.class);
+            assertNotNull(cache, "Cache should exist");
+            assertNotNull(cache.get("test-segment"), "Segment should be in cache");
+
+            // Update segment directly in persistence
+            segment.getMetadata().setName("Updated Name");
+            persistenceService.save(segment);
+
+            // Force cache refresh
+            segmentService.postConstruct();
+
+            // Verify cache was updated
+            cache = multiTypeCacheService.getTenantCache(TENANT_1, Segment.class);
+            assertEquals("Updated Name",
+                cache.get("test-segment").getMetadata().getName(),
+                "Cache should have updated name");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testPredefinedSegmentLoading() {
+        // Mock bundle entries
+        URL mockUrl = getClass().getResource("/test-segments/test-segment.json");
+        when(bundleContext.getBundle().findEntries(eq("META-INF/cxs/segments"), eq("*.json"), eq(true)))
+            .thenReturn(Collections.enumeration(Collections.singletonList(mockUrl)));
+
+        // Initialize service
+        segmentService.postConstruct();
+
+        // Verify predefined segment was loaded
+        executionContextManager.executeAsSystem(() -> {
+            Segment segment = segmentService.getSegmentDefinition("test-segment");
+            assertNotNull(segment, "Predefined segment should be loaded");
+            assertEquals("Test Segment", segment.getMetadata().getName(), "Should have correct name");
+            return null;
+        });
+    }
+
+    @Test
+    public void testGetSegmentMetadatasTenantInheritance() {
+        // Create segments in system tenant
+        executionContextManager.executeAsSystem(() -> {
+            Segment systemSegment1 = createTestSegment("system-segment-1", "System Segment 1");
+            Segment systemSegment2 = createTestSegment("system-segment-2", "System Segment 2");
+            segmentService.setSegmentDefinition(systemSegment1);
+            segmentService.setSegmentDefinition(systemSegment2);
+            return null;
+        });
+
+        // Create segments in tenant1
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Segment tenant1Segment = createTestSegment("tenant1-segment", "Tenant 1 Segment");
+            segmentService.setSegmentDefinition(tenant1Segment);
+
+            // Refresh persistence to ensure segments are available for querying (handles refresh delay)
+            persistenceService.refresh();
+
+            // Verify tenant1 can see both system and tenant1 segments - retry until segments are available
+            PartialList<Metadata> metadatas = TestHelper.retryQueryUntilAvailable(
+                () -> segmentService.getSegmentMetadatas(0, 10, null),
+                3
+            );
+            assertEquals(3, metadatas.getList().size(), "Should see all segments");
+            assertTrue(
+                metadatas.getList().stream().anyMatch(m -> m.getId().equals("system-segment-1")),
+                "Should contain system segment 1");
+            assertTrue(
+                metadatas.getList().stream().anyMatch(m -> m.getId().equals("system-segment-2")),
+                "Should contain system segment 2");
+            assertTrue(
+                metadatas.getList().stream().anyMatch(m -> m.getId().equals("tenant1-segment")),
+                "Should contain tenant segment");
+            return null;
+        });
+
+        // Verify tenant2 only sees system segments
+        executionContextManager.executeAsTenant(TENANT_2, () -> {
+            PartialList<Metadata> metadatas = segmentService.getSegmentMetadatas(0, 10, null);
+            assertEquals(2, metadatas.getList().size(), "Should only see system segments");
+            assertTrue(
+                metadatas.getList().stream().anyMatch(m -> m.getId().equals("system-segment-1")),
+                "Should contain system segment 1");
+            assertTrue(
+                metadatas.getList().stream().anyMatch(m -> m.getId().equals("system-segment-2")),
+                "Should contain system segment 2");
+            assertFalse(
+                metadatas.getList().stream().anyMatch(m -> m.getId().equals("tenant1-segment")),
+                "Should not contain tenant1 segment");
+            return null;
+        });
+    }
+
+    @Test
+    public void testSegmentUpdateAcrossTenants() {
+        // Create segment in system tenant
+        executionContextManager.executeAsSystem(() -> {
+            Segment systemSegment = createTestSegment("system-segment", "System Segment");
+            segmentService.setSegmentDefinition(systemSegment);
+            return null;
+        });
+
+        // Verify tenant1 sees original name
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Segment segment = segmentService.getSegmentDefinition("system-segment");
+            assertEquals("System Segment", segment.getMetadata().getName(), "Should see original name");
+            return null;
+        });
+
+        // Update segment in system tenant
+        executionContextManager.executeAsSystem(() -> {
+            Segment systemSegment = segmentService.getSegmentDefinition("system-segment");
+            systemSegment.getMetadata().setName("Updated System Segment");
+            segmentService.setSegmentDefinition(systemSegment);
+            return null;
+        });
+
+        // Verify tenant1 sees updated name
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Segment segment = segmentService.getSegmentDefinition("system-segment");
+            assertEquals("Updated System Segment", segment.getMetadata().getName(), "Should see updated name");
+            return null;
+        });
+    }
+
+    @Test
+    public void testSegmentDeletionAcrossTenants() {
+        // Create segment in system tenant
+        executionContextManager.executeAsSystem(() -> {
+            Segment systemSegment = createTestSegment("system-segment", "System Segment");
+            segmentService.setSegmentDefinition(systemSegment);
+            return null;
+        });
+
+        // Create profile in tenant1 that matches the segment
+        final String[] profileId = new String[1];
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            Profile profile = createTestProfile();
+            persistenceService.save(profile);
+            profileId[0] = profile.getItemId();
+            assertTrue(
+                segmentService.isProfileInSegment(profile, "system-segment"),
+                "Profile should be in system segment");
+            return null;
+        });
+
+        // Delete segment in system tenant
+        executionContextManager.executeAsSystem(() -> {
+            segmentService.removeSegmentDefinition("system-segment", true);
+            return null;
+        });
+
+        // Verify segment is removed from tenant1 and profile
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            assertNull(
+                segmentService.getSegmentDefinition("system-segment"),
+                "Segment should be removed");
+            Profile profile = persistenceService.load(profileId[0], Profile.class);
+            assertFalse(
+                profile.getSegments().contains("system-segment"),
+                "Profile should not be in removed segment");
+            return null;
+        });
+    }
+
+    @Test
+    public void testCustomEventConditionTypeWithBooleanParent() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create profile
+            Profile profile = createTestProfile();
+            persistenceService.save(profile);
+
+            // Register custom condition type with boolean parent condition
+            ConditionType customEventConditionType = new ConditionType();
+            customEventConditionType.setItemId("customEventCondition");
+            // No direct evaluator or queryBuilder - will use parent condition's evaluator (booleanConditionEvaluator)
+            customEventConditionType.setConditionEvaluator(null);
+            customEventConditionType.setQueryBuilder(null);
+
+            // Create simple boolean parent condition
+            Condition booleanParent = new Condition(definitionsService.getConditionType("booleanCondition"));
+            booleanParent.setParameter("operator", "and");
+
+            // Add two simple event conditions
+            Condition eventTypeCondition = new Condition(definitionsService.getConditionType("eventTypeCondition"));
+            eventTypeCondition.setParameter("eventTypeId", "view");
+
+            Condition propertyCondition = new Condition(definitionsService.getConditionType("eventPropertyCondition"));
+            propertyCondition.setParameter("propertyName", "testProperty");
+            propertyCondition.setParameter("comparisonOperator", "equals");
+            propertyCondition.setParameter("propertyValue", "parameter::value");
+
+            booleanParent.setParameter("subConditions", Arrays.asList(eventTypeCondition, propertyCondition));
+            customEventConditionType.setParentCondition(booleanParent);
+
+            // Set metadata with eventCondition tag
+            customEventConditionType.setMetadata(new Metadata(null, "customEventCondition", "Custom Event Condition", ""));
+            customEventConditionType.getMetadata().setSystemTags(new HashSet<>(Arrays.asList("eventCondition")));
+            customEventConditionType.getMetadata().setEnabled(true);
+
+            definitionsService.setConditionType(customEventConditionType);
+
+            // Create segment
+            Segment segment = createTestSegment("test-segment", "Test Segment");
+
+            // Create past event condition using the custom condition
+            Condition pastEventCondition = new Condition(definitionsService.getConditionType("pastEventCondition"));
+            Condition customCondition = new Condition(customEventConditionType);
+            // Add "value" parameter to make it available in context for parameter::value reference
+            customCondition.setParameter("value", "test");
+
+            pastEventCondition.setParameter("eventCondition", customCondition);
+            pastEventCondition.setParameter("numberOfDays", 30);
+            pastEventCondition.setParameter("operator", "eventsOccurred");
+            segment.setCondition(pastEventCondition);
+
+            segmentService.setSegmentDefinition(segment);
+
+            // Send matching event
+            Event event = createTestEvent(profile, "view");
+            event.setProperty("testProperty", "test");
+            eventService.send(event);
+
+            // Force recalculation
+            segmentService.recalculatePastEventConditions();
+
+            // Verify profile is in segment
+            assertTrue(profile.getSegments().contains("test-segment"), "Profile should be in segment");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testMultiplePastEventConditionsWithBoolean() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create profile
+            Profile profile = createTestProfile();
+            persistenceService.save(profile);
+
+            // Create segment with boolean condition combining two past event conditions
+            Segment segment = new Segment();
+            segment.setItemId("test-segment");
+            segment.setTenantId(executionContextManager.getCurrentContext().getTenantId());
+
+            Metadata metadata = new Metadata();
+            metadata.setId("test-segment");
+            metadata.setName("Test Segment");
+            metadata.setScope("systemscope");
+            metadata.setEnabled(true);
+            segment.setMetadata(metadata);
+
+            // Create first past event condition (view events)
+            Condition eventCondition1 = new Condition(definitionsService.getConditionType("eventTypeCondition"));
+            eventCondition1.setParameter("eventTypeId", "view");
+            // Ensure event condition type is properly tagged
+            eventCondition1.getConditionType().getMetadata().setSystemTags(Collections.singleton("eventCondition"));
+
+            Condition pastEventCondition1 = new Condition(definitionsService.getConditionType("pastEventCondition"));
+            pastEventCondition1.setParameter("eventCondition", eventCondition1);
+            pastEventCondition1.setParameter("numberOfDays", 30);
+            pastEventCondition1.setParameter("minimumEventCount", 1);
+            pastEventCondition1.setParameter("operator", "eventsOccurred");
+
+            // Create second past event condition (login events)
+            Condition eventCondition2 = new Condition(definitionsService.getConditionType("eventTypeCondition"));
+            eventCondition2.setParameter("eventTypeId", "login");
+            // Ensure event condition type is properly tagged
+            eventCondition2.getConditionType().getMetadata().setSystemTags(Collections.singleton("eventCondition"));
+
+            Condition pastEventCondition2 = new Condition(definitionsService.getConditionType("pastEventCondition"));
+            pastEventCondition2.setParameter("eventCondition", eventCondition2);
+            pastEventCondition2.setParameter("numberOfDays", 30);
+            pastEventCondition2.setParameter("minimumEventCount", 1);
+            pastEventCondition2.setParameter("operator", "eventsOccurred");
+
+            // Combine with boolean condition
+            Condition booleanCondition = new Condition(definitionsService.getConditionType("booleanCondition"));
+            booleanCondition.setParameter("operator", "and");
+            booleanCondition.setParameter("subConditions", Arrays.asList(pastEventCondition1, pastEventCondition2));
+
+            segment.setCondition(booleanCondition);
+            segmentService.setSegmentDefinition(segment);
+
+            // Send first matching event (view)
+            Event viewEvent = createTestEvent(profile, "view");
+            viewEvent.setPersistent(true);
+            eventService.send(viewEvent);
+            persistenceService.save(viewEvent);
+
+            // Force event indexing and recalculation
+            persistenceService.refresh();
+            segmentService.recalculatePastEventConditions();
+
+            // Reload profile and verify intermediate state
+            profile = persistenceService.load(profile.getItemId(), Profile.class);
+            assertFalse(profile.getSegments().contains("test-segment"), "Profile should not be in segment yet");
+
+            // Send second matching event (login)
+            Event loginEvent = createTestEvent(profile, "login");
+            loginEvent.setPersistent(true);
+            eventService.send(loginEvent);
+            persistenceService.save(loginEvent);
+
+            // Force event indexing and recalculation
+            persistenceService.refresh();
+            segmentService.recalculatePastEventConditions();
+
+            // Reload profile and verify final state
+            profile = persistenceService.load(profile.getItemId(), Profile.class);
+            assertTrue(profile.getSegments().contains("test-segment"), "Profile should be in segment");
+
+            return null;
+        });
+    }
+
+    @Test
+    public void testSetSegmentWithInvalidCondition() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a segment with invalid condition
+            Segment segment = new Segment();
+            segment.setItemId("testSegment");
+            segment.setMetadata(new Metadata());
+            segment.getMetadata().setId("testSegment");
+            segment.getMetadata().setEnabled(true);
+
+            // Create an invalid condition (missing required parameters)
+            Condition condition = new Condition();
+            condition.setConditionTypeId("profilePropertyCondition");
+
+            // Get the condition type from definitions service
+            ConditionType conditionType = definitionsService.getConditionType("profilePropertyCondition");
+            assertNotNull(conditionType, "Condition type should exist");
+            condition.setConditionType(conditionType);
+
+            // Don't set required parameters
+            segment.setCondition(condition);
+
+            // Should throw BadSegmentConditionException since condition is missing required parameters
+            org.junit.jupiter.api.Assertions.assertThrows(
+                BadSegmentConditionException.class,
+                () -> segmentService.setSegmentDefinition(segment),
+                "Setting segment with missing required parameters should fail (segmentId=testSegment)"
+            );
+            return null;
+        });
+    }
+
+    @Test
+    public void testSetSegmentWithValidCondition() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a segment with valid condition
+            Segment segment = new Segment();
+            Metadata metadata = new Metadata();
+            metadata.setId("testSegment");
+            metadata.setEnabled(true);
+            segment.setMetadata(metadata);
+
+            // Create a valid condition
+            Condition condition = new Condition();
+            condition.setConditionTypeId("profilePropertyCondition");
+
+            // Get the condition type from definitions service
+            ConditionType conditionType = definitionsService.getConditionType("profilePropertyCondition");
+            assertNotNull(conditionType, "Condition type should exist");
+            condition.setConditionType(conditionType);
+
+            // Set all required parameters
+            condition.setParameter("propertyName", "properties.testProperty");
+            condition.setParameter("comparisonOperator", "equals");
+            condition.setParameter("propertyValue", "testValue");
+            segment.setCondition(condition);
+
+            // Should not throw any exceptions
+            segmentService.setSegmentDefinition(segment);
+
+            // Verify segment was saved
+            Segment savedSegment = segmentService.getSegmentDefinition("testSegment");
+            assertNotNull(savedSegment, "Segment should be saved (segmentId=testSegment)");
+            assertEquals(
+                "profilePropertyCondition",
+                savedSegment.getCondition().getConditionTypeId(),
+                "Saved segment should reference profilePropertyCondition type (segmentId=testSegment)"
+            );
+            return null;
+        });
+    }
+
+    @Test
+    public void testSetSegmentWithNestedConditions() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a segment with nested conditions
+            Segment segment = new Segment();
+            // We have to create the metadata before setting it because the metadata id will be used to set the itemId of the segment
+            Metadata metadata = new Metadata();
+            metadata.setId("testSegment");
+            metadata.setEnabled(true);
+            segment.setMetadata(metadata);
+
+            // Create parent condition
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("booleanCondition");
+
+            // Get the condition type from definitions service
+            ConditionType booleanConditionType = definitionsService.getConditionType("booleanCondition");
+            assertNotNull(booleanConditionType, "Boolean condition type should exist");
+            parentCondition.setConditionType(booleanConditionType);
+            parentCondition.setParameter("operator", "and");
+
+            // Create child condition
+            Condition childCondition = new Condition();
+            childCondition.setConditionTypeId("profilePropertyCondition");
+
+            // Get the condition type from definitions service
+            ConditionType profilePropertyConditionType = definitionsService.getConditionType("profilePropertyCondition");
+            assertNotNull(profilePropertyConditionType, "Profile property condition type should exist");
+            childCondition.setConditionType(profilePropertyConditionType);
+
+            childCondition.setParameter("propertyName", "properties.testProperty");
+            childCondition.setParameter("comparisonOperator", "equals");
+            childCondition.setParameter("propertyValue", "testValue");
+
+            // Set up nested structure
+            List<Condition> subConditions = new ArrayList<>();
+            subConditions.add(childCondition);
+            parentCondition.setParameter("subConditions", subConditions);
+
+            segment.setCondition(parentCondition);
+
+            // Should not throw any exceptions
+            segmentService.setSegmentDefinition(segment);
+
+            // Verify segment was saved with nested conditions
+            Segment savedSegment = segmentService.getSegmentDefinition("testSegment");
+            assertNotNull(savedSegment, "Segment should be saved");
+            assertEquals(
+                "booleanCondition",
+                savedSegment.getCondition().getConditionTypeId(),
+                "Saved segment should use boolean parent condition (segmentId=testSegment)"
+            );
+            List<Condition> savedSubConditions = (List<Condition>) savedSegment.getCondition().getParameter("subConditions");
+            assertNotNull(savedSubConditions, "Saved segment should include sub conditions (segmentId=testSegment)");
+            assertEquals(1, savedSubConditions.size(), "Saved segment should have one sub condition (segmentId=testSegment)");
+            assertEquals(
+                "profilePropertyCondition",
+                savedSubConditions.get(0).getConditionTypeId(),
+                "Child condition should be profilePropertyCondition (segmentId=testSegment)"
+            );
+            return null;
+        });
+    }
+
+    @Test
+    public void testSetSegmentWithInvalidNestedCondition() {
+        executionContextManager.executeAsTenant(TENANT_1, () -> {
+            // Create a segment with nested conditions where child is invalid
+            Segment segment = new Segment();
+            segment.setItemId("testSegment");
+            segment.setMetadata(new Metadata());
+            segment.getMetadata().setId("testSegment");
+            segment.getMetadata().setEnabled(true);
+
+            // Create parent condition
+            Condition parentCondition = new Condition();
+            parentCondition.setConditionTypeId("booleanCondition");
+
+            // Get the condition type from definitions service
+            ConditionType booleanConditionType = definitionsService.getConditionType("booleanCondition");
+            assertNotNull(booleanConditionType, "Boolean condition type should exist");
+            parentCondition.setConditionType(booleanConditionType);
+            parentCondition.setParameter("operator", "and");
+
+            // Create invalid child condition (missing required parameters)
+            Condition childCondition = new Condition();
+            childCondition.setConditionTypeId("profilePropertyCondition");
+
+            // Get the condition type from definitions service
+            ConditionType profilePropertyConditionType = definitionsService.getConditionType("profilePropertyCondition");
+            assertNotNull(profilePropertyConditionType, "Profile property condition type should exist");
+            childCondition.setConditionType(profilePropertyConditionType);
+
+            // Don't set required parameters
+
+            // Set up nested structure
+            List<Condition> subConditions = new ArrayList<>();
+            subConditions.add(childCondition);
+            parentCondition.setParameter("subConditions", subConditions);
+
+            segment.setCondition(parentCondition);
+
+            // Should throw BadSegmentConditionException since child condition is missing required parameters
+            org.junit.jupiter.api.Assertions.assertThrows(
+                BadSegmentConditionException.class,
+                () -> segmentService.setSegmentDefinition(segment),
+                "Setting segment with invalid nested child condition should fail (segmentId=testSegment)"
+            );
+            return null;
+        });
+    }
+}

--- a/services/src/test/java/org/apache/unomi/services/impl/segments/SegmentServiceImplTest.java
+++ b/services/src/test/java/org/apache/unomi/services/impl/segments/SegmentServiceImplTest.java
@@ -156,9 +156,6 @@ public class SegmentServiceImplTest {
         actionExecutorDispatcher.addExecutor("evaluateProfileSegments",
                 new TestEvaluateProfileSegmentsAction(segmentService));
 
-        // Register TestEvaluateProfileSegmentsAction
-        actionExecutorDispatcher.addExecutor("evaluateProfileSegments", new TestEvaluateProfileSegmentsAction(segmentService));
-
         // Set up action types
         TestHelper.setupSegmentActionTypes(definitionsService);
 


### PR DESCRIPTION
## Summary
- Adds UNOMI-881 part 2: service unit tests that depend on tracing (UNOMI-873) and condition validation/type resolution (UNOMI-883), deferred from #772.
- Extends the test harness (`TestHelper`, `TestRequestTracer`, `TestActionExecutorDispatcher`, etc.) with tracing-aware factories for rules, events, and definitions.
- Adds extension unit tests for `GroovyActionsServiceImpl` and `SchemaServiceImpl` with test resources.

## Test plan
- [x] `mvn -pl services install -DskipTests` (refresh test-jar for extension modules)
- [x] `mvn -pl services,extensions/groovy-actions/services,extensions/json-schema/services test`
- [x] `mvn -pl services test` (full services suite, ~547 tests)
- [ ] CI green

## Notes
- Test-only backport from `unomi-3-dev`; no production code changes.
- Master review fixes preserved (`clearCurrentTenantId`, `cleanupReferences` no-op, `TestTracerService.cleanup()`).
- Completes the planned backport stack (PR E of A→E).