### PR TITLE
UNOMI-953: Backport packaging bundle (Phase 2 PR 2)

### DIFF
--- a/distribution/src/main/feature/feature.xml
+++ b/distribution/src/main/feature/feature.xml
@@ -29,16 +29,17 @@
         <feature dependency="true" version="${project.version}">unomi-elasticsearch-core</feature>
         <feature dependency="true" version="${project.version}">unomi-persistence-core</feature>
         <feature dependency="true" version="${project.version}">unomi-services</feature>
-        <feature dependency="true" version="${project.version}">unomi-rest-api</feature>
-        <feature dependency="true" version="${project.version}">unomi-cxs-lists-extension</feature>
-        <feature dependency="true" version="${project.version}">unomi-cxs-geonames-extension</feature>
-        <feature dependency="true" version="${project.version}">unomi-cxs-privacy-extension</feature>
-        <feature dependency="true" version="${project.version}">unomi-elasticsearch-conditions</feature>
-        <feature dependency="true" version="${project.version}">unomi-plugins-advanced-conditions</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-privacy-extension-services</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-base</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-request</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-mail</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-optimization-test</feature>
+        <feature dependency="true" version="${project.version}">unomi-rest-api</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-privacy-extension</feature>
+        <feature dependency="true" version="${project.version}">unomi-elasticsearch-conditions</feature>
+        <feature dependency="true" version="${project.version}">unomi-plugins-advanced-conditions</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-lists-extension</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-geonames-extension</feature>
         <feature dependency="true" version="${project.version}">unomi-shell-dev-commands</feature>
         <feature dependency="true" version="${project.version}">unomi-wab</feature>
         <feature dependency="true" version="${project.version}">unomi-web-tracker</feature>
@@ -55,16 +56,17 @@
         <feature dependency="true" version="${project.version}">unomi-elasticsearch-core</feature>
         <feature dependency="true" version="${project.version}">unomi-persistence-core</feature>
         <feature dependency="true" version="${project.version}">unomi-services</feature>
-        <feature dependency="true" version="${project.version}">unomi-rest-api</feature>
-        <feature dependency="true" version="${project.version}">unomi-cxs-lists-extension</feature>
-        <feature dependency="true" version="${project.version}">unomi-cxs-geonames-extension</feature>
-        <feature dependency="true" version="${project.version}">unomi-cxs-privacy-extension</feature>
-        <feature dependency="true" version="${project.version}">unomi-elasticsearch-conditions</feature>
-        <feature dependency="true" version="${project.version}">unomi-plugins-advanced-conditions</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-privacy-extension-services</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-base</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-request</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-mail</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-optimization-test</feature>
+        <feature dependency="true" version="${project.version}">unomi-rest-api</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-privacy-extension</feature>
+        <feature dependency="true" version="${project.version}">unomi-elasticsearch-conditions</feature>
+        <feature dependency="true" version="${project.version}">unomi-plugins-advanced-conditions</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-lists-extension</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-geonames-extension</feature>
         <feature dependency="true" version="${project.version}">unomi-shell-dev-commands</feature>
         <feature dependency="true" version="${project.version}">unomi-wab</feature>
         <feature dependency="true" version="${project.version}">unomi-web-tracker</feature>
@@ -82,16 +84,17 @@
         <feature dependency="true" version="${project.version}">unomi-opensearch-core</feature>
         <feature dependency="true" version="${project.version}">unomi-persistence-core</feature>
         <feature dependency="true" version="${project.version}">unomi-services</feature>
-        <feature dependency="true" version="${project.version}">unomi-rest-api</feature>
-        <feature dependency="true" version="${project.version}">unomi-cxs-lists-extension</feature>
-        <feature dependency="true" version="${project.version}">unomi-cxs-geonames-extension</feature>
-        <feature dependency="true" version="${project.version}">unomi-cxs-privacy-extension</feature>
-        <feature dependency="true" version="${project.version}">unomi-opensearch-conditions</feature>
-        <feature dependency="true" version="${project.version}">unomi-plugins-advanced-conditions</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-privacy-extension-services</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-base</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-request</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-mail</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-optimization-test</feature>
+        <feature dependency="true" version="${project.version}">unomi-rest-api</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-privacy-extension</feature>
+        <feature dependency="true" version="${project.version}">unomi-opensearch-conditions</feature>
+        <feature dependency="true" version="${project.version}">unomi-plugins-advanced-conditions</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-lists-extension</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-geonames-extension</feature>
         <feature dependency="true" version="${project.version}">unomi-shell-dev-commands</feature>
         <feature dependency="true" version="${project.version}">unomi-wab</feature>
         <feature dependency="true" version="${project.version}">unomi-web-tracker</feature>
@@ -108,16 +111,17 @@
         <feature dependency="true" version="${project.version}">unomi-opensearch-core</feature>
         <feature dependency="true" version="${project.version}">unomi-persistence-core</feature>
         <feature dependency="true" version="${project.version}">unomi-services</feature>
-        <feature dependency="true" version="${project.version}">unomi-rest-api</feature>
-        <feature dependency="true" version="${project.version}">unomi-cxs-lists-extension</feature>
-        <feature dependency="true" version="${project.version}">unomi-cxs-geonames-extension</feature>
-        <feature dependency="true" version="${project.version}">unomi-cxs-privacy-extension</feature>
-        <feature dependency="true" version="${project.version}">unomi-opensearch-conditions</feature>
-        <feature dependency="true" version="${project.version}">unomi-plugins-advanced-conditions</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-privacy-extension-services</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-base</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-request</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-mail</feature>
         <feature dependency="true" version="${project.version}">unomi-plugins-optimization-test</feature>
+        <feature dependency="true" version="${project.version}">unomi-rest-api</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-privacy-extension</feature>
+        <feature dependency="true" version="${project.version}">unomi-opensearch-conditions</feature>
+        <feature dependency="true" version="${project.version}">unomi-plugins-advanced-conditions</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-lists-extension</feature>
+        <feature dependency="true" version="${project.version}">unomi-cxs-geonames-extension</feature>
         <feature dependency="true" version="${project.version}">unomi-shell-dev-commands</feature>
         <feature dependency="true" version="${project.version}">unomi-wab</feature>
         <feature dependency="true" version="${project.version}">unomi-web-tracker</feature>

--- a/extensions/groovy-actions/services/src/main/java/org/apache/unomi/groovy/actions/ScriptMetadata.java
+++ b/extensions/groovy-actions/services/src/main/java/org/apache/unomi/groovy/actions/ScriptMetadata.java
@@ -17,7 +17,6 @@
 package org.apache.unomi.groovy.actions;
 
 import groovy.lang.Script;
-
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.nio.charset.StandardCharsets;
@@ -29,9 +28,12 @@ import java.util.Base64;
  * This class encapsulates all metadata associated with a compiled Groovy script,
  * including content hash for efficient change detection and the compiled class
  * for direct execution without recompilation.
+ * </p>
+ *
  * <p>
  * Thread Safety: This class is immutable and thread-safe. All fields are final
  * and the class provides no methods to modify its state after construction.
+ * </p>
  *
  * @since 2.7.0
  */
@@ -90,6 +92,7 @@ public final class ScriptMetadata {
      * <p>
      * This method uses SHA-256 hash comparison for efficient change detection
      * without storing or comparing the full script content.
+     * </p>
      *
      * @param newContent the new script content to compare against
      * @return {@code true} if content has changed, {@code false} if unchanged
@@ -143,6 +146,7 @@ public final class ScriptMetadata {
      * <p>
      * This class can be used to create new script instances for execution
      * without requiring recompilation.
+     * </p>
      *
      * @return the compiled script class, never null
      */

--- a/extensions/groovy-actions/services/src/main/java/org/apache/unomi/groovy/actions/services/GroovyActionsService.java
+++ b/extensions/groovy-actions/services/src/main/java/org/apache/unomi/groovy/actions/services/GroovyActionsService.java
@@ -31,13 +31,13 @@ import org.apache.unomi.groovy.actions.ScriptMetadata;
  *
  * <p>
  * Key features:
+ * </p>
  * <ul>
  *   <li>Pre-compilation of scripts at startup</li>
  *   <li>Hash-based change detection for selective recompilation</li>
  *   <li>Thread-safe compilation and execution</li>
  *   <li>Unified caching architecture for compiled scripts</li>
  * </ul>
- * </p>
  *
  * <p>
  * Thread Safety: Implementations must be thread-safe as this service

--- a/extensions/groovy-actions/services/src/main/java/org/apache/unomi/groovy/actions/services/GroovyActionsService.java
+++ b/extensions/groovy-actions/services/src/main/java/org/apache/unomi/groovy/actions/services/GroovyActionsService.java
@@ -27,6 +27,8 @@ import org.apache.unomi.groovy.actions.ScriptMetadata;
  * This service provides functionality to load, compile, cache, and execute
  * Groovy scripts as actions within the Apache Unomi framework. It implements
  * optimized compilation and caching strategies to achieve high performance.
+ * </p>
+ *
  * <p>
  * Key features:
  * <ul>
@@ -35,9 +37,13 @@ import org.apache.unomi.groovy.actions.ScriptMetadata;
  *   <li>Thread-safe compilation and execution</li>
  *   <li>Unified caching architecture for compiled scripts</li>
  * </ul>
+ * </p>
+ *
  * <p>
  * Thread Safety: Implementations must be thread-safe as this service
  * is accessed concurrently during script execution.
+ * </p>
+ *
  * @see GroovyAction
  * @see ScriptMetadata
  * @since 2.7.0
@@ -50,6 +56,8 @@ public interface GroovyActionsService {
      * This method compiles the script, validates it has the required
      * annotations, persists it, and updates the internal cache.
      * If the script content hasn't changed, recompilation is skipped.
+     * </p>
+     *
      * @param actionName   the unique identifier for the action
      * @param groovyScript the Groovy script source code
      * @throws IllegalArgumentException if actionName or groovyScript is null
@@ -62,6 +70,8 @@ public interface GroovyActionsService {
      * <p>
      * This method removes the action from both the cache and persistent storage,
      * and cleans up any registered action types in the definitions service.
+     * </p>
+     *
      * @param actionName the unique identifier of the action to remove
      * @throws IllegalArgumentException if id is null
      */
@@ -73,6 +83,8 @@ public interface GroovyActionsService {
      * This is the preferred method for script execution as it returns
      * pre-compiled classes without any compilation overhead. Returns
      * {@code null} if the script is not found in the cache.
+     * </p>
+     *
      * @param actionName the unique identifier of the action
      * @return the compiled script class, or {@code null} if not found in cache
      * @throws IllegalArgumentException if id is null
@@ -85,6 +97,8 @@ public interface GroovyActionsService {
      * The returned metadata includes content hash, compilation timestamp,
      * and the compiled class reference. This is useful for monitoring
      * tools and debugging.
+     * </p>
+     *
      * @param actionName the unique identifier of the action
      * @return the script metadata, or {@code null} if not found
      * @throws IllegalArgumentException if actionName is null

--- a/extensions/lists-extension/services/src/main/java/org/apache/unomi/services/UserListServiceImpl.java
+++ b/extensions/lists-extension/services/src/main/java/org/apache/unomi/services/UserListServiceImpl.java
@@ -59,7 +59,9 @@ public class UserListServiceImpl implements UserListService {
         if (query.isForceRefresh()) {
             persistenceService.refreshIndex(UserList.class);
         }
-        definitionsService.resolveConditionType(query.getCondition());
+        if (query.getCondition() != null) {
+            definitionsService.getConditionValidationService().validate(query.getCondition());
+        }
         PartialList<UserList> userLists = persistenceService.query(query.getCondition(), query.getSortby(), UserList.class, query.getOffset(), query.getLimit());
         List<Metadata> metadata = new LinkedList<>();
         for (UserList definition : userLists.getList()) {


### PR DESCRIPTION
## Summary
- Reorder `distribution/src/main/feature/feature.xml` so `unomi-cxs-privacy-extension-services` and plugin features install before REST, privacy, conditions, lists, and geonames (matches `unomi-3-dev` / `kar/` dependency graph).
- Preserve master’s `#774` `unomi-plugins-advanced-conditions` wiring in all four distribution features.
- Port extension micro-deltas from `unomi-3-dev`: null-safe condition validation in `UserListServiceImpl`, and Javadoc `</p>` fixes in `ScriptMetadata` / `GroovyActionsService` (UNOMI-897).
- Intentionally skipped: `GroovyActionDispatcher` (master #775 tracing wins), `GroovyActionsServiceImplTest` (master #776), `geonameEntry.json` (newline-only diff).

## Test plan
- [ ] `mvn -pl extensions/lists-extension/services compile`
- [ ] `mvn -pl distribution -am package -DskipTests`
- [ ] Karaf boot smoke: verify distribution features resolve and privacy/REST bundles start in correct order
- [ ] List metadata query with and without a condition filter