### PR TITLE
UNOMI-945: Apply sanitized condition parameters and add list IT

### DIFF
--- a/itests/src/test/java/org/apache/unomi/itests/ContextServletIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/ContextServletIT.java
@@ -492,6 +492,26 @@ public class ContextServletIT extends BaseIT {
     }
 
     @Test
+    public void testMVELVulnerabilityWithListPropertyValues() throws Exception {
+        File vulnFile = new File("target/vuln-file-list.txt");
+        if (vulnFile.exists()) {
+            vulnFile.delete();
+        }
+        String vulnFileCanonicalPath = vulnFile.getCanonicalPath();
+        vulnFileCanonicalPath = vulnFileCanonicalPath.replace("\\", "\\\\"); // this is required for Windows support
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("VULN_FILE_PATH", vulnFileCanonicalPath);
+        HttpPost request = new HttpPost(getFullUrl(CONTEXT_URL));
+        request.setEntity(
+                new StringEntity(getValidatedBundleJSON("security/mvel-payload-list.json", parameters), ContentType.APPLICATION_JSON));
+        TestUtils.executeContextJSONRequest(request);
+
+        shouldBeTrueUntilEnd("Vulnerability successfully executed ! File created at " + vulnFileCanonicalPath, vulnFile::exists,
+                exists -> exists == Boolean.FALSE, DEFAULT_TRYING_TIMEOUT, DEFAULT_TRYING_TRIES);
+    }
+
+    @Test
     public void testPersonalization() throws Exception {
 
         Map<String, String> parameters = new HashMap<>();

--- a/itests/src/test/resources/security/mvel-payload-list.json
+++ b/itests/src/test/resources/security/mvel-payload-list.json
@@ -1,0 +1,23 @@
+{
+  "filters": [
+    {
+      "id": "filter1",
+      "filters": [
+        {
+          "condition": {
+            "parameterValues": {
+              "propertyName": "firstName",
+              "comparisonOperator": "equals",
+              "propertyValues": [
+                "safe-value",
+                "script::Runtime r = Runtime.getRuntime(); r.exec(\"touch ###VULN_FILE_PATH###\");"
+              ]
+            },
+            "type": "profilePropertyCondition"
+          }
+        }
+      ]
+    }
+  ],
+  "sessionId": "demo-session-id"
+}

--- a/rest/src/main/java/org/apache/unomi/rest/endpoints/ContextJsonEndpoint.java
+++ b/rest/src/main/java/org/apache/unomi/rest/endpoints/ContextJsonEndpoint.java
@@ -331,11 +331,12 @@ public class ContextJsonEndpoint {
         for (Map.Entry<String, Object> parameterEntry : condition.getParameterValues().entrySet()) {
             Object sanitizedValue = sanitizeValue(parameterEntry.getValue());
             if (sanitizedValue != null) {
-                newParameterValues.put(parameterEntry.getKey(), parameterEntry.getValue());
+                newParameterValues.put(parameterEntry.getKey(), sanitizedValue);
             } else {
                 return null;
             }
         }
+        condition.setParameterValues(newParameterValues);
         return condition;
     }
 


### PR DESCRIPTION
## Summary

- Fix `ContextJsonEndpoint.sanitizeCondition()` so filtered parameter values are stored and applied via `setParameterValues()` (complements the list sanitization fix already in #778).
- Add integration test for list-based `propertyValues` payloads mixing safe values with `script::` entries.

Complements master [#789](https://github.com/apache/unomi/pull/789) — fix + IT only; no REST unit tests (3.0.x has no `rest/src/test` harness).

## Commits

1. `b13429c2f` — production fix (`sanitizeCondition`)
2. `d445ad6d7` — IT (`mvel-payload-list.json`, `testMVELVulnerabilityWithListPropertyValues`)

## Test plan

- [x] `mvn -pl rest -am compile -DskipTests`
- [ ] CI integration tests (`ContextServletIT#testMVELVulnerabilityWithListPropertyValues`)