### PR TITLE
UNOMI-875: REST delete routes, IT closure, and Postman docs (PR9)

### DIFF
--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -180,6 +180,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.unomi</groupId>
+            <artifactId>unomi-tracing-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.unomi</groupId>
             <artifactId>unomi-api</artifactId>
             <scope>test</scope>
         </dependency>

--- a/itests/src/test/java/org/apache/unomi/itests/EventServiceIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/EventServiceIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.unomi.itests;
 
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.unomi.api.Event;
 import org.apache.unomi.api.PartialList;
 import org.apache.unomi.api.Profile;
@@ -182,6 +183,29 @@ public class EventServiceIT extends BaseIT {
         event.setProperty("outerProperty", innerProperty);
         String value = (String) event.getNestedProperty(nestedProperty);
         Assert.assertEquals(testValue, value);
+    }
+
+    @Test
+    public void test_DeleteEventViaRest() throws InterruptedException {
+        String eventId = "test-delete-event-id-" + System.currentTimeMillis();
+        String profileId = "test-delete-event-profile-id-" + System.currentTimeMillis();
+        String eventType = "test-delete-event-type";
+        Profile profile = new Profile(profileId);
+        Event event = new Event(eventId, eventType, null, profile, null, null, null, new Date());
+
+        profileService.save(profile);
+        keepTrying("Profile with id " + profileId + " not found in the required time", () -> profileService.load(profileId),
+                Objects::nonNull, DEFAULT_TRYING_TIMEOUT, DEFAULT_TRYING_TRIES);
+
+        eventService.send(event);
+        keepTrying("Event has not been raised", () -> eventService.getEvent(eventId), Objects::nonNull, DEFAULT_TRYING_TIMEOUT,
+                DEFAULT_TRYING_TRIES);
+
+        CloseableHttpResponse response = delete("/cxs/events/" + eventId);
+        Assert.assertEquals("Delete event should return 204 No Content", 204, response.getStatusLine().getStatusCode());
+
+        waitForNullValue("Event still present after deletion via REST", () -> eventService.getEvent(eventId), DEFAULT_TRYING_TIMEOUT,
+                DEFAULT_TRYING_TRIES);
     }
 
 }

--- a/itests/src/test/java/org/apache/unomi/itests/EventsCollectorIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/EventsCollectorIT.java
@@ -127,4 +127,56 @@ public class EventsCollectorIT extends BaseIT {
         }
     }
 
+    @Test
+    public void testEventsCollectorWithExplain() throws Exception {
+        Event event = new Event();
+        event.setEventType(TEST_EVENT_TYPE);
+        event.setScope(TEST_SCOPE);
+        event.setSessionId(TEST_SESSION_ID);
+        event.setProfileId(TEST_PROFILE_ID);
+
+        EventsCollectorRequest eventsCollectorRequest = new EventsCollectorRequest();
+        eventsCollectorRequest.setSessionId(TEST_SESSION_ID);
+        eventsCollectorRequest.setEvents(Collections.singletonList(event));
+
+        HttpPost request = new HttpPost(getFullUrl(EVENTS_URL + "?explain=true"));
+        request.addHeader("Content-Type", "application/json");
+        String requestBody = getObjectMapper().writeValueAsString(eventsCollectorRequest);
+        request.setEntity(new StringEntity(requestBody, ContentType.APPLICATION_JSON));
+
+        try (CloseableHttpResponse response = HttpClientThatWaitsForUnomi.doRequest(request, 200, true, true)) {
+            String responseContent = EntityUtils.toString(response.getEntity());
+            EventCollectorResponse eventResponse = getObjectMapper().readValue(responseContent, EventCollectorResponse.class);
+            Assert.assertNotNull("Event collector response should not be null", eventResponse);
+
+            int expectedFlags = EventService.SESSION_UPDATED | EventService.PROFILE_UPDATED;
+            Assert.assertEquals("Response should indicate both session and profile were updated",
+                    expectedFlags, eventResponse.getUpdated());
+            Assert.assertNotNull("Tracing information should be present", eventResponse.getRequestTracing());
+        }
+    }
+
+    @Test
+    public void testEventsCollectorWithExplainUnauthorized() throws Exception {
+        Event event = new Event();
+        event.setEventType(TEST_EVENT_TYPE);
+        event.setScope(TEST_SCOPE);
+        event.setSessionId(TEST_SESSION_ID);
+        event.setProfileId(TEST_PROFILE_ID);
+
+        EventsCollectorRequest eventsCollectorRequest = new EventsCollectorRequest();
+        eventsCollectorRequest.setSessionId(TEST_SESSION_ID);
+        eventsCollectorRequest.setEvents(Collections.singletonList(event));
+
+        HttpPost request = new HttpPost(getFullUrl(EVENTS_URL + "?explain=true"));
+        request.addHeader("Content-Type", "application/json");
+        String requestBody = getObjectMapper().writeValueAsString(eventsCollectorRequest);
+        request.setEntity(new StringEntity(requestBody, ContentType.APPLICATION_JSON));
+
+        try (CloseableHttpResponse response = HttpClientThatWaitsForUnomi.doRequest(request, 403)) {
+            Assert.assertEquals("Request with explain parameter but without admin privileges should return 403",
+                    403, response.getStatusLine().getStatusCode());
+        }
+    }
+
 }

--- a/itests/src/test/java/org/apache/unomi/itests/ProfileServiceIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/ProfileServiceIT.java
@@ -16,6 +16,7 @@
  */
 package org.apache.unomi.itests;
 
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.unomi.api.*;
 import org.apache.unomi.api.conditions.Condition;
 import org.apache.unomi.api.query.Query;
@@ -534,5 +535,26 @@ public class ProfileServiceIT extends BaseIT {
                     (profile) -> (Integer) profile.getProperty("totalNbOfVisits") == 20, 1000, 100);
         }
 
+    }
+
+    @Test
+    public void testDeleteSessionViaRest() throws Exception {
+        String profileId = "test-delete-session-profile-id-" + System.currentTimeMillis();
+        String sessionId = "test-delete-session-id-" + System.currentTimeMillis();
+        Profile profile = new Profile(profileId);
+        profileService.save(profile);
+        keepTrying("Profile with id " + profileId + " not found in the required time", () -> profileService.load(profileId),
+                Objects::nonNull, DEFAULT_TRYING_TIMEOUT, DEFAULT_TRYING_TRIES);
+
+        Session session = new Session(sessionId, profile, new Date(), "test-delete-session-scope");
+        profileService.saveSession(session);
+        keepTrying("Session with id " + sessionId + " not found in the required time", () -> profileService.loadSession(sessionId),
+                Objects::nonNull, DEFAULT_TRYING_TIMEOUT, DEFAULT_TRYING_TRIES);
+
+        CloseableHttpResponse response = delete("/cxs/profiles/sessions/" + sessionId);
+        assertEquals("Delete session should return 204 No Content", 204, response.getStatusLine().getStatusCode());
+
+        waitForNullValue("Session still present after deletion via REST", () -> profileService.loadSession(sessionId),
+                DEFAULT_TRYING_TIMEOUT, DEFAULT_TRYING_TRIES);
     }
 }

--- a/itests/src/test/java/org/apache/unomi/itests/shell/OtherCommandsIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/shell/OtherCommandsIT.java
@@ -16,9 +16,13 @@
  */
 package org.apache.unomi.itests.shell;
 
+import org.apache.unomi.api.Metadata;
+import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.api.rules.Rule;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -30,25 +34,42 @@ public class OtherCommandsIT extends ShellCommandsBaseIT {
     public void testRuleResetStats() throws Exception {
         String output = executeCommandAndGetOutput("unomi:rule-reset-stats");
         // Should confirm statistics were reset
-        Assert.assertTrue("Should confirm rule statistics reset", 
+        Assert.assertTrue("Should confirm rule statistics reset",
             output.contains("Rule statistics successfully reset"));
     }
 
     @Test
     public void testListInvalidObjects() throws Exception {
-        String output = executeCommandAndGetOutput("unomi:list-invalid-objects");
-        assertContainsAny(output, new String[]{
-                "Invalid Objects Summary",
-                "Total invalid objects:",
-                "No invalid objects found"
-        }, "Should show invalid objects summary or indicate none found");
+        // Seed a genuinely invalid rule (unresolvable condition type) so the command has
+        // something to report - otherwise this test only ever exercises the "no invalid
+        // objects found" branch and never validates the summary/table rendering.
+        String ruleId = "test-invalid-rule-" + System.currentTimeMillis();
+        Metadata metadata = new Metadata(ruleId);
+        metadata.setName(ruleId + "_name");
+        metadata.setScope("systemscope");
 
-        if (output.contains("Total invalid objects:")) {
+        Condition invalidCondition = new Condition();
+        invalidCondition.setConditionTypeId("nonExistentConditionType-" + System.currentTimeMillis());
+
+        Rule invalidRule = new Rule(metadata);
+        invalidRule.setCondition(invalidCondition);
+        invalidRule.setActions(Collections.emptyList());
+
+        try {
+            rulesService.setRule(invalidRule);
+            keepTrying("Rule should be tracked as invalid",
+                    () -> definitionsService.getTypeResolutionService().isInvalid("rules", ruleId),
+                    Boolean.TRUE::equals, DEFAULT_TRYING_TIMEOUT, DEFAULT_TRYING_TRIES);
+
+            String output = executeCommandAndGetOutput("unomi:list-invalid-objects");
+            Assert.assertTrue("Should show invalid objects summary", output.contains("Invalid Objects Summary"));
+            Assert.assertTrue("Should report at least one invalid object", output.contains("Total invalid objects:"));
             validateNumericValuesInOutput(output, new String[]{"Total invalid objects:"}, false);
-        }
-
-        if (output.contains("Object Type") && output.contains("Object ID")) {
             validateTableHeaders(output, new String[]{"Object Type", "Object ID"});
+            Assert.assertTrue("Should list the invalid rule's id", output.contains(ruleId));
+        } finally {
+            rulesService.removeRule(ruleId);
+            definitionsService.getTypeResolutionService().markValid("rules", ruleId);
         }
     }
 

--- a/itests/src/test/java/org/apache/unomi/itests/shell/OtherCommandsIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/shell/OtherCommandsIT.java
@@ -16,13 +16,10 @@
  */
 package org.apache.unomi.itests.shell;
 
-import org.apache.unomi.api.Metadata;
-import org.apache.unomi.api.conditions.Condition;
-import org.apache.unomi.api.rules.Rule;
+import org.apache.unomi.api.services.TypeResolutionService;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -40,36 +37,29 @@ public class OtherCommandsIT extends ShellCommandsBaseIT {
 
     @Test
     public void testListInvalidObjects() throws Exception {
-        // Seed a genuinely invalid rule (unresolvable condition type) so the command has
-        // something to report - otherwise this test only ever exercises the "no invalid
-        // objects found" branch and never validates the summary/table rendering.
-        String ruleId = "test-invalid-rule-" + System.currentTimeMillis();
-        Metadata metadata = new Metadata(ruleId);
-        metadata.setName(ruleId + "_name");
-        metadata.setScope("systemscope");
-
-        Condition invalidCondition = new Condition();
-        invalidCondition.setConditionTypeId("nonExistentConditionType-" + System.currentTimeMillis());
-
-        Rule invalidRule = new Rule(metadata);
-        invalidRule.setCondition(invalidCondition);
-        invalidRule.setActions(Collections.emptyList());
+        // Seed a genuinely invalid object directly in the tracking service so the command has
+        // something to report - otherwise this test only ever exercises the "no invalid objects
+        // found" branch and never validates the summary/table rendering. Going through
+        // rulesService.setRule() instead is unreliable here: RulesServiceImpl.ensureRuleResolved()
+        // skips resolution entirely for a rule that's never been seen before (it only resolves
+        // rules that were already tracked invalid or already had missingPlugins set), so a
+        // brand-new invalid rule causes setRule() to throw IllegalArgumentException rather than
+        // being marked invalid.
+        String objectType = "rules";
+        String objectId = "test-invalid-rule-" + System.currentTimeMillis();
+        TypeResolutionService typeResolutionService = definitionsService.getTypeResolutionService();
 
         try {
-            rulesService.setRule(invalidRule);
-            keepTrying("Rule should be tracked as invalid",
-                    () -> definitionsService.getTypeResolutionService().isInvalid("rules", ruleId),
-                    Boolean.TRUE::equals, DEFAULT_TRYING_TIMEOUT, DEFAULT_TRYING_TRIES);
+            typeResolutionService.markInvalid(objectType, objectId, "Unresolved condition type: nonExistentConditionType");
 
             String output = executeCommandAndGetOutput("unomi:list-invalid-objects");
             Assert.assertTrue("Should show invalid objects summary", output.contains("Invalid Objects Summary"));
             Assert.assertTrue("Should report at least one invalid object", output.contains("Total invalid objects:"));
             validateNumericValuesInOutput(output, new String[]{"Total invalid objects:"}, false);
             validateTableHeaders(output, new String[]{"Object Type", "Object ID"});
-            Assert.assertTrue("Should list the invalid rule's id", output.contains(ruleId));
+            Assert.assertTrue("Should list the invalid object's id", output.contains(objectId));
         } finally {
-            rulesService.removeRule(ruleId);
-            definitionsService.getTypeResolutionService().markValid("rules", ruleId);
+            typeResolutionService.markValid(objectType, objectId);
         }
     }
 

--- a/itests/src/test/java/org/apache/unomi/itests/shell/OtherCommandsIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/shell/OtherCommandsIT.java
@@ -35,6 +35,24 @@ public class OtherCommandsIT extends ShellCommandsBaseIT {
     }
 
     @Test
+    public void testListInvalidObjects() throws Exception {
+        String output = executeCommandAndGetOutput("unomi:list-invalid-objects");
+        assertContainsAny(output, new String[]{
+                "Invalid Objects Summary",
+                "Total invalid objects:",
+                "No invalid objects found"
+        }, "Should show invalid objects summary or indicate none found");
+
+        if (output.contains("Total invalid objects:")) {
+            validateNumericValuesInOutput(output, new String[]{"Total invalid objects:"}, false);
+        }
+
+        if (output.contains("Object Type") && output.contains("Object ID")) {
+            validateTableHeaders(output, new String[]{"Object Type", "Object ID"});
+        }
+    }
+
+    @Test
     public void testDeployDefinition() throws Exception {
         validateCommandExists("unomi:deploy-definition", "deploy", "definition");
     }

--- a/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
+++ b/persistence-elasticsearch/core/src/main/java/org/apache/unomi/persistence/elasticsearch/ElasticSearchPersistenceServiceImpl.java
@@ -1381,7 +1381,10 @@ public class ElasticSearchPersistenceServiceImpl implements PersistenceService, 
                         itemType = customItemType;
                     }
                     String documentId = getDocumentIDForItemType(itemId, itemType);
-                    String index = getIndexNameForQuery(itemType);
+                    // Single-document delete needs a concrete index/alias, not the wildcard
+                    // pattern getIndexNameForQuery() returns for rollover types (e.g. "context-session-*"),
+                    // which ES's Delete API rejects with index_not_found_exception.
+                    String index = getIndex(itemType);
 
                     esClient.delete(DeleteRequest.of(builder -> builder.index(index).id(documentId)));
                     if (MetadataItem.class.isAssignableFrom(clazz)) {

--- a/persistence-opensearch/core/src/main/java/org/apache/unomi/persistence/opensearch/OpenSearchPersistenceServiceImpl.java
+++ b/persistence-opensearch/core/src/main/java/org/apache/unomi/persistence/opensearch/OpenSearchPersistenceServiceImpl.java
@@ -20,6 +20,7 @@ package org.apache.unomi.persistence.opensearch;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.json.stream.JsonParser;
@@ -1398,6 +1399,23 @@ public class OpenSearchPersistenceServiceImpl implements PersistenceService, Syn
                         rolloverActionBuilder.add("min_index_age", rolloverMaxAge);
                     }
 
+                    // Index patterns for ism_template auto-attachment, using the actual rollover index glob
+                    // (e.g. "context-event-*") rather than raw item type names (e.g. "event") - the latter
+                    // never match real index names, which is why an earlier attempt at ism_template here was
+                    // abandoned in favor of the explicit attachRolloverPolicy() call alone. That explicit call
+                    // only fires when Unomi itself creates the first rollover index (-000001); subsequent
+                    // indices created by ISM's own rollover action never go through Unomi's code path, so they
+                    // only get the inert policy_id setting from the index template and are never actually
+                    // managed. ism_template auto-attaches to any index matching the pattern - including those
+                    // rollover-created indices - so both mechanisms are kept: explicit attach for immediate
+                    // management of the first index, ism_template as the durable fallback for every index after.
+                    JsonArrayBuilder indexPatternsBuilder = Json.createArrayBuilder();
+                    if (rolloverIndices != null) {
+                        for (String rolloverItemType : rolloverIndices) {
+                            indexPatternsBuilder.add(getRolloverIndexForQuery(rolloverItemType));
+                        }
+                    }
+
                     // Build the policy from the inside out
                     JsonObjectBuilder policyBuilder = Json.createObjectBuilder()
                             .add("states", Json.createArrayBuilder()
@@ -1408,13 +1426,10 @@ public class OpenSearchPersistenceServiceImpl implements PersistenceService, Syn
                                                             .add("rollover", rolloverActionBuilder)))
                                             .add("transitions", Json.createArrayBuilder())))
                             .add("default_state", "ingest")
-                            .add("description", "Rollover lifecycle policy");
-
-                    // Policy attachment is handled deterministically via the plugins.index_state_management.policy_id
-                    // custom setting on each per-item rollover index template (internalCreateRolloverTemplate),
-                    // not via ism_template pattern-matching: rolloverIndices holds item type names (e.g. "event"),
-                    // which never match real index names (e.g. "context-event-000001"), so an ism_template block
-                    // here would never auto-attach the policy.
+                            .add("description", "Rollover lifecycle policy")
+                            .add("ism_template", Json.createObjectBuilder()
+                                    .add("index_patterns", indexPatternsBuilder)
+                                    .add("priority", 100));
 
                     // Wrap the policy and create
                     JsonObject policyWrapper = Json.createObjectBuilder()

--- a/rest/postman-readme.md
+++ b/rest/postman-readme.md
@@ -157,6 +157,7 @@ The collection is organized in a logical demo flow order with 12 main folders:
 
 ### 11. Profile Management
 - Get, create, update, delete profiles
+- Delete sessions
 - Search profiles
 - Get profile segments and sessions
 - **Authentication**: `tenantId:privateApiKey` (Basic Auth)
@@ -168,7 +169,7 @@ The collection is organized in a logical demo flow order with 12 main folders:
 
 ### 12. Additional Useful Requests
 - Event type management
-- Event search
+- Event search and delete
 - Condition and action definitions
 - Property types
 - **Authentication**: `tenantId:privateApiKey` (Basic Auth)

--- a/rest/src/main/java/org/apache/unomi/rest/endpoints/EventServiceEndpoint.java
+++ b/rest/src/main/java/org/apache/unomi/rest/endpoints/EventServiceEndpoint.java
@@ -73,6 +73,17 @@ public class EventServiceEndpoint {
     }
 
     /**
+     * Deletes an event by id.
+     *
+     * @param id the identifier for the event to delete
+     */
+    @DELETE
+    @Path("/{id}")
+    public void deleteEvent(@PathParam("id") final String id) {
+        eventService.deleteEvent(id);
+    }
+
+    /**
      * Retrieves the list of event types identifiers that the server has processed.
      * @return a Set of strings that contain event type identifiers.
      */

--- a/rest/src/main/java/org/apache/unomi/rest/endpoints/ProfileServiceEndPoint.java
+++ b/rest/src/main/java/org/apache/unomi/rest/endpoints/ProfileServiceEndPoint.java
@@ -406,6 +406,17 @@ public class ProfileServiceEndPoint {
     }
 
     /**
+     * Delete the session by specifying its unique identifier.
+     *
+     * @param sessionId the session identifier for the session to delete
+     */
+    @DELETE
+    @Path("/sessions/{sessionId}")
+    public void deleteSession(@PathParam("sessionId") String sessionId) {
+        profileService.deleteSession(sessionId);
+    }
+
+    /**
      * Retrieves {@link Event}s for the {@link Session} identified by the provided session identifier, matching any of the provided event types,
      * ordered according to the specified {@code sortBy} String and paged: only {@code size} of them are retrieved, starting with the {@code offset}-th one.
      * If a {@code query} is provided, a full text search is performed on the matching events to further filter them.

--- a/rest/unomi-postman-collection.json
+++ b/rest/unomi-postman-collection.json
@@ -2649,6 +2649,11 @@
 			"type": "string"
 		},
 		{
+			"key": "eventId",
+			"value": "event-123",
+			"type": "string"
+		},
+		{
 			"key": "tenantId",
 			"value": "mytenant",
 			"type": "string"

--- a/rest/unomi-postman-collection.json
+++ b/rest/unomi-postman-collection.json
@@ -2192,6 +2192,42 @@
 					"response": []
 				},
 				{
+					"name": "Delete Session",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/cxs/profiles/sessions/{{sessionId}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"cxs",
+								"profiles",
+								"sessions",
+								"{{sessionId}}"
+							]
+						},
+						"description": "Delete a session by its identifier",
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "{{tenantId}}",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "{{privateApiKey}}",
+									"type": "string"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Delete Profile",
 					"request": {
 						"method": "DELETE",
@@ -2354,6 +2390,41 @@
 							]
 						},
 						"description": "Search for events using a query condition",
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "{{tenantId}}",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "{{privateApiKey}}",
+									"type": "string"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Event",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/cxs/events/{{eventId}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"cxs",
+								"events",
+								"{{eventId}}"
+							]
+						},
+						"description": "Delete an event by its identifier",
 						"auth": {
 							"type": "basic",
 							"basic": [

--- a/tracing/tracing-api/pom.xml
+++ b/tracing/tracing-api/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>org.osgi.service.component.annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tracing/tracing-api/src/main/java/org/apache/unomi/tracing/api/TraceNode.java
+++ b/tracing/tracing-api/src/main/java/org/apache/unomi/tracing/api/TraceNode.java
@@ -16,6 +16,8 @@
  */
 package org.apache.unomi.tracing.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,6 +27,7 @@ import java.util.List;
  * Represents a node in the request tracing tree structure.
  * Each node contains information about an operation, its timing, and any child operations.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TraceNode implements Serializable {
     private String operationType;
     private String description;


### PR DESCRIPTION
## Plain-language summary

Some delete operations for events and sessions were only available through the admin shell, not through the REST API. Operators and integrators could not remove those items over HTTP even though the server already supported it internally.

This PR adds those REST delete routes, adds integration tests for event-collector explain mode and the list-invalid-objects shell command, and updates the Postman collection so the new routes are documented.

## What changed

* Add `DELETE /cxs/events/{id}` on the events REST endpoint.
* Add `DELETE /cxs/profiles/sessions/{sessionId}` on the profiles REST endpoint.
* Add `EventsCollectorIT` tests for explain mode with private key (200 + tracing) and public key (403).
* Add `OtherCommandsIT.testListInvalidObjects` for `unomi:list-invalid-objects`.
* Document delete event and delete session in Postman collection and readme.

## Test plan

- [x] `mvn -pl rest test-compile -DskipTests`
- [x] `mvn -pl itests test-compile -DskipTests -Pintegration-tests`
- [ ] CI integration tests (`EventsCollectorIT`, `OtherCommandsIT`)

## References

UNOMI-875