### PR TITLE
UNOMI-875: Document unomi-3-dev branch archive in agent guides

### DIFF
--- a/.cursor/rules/unomi-3-dev-backport.mdc
+++ b/.cursor/rules/unomi-3-dev-backport.mdc
@@ -5,18 +5,23 @@ alwaysApply: true
 
 # unomi-3-dev → master (UNOMI-875)
 
-**Status:** Backport phase **complete** (Phase 2 + [#791](https://github.com/apache/unomi/pull/791)). **Active tracker:** `.local-notes/unomi-3.1-remaining-work-plan.md`.
+**Status:** Backport phase **complete** (Phase 2 + [#791](https://github.com/apache/unomi/pull/791) + [#819](https://github.com/apache/unomi/pull/819) 3-dev closure, July 2026). **Active tracker:** `.local-notes/unomi-3.1-remaining-work-plan.md`.
+
+**Branch archive (2026-07-11):** Remote `unomi-3-dev` **deleted**. Tip preserved as tag `unomi-3-dev-archive-2026-07` (`eca005fd8`). Do **not** expect `origin/unomi-3-dev` to exist.
 
 **Historical plans:** `.local-notes/archive/unomi-3-dev-backport-plan-phase2.md` (§1 exclusion register, §2 playbook).
 
 **Generic workflow first:** `.cursor/rules/branch-backport.mdc` (history audit, diff audit, ADD/MODIFY/MERGE).
 
-For any future cherry-pick from `unomi-3-dev`, set:
+For any future cherry-pick from the archived 3-dev line, use the tag — not a branch:
 
 ```bash
-SOURCE=unomi-3-dev
+SOURCE=unomi-3-dev-archive-2026-07   # tag, not branch
 TARGET=master
+git fetch origin tag unomi-3-dev-archive-2026-07
 ```
+
+In generic backport commands, substitute the tag ref wherever `origin/$SOURCE` appeared (e.g. `git diff origin/master unomi-3-dev-archive-2026-07 -- <path>`).
 
 ## Unomi-specific never
 
@@ -24,18 +29,19 @@ TARGET=master
 - **Never** port items in archived plan §1 exclusion register: REST exception mappers (implement on master patterns), migration scripts (UNOMI-943), security WIP, wholesale 3-dev test harness.
 - **Never** wholesale-checkout `.github/workflows` (master ahead: #780, #957), `AGENTS.md` (#769), migration groovy, `.asf.yaml` rulesets.
 - **Never** blind-checkout `extensions/router/**` — master ahead (#756, #779, #780).
+- **Never** recreate or push a `unomi-3-dev` branch — use the archive tag for historical diffs only.
 
 ## Unomi-specific always
 
-- Check merged master PRs (#755–#791, etc.) before assuming master lacks a 3-dev feature.
+- Check merged master PRs (#755–#819, etc.) before assuming master lacks a 3-dev feature.
 - **MERGE surgically:** `build.sh`, root `pom.xml`, CI — keep master non-interactive CI, Javadoc, IT memory sampler (#780, #957).
 - **Docker compose:** additive only; align image pins with Track E in the remaining-work plan.
 
 ## Shell CRUD — learned 2026-06-10
 
-Shell polish from 3-dev is **mostly already on master** (#755, #763). Before any shell port:
+Shell polish from 3-dev is **on master** (#755, #763). Before any shell port from the archive tag:
 
-`git log origin/unomi-3-dev..origin/master -- tools/shell-dev-commands/`
+`git log unomi-3-dev-archive-2026-07..origin/master -- tools/shell-dev-commands/`
 
 ## Validation before PR (Unomi)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,15 +51,22 @@ Cursor rule: `.cursor/rules/branch-backport.mdc`
 
 ## Backporting `unomi-3-dev` → `master` (UNOMI-875)
 
-**Backport phase complete** (Phase 2 mega-PRs + [#791](https://github.com/apache/unomi/pull/791) final hygiene). **Apply generic rules above** for any future cherry-picks; see
+**Backport phase complete** (Phase 2 mega-PRs + [#791](https://github.com/apache/unomi/pull/791) final hygiene + [#819](https://github.com/apache/unomi/pull/819) 3-dev closure, July 2026). **Apply generic rules above** for any future cherry-picks; see
 `.cursor/rules/unomi-3-dev-backport.mdc` for standing exclusions.
 
 | | |
 |---|---|
-| Source | `unomi-3-dev` (archive/reference only) |
+| Source (archived) | Tag `unomi-3-dev-archive-2026-07` @ `eca005fd8` — remote branch **deleted** |
 | Target | `master` |
 | **Active local plan** | `.local-notes/unomi-3.1-remaining-work-plan.md` |
 | Archived backport plans | `.local-notes/archive/` (Phase 1, Phase 2, #757 stack tracker) |
+
+To inspect the archived tip:
+
+```bash
+git fetch origin tag unomi-3-dev-archive-2026-07
+git diff master...unomi-3-dev-archive-2026-07 -- <path>
+```
 
 Unomi-specific reminders:
 
@@ -68,3 +75,4 @@ Unomi-specific reminders:
 - Safe wholesale adds: new scripts, Postman, docs, new Java classes.
 - Do not port: migration scripts (UNOMI-943), 3-dev REST mappers, security
   WIP, wholesale test harness from 3-dev.
+- Remaining 3.1 work: [UNOMI-960](https://issues.apache.org/jira/browse/UNOMI-960) (Javadoc / PR10) — not a 3-dev backport.


### PR DESCRIPTION
## Plain-language summary

The old `unomi-3-dev` integration branch is gone. Its last state is saved as a git tag. Agent and contributor docs still described the branch as an active reference, which could mislead people or tools looking for a branch that no longer exists.

This PR updates the agent guide and backport cursor rule so they point at the archive tag and state that the backport phase finished with PR9.

## What changed

* Update `AGENTS.md` with archive tag `unomi-3-dev-archive-2026-07`, deleted branch note, and diff example.
* Update `.cursor/rules/unomi-3-dev-backport.mdc` with the same archive facts, tag-based `SOURCE`, and a rule not to recreate the branch.
* Note that remaining 3.1 work is UNOMI-960 (Javadoc), not a 3-dev backport.

## Test plan

- [x] Docs-only change (no code or build impact)
- [x] No functional tests required for markdown and cursor rule updates

## References

UNOMI-875