### PR TITLE
update copyright in notice file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Unomi
-Copyright 2015-2025 The Apache Software Foundation
+Copyright 2015-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE.template
+++ b/NOTICE.template
@@ -1,5 +1,5 @@
 Apache Unomi
-Copyright 2015-2025 The Apache Software Foundation
+Copyright 2015-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/package/src/main/resources/NOTICE
+++ b/package/src/main/resources/NOTICE
@@ -1,5 +1,5 @@
 Apache Unomi
-Copyright 2015-2025 The Apache Software Foundation
+Copyright 2015-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
This pull request updates copyright years in several `NOTICE` files to reflect the extension from 2025 to 2026.

Updates to copyright statements:

* Updated the copyright year range to 2015-2026 in `NOTICE`, `NOTICE.template`, and `package/src/main/resources/NOTICE` to keep legal information current. [[1]](diffhunk://#diff-dfb14fbb9e7d095209ec4cfd621069437bf9c442ff9de9d4ce889781bd0fefcfL2-R2) [[2]](diffhunk://#diff-bd9269d40a8599dbc10c21b8a854bf0d6dc40114d0e7eac86accdc6ac0729362L2-R2) [[3]](diffhunk://#diff-105b503d44acff552e5302128df750524ca6fb71d9b1571855264a35ee3a0733L2-R2)