### PR TITLE
UNOMI-966: Upgrade remaining setup-java actions to v5 and speed up CI workflows

### DIFF
--- a/.github/workflows/codeql-analysis-java.yml
+++ b/.github/workflows/codeql-analysis-java.yml
@@ -44,8 +44,9 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v5
       with:
+        distribution: temurin
         java-version: 17
     - run: mvn -U -ntp -e clean install -DskipTests
 

--- a/.github/workflows/codeql-analysis-java.yml
+++ b/.github/workflows/codeql-analysis-java.yml
@@ -24,6 +24,11 @@ on:
 env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+# Cancel superseded runs on the same PR, but never cancel master/scheduled runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze
@@ -46,9 +51,16 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v5
       with:
-        distribution: temurin
-        java-version: 17
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'maven'
     - run: mvn -U -ntp -e clean install -DskipTests
+
+    # Keep only third-party dependencies in the post-job Maven cache: Unomi's own
+    # snapshots are rebuilt every run and would only bloat the cache / risk staleness
+    - name: Clean Unomi artifacts from Maven cache
+      if: always()
+      run: rm -rf ~/.m2/repository/org/apache/unomi
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis-javascript.yml
+++ b/.github/workflows/codeql-analysis-javascript.yml
@@ -21,6 +21,11 @@ on:
   schedule:
     - cron: '38 1 * * 0'
 
+# Cancel superseded runs on the same PR, but never cancel master/scheduled runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/unomi-ci-build-tests.yml
+++ b/.github/workflows/unomi-ci-build-tests.yml
@@ -12,6 +12,11 @@ on:
 env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+# Cancel superseded runs on the same PR, but never cancel master runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   unit-tests:
     name: Execute unit tests
@@ -32,6 +37,11 @@ jobs:
         dot -V
     - name: Build and Unit tests
       run: ./build.sh --ci
+    # Keep only third-party dependencies in the post-job Maven cache: Unomi's own
+    # snapshots are rebuilt every run and would only bloat the cache / risk staleness
+    - name: Clean Unomi artifacts from Maven cache
+      if: always()
+      run: rm -rf ~/.m2/repository/org/apache/unomi
 
   integration-tests:
     name: Execute integration tests
@@ -70,6 +80,11 @@ jobs:
           else
             ./build.sh --ci --integration-tests
           fi
+      # Keep only third-party dependencies in the post-job Maven cache: Unomi's own
+      # snapshots are rebuilt every run and would only bloat the cache / risk staleness
+      - name: Clean Unomi artifacts from Maven cache
+        if: always()
+        run: rm -rf ~/.m2/repository/org/apache/unomi
       - name: Archive IT memory metrics
         uses: actions/upload-artifact@v6
         if: always()

--- a/.github/workflows/unomi-ci-docs-deploy.yml
+++ b/.github/workflows/unomi-ci-docs-deploy.yml
@@ -10,6 +10,11 @@ on:
 env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+# Serialize deploys from consecutive master pushes; never cancel a publish mid-run
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   publish-docs-and-snapshots:
     name: Publish Javadoc and snapshots
@@ -19,8 +24,9 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          distribution: temurin
-          java-version: 17
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
           server-id: apache.snapshots.https
           server-username: NEXUS_USER
           server-password: NEXUS_PW
@@ -36,6 +42,11 @@ jobs:
         env:
           NEXUS_USER: ${{ secrets.NEXUS_USER }}
           NEXUS_PW: ${{ secrets.NEXUS_PW }}
+      # Keep only third-party dependencies in the post-job Maven cache: Unomi's own
+      # snapshots are rebuilt every run and would only bloat the cache / risk staleness
+      - name: Clean Unomi artifacts from Maven cache
+        if: always()
+        run: rm -rf ~/.m2/repository/org/apache/unomi
 
   publish-docker-image:
     name: Push Docker image snapshot
@@ -45,10 +56,13 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          distribution: temurin
-          java-version: 17
-          server-id: apache.snapshots.https
-          server-username: NEXUS_USER
-          server-password: NEXUS_PW
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
       - name: Building & pushing Docker snapshot image
         run: mvn -ntp clean install -P docker; pushd docker; mvn -Ddocker.username=${{ secrets.DOCKERHUB_USER }} -Ddocker.password=${{ secrets.DOCKERHUB_TOKEN }} docker:push; popd
+      # Keep only third-party dependencies in the post-job Maven cache: Unomi's own
+      # snapshots are rebuilt every run and would only bloat the cache / risk staleness
+      - name: Clean Unomi artifacts from Maven cache
+        if: always()
+        run: rm -rf ~/.m2/repository/org/apache/unomi

--- a/.github/workflows/unomi-ci-docs-deploy.yml
+++ b/.github/workflows/unomi-ci-docs-deploy.yml
@@ -17,8 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: temurin
           java-version: 17
           server-id: apache.snapshots.https
           server-username: NEXUS_USER
@@ -42,8 +43,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: temurin
           java-version: 17
           server-id: apache.snapshots.https
           server-username: NEXUS_USER

--- a/.github/workflows/unomi-ci-docs.yml
+++ b/.github/workflows/unomi-ci-docs.yml
@@ -9,6 +9,11 @@ on:
       - 'manual/**'
       - '.github/workflows/unomi-ci-docs.yml'
 
+# Cancel superseded runs on the same PR, but never cancel master runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-docs:
     name: Build Documentation
@@ -33,7 +38,13 @@ jobs:
         run: |
           cd manual
           mvn -U -ntp clean install
-      
+
+      # Keep only third-party dependencies in the post-job Maven cache: Unomi's own
+      # snapshots are rebuilt every run and would only bloat the cache / risk staleness
+      - name: Clean Unomi artifacts from Maven cache
+        if: always()
+        run: rm -rf ~/.m2/repository/org/apache/unomi
+
       - name: Archive documentation
         uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
## Summary
- Bump `actions/setup-java` from `@v1` to `@v5` in `unomi-ci-docs-deploy.yml` (both jobs) and `codeql-analysis-java.yml`
- Add explicit `distribution: temurin` (required by modern setup-java) while keeping JDK 17 and existing Nexus credential wiring
- Speed up and harden all five CI workflows:
  - Add `cache: maven` to the CodeQL Java build and both docs-deploy jobs (the other workflows already had it)
  - Add a final "Clean Unomi artifacts from Maven cache" step to **every** cached job, so the post-job cache save keeps only third-party dependencies — Unomi's own snapshots (including the large kar/Karaf distribution) are rebuilt each run and would only bloat the cache and risk staleness
  - Add `concurrency` groups everywhere: superseded PR runs are cancelled (`cancel-in-progress` only when `github.event_name == 'pull_request'`), master pushes and scheduled CodeQL runs are never cancelled, and the docs-deploy workflow serializes runs without cancelling so a snapshot publish is never killed mid-upload
- Remove dead Nexus `server-id`/`server-username`/`server-password` config from the `publish-docker-image` job (it only pushes to Docker Hub and never had the NEXUS env vars wired)
- Quote `distribution`/`java-version` values consistently with the workflows upgraded in [#795](https://github.com/apache/unomi/pull/795)

Closes the remaining Node 24–compatible Actions gap after [#795](https://github.com/apache/unomi/pull/795).

JIRA: [UNOMI-966](https://issues.apache.org/jira/browse/UNOMI-966)

## Test plan
- [x] Confirm no remaining `actions/setup-java@v1` under `.github/workflows/`
- [ ] CodeQL Java workflow runs on the PR (or a follow-up push to master after merge)
- [ ] PR runs show superseded runs being cancelled when a new commit is pushed
- [ ] After merge to `master`, docs-deploy job still publishes with JDK 17 / Nexus credentials unchanged aside from the action major, and the saved Maven cache contains only third-party dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)