### PR TITLE
[UNOMI-973] - Follow-ups from the review of the file endpoint containment PR

### DIFF
--- a/extensions/router/router-api/src/main/java/org/apache/unomi/router/api/EndpointValidator.java
+++ b/extensions/router/router-api/src/main/java/org/apache/unomi/router/api/EndpointValidator.java
@@ -93,6 +93,10 @@ public final class EndpointValidator {
     /** Stands in for a token that expands to a name: one path component, never a parent segment. */
     private static final String NAME_PLACEHOLDER = "_";
 
+    /** The path segments the walk interprets rather than resolves against the file system. */
+    private static final String CURRENT_DIRECTORY = ".";
+    private static final String PARENT_DIRECTORY = "..";
+
     private EndpointValidator() {
     }
 
@@ -189,29 +193,59 @@ public final class EndpointValidator {
     }
 
     /**
-     * Resolves a path to the one the file system would actually use: made absolute, stripped of its
-     * parent segments, and with the symbolic links of its existing part followed. A path that does not
-     * exist yet is canonicalized through its deepest existing ancestor — an export destination is
-     * created on first write, and must be decided on before it exists.
+     * Resolves a path to the one the file system would actually use, walking it one component at a
+     * time from the root the way the file system does: a symbolic link is expanded where it stands,
+     * and a parent segment is applied to what the walk has resolved so far.
+     *
+     * <p>The order is what makes this correct. Collapsing parent segments first — {@code normalize()}
+     * on the whole path — erases the component they cancel, symbolic link included, so
+     * {@code /base/link/..} reads as {@code /base} while the file system resolves it to the parent of
+     * the link's target. Only a walk sees the link before the segment that cancels it.
+     *
+     * <p>A path that does not exist yet is resolved as far as it exists and kept as it stands from
+     * there — an export destination is created on first write, and must be decided on before it
+     * exists.
      *
      * <p>A path whose existing part cannot be resolved is refused rather than accepted as it stands: a
      * dangling symbolic link inside a permitted directory would otherwise be taken for a child of it,
      * and would leave it as soon as its target is created.
      */
     private static Path canonicalize(Path path) throws Refusal {
-        Path normalized = path.toAbsolutePath().normalize();
-        Path existing = normalized;
-        while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
-            existing = existing.getParent();
+        Path absolute = path.toAbsolutePath();
+        Path resolved = absolute.getRoot();
+        if (resolved == null) {
+            // an absolute path always has a root; without one there is nothing to decide on
+            throw new Refusal("path '" + path + "' cannot be made absolute");
         }
-        if (existing == null) {
-            return normalized;
+        // once a component is missing, nothing below it can exist: the rest is kept as written
+        boolean belowWhatExists = false;
+        for (Path component : absolute) {
+            String name = component.toString();
+            if (CURRENT_DIRECTORY.equals(name)) {
+                continue;
+            }
+            if (PARENT_DIRECTORY.equals(name)) {
+                Path parent = resolved.getParent();
+                if (parent != null) {
+                    resolved = parent;
+                }
+                continue;
+            }
+            Path candidate = resolved.resolve(component);
+            if (belowWhatExists || !Files.exists(candidate, LinkOption.NOFOLLOW_LINKS)) {
+                belowWhatExists = true;
+                resolved = candidate;
+            } else if (Files.isSymbolicLink(candidate)) {
+                try {
+                    resolved = candidate.toRealPath();
+                } catch (IOException e) {
+                    throw new Refusal("path '" + candidate + "' cannot be resolved on the file system: " + e);
+                }
+            } else {
+                resolved = candidate;
+            }
         }
-        try {
-            return existing.toRealPath().resolve(existing.relativize(normalized));
-        } catch (IOException e) {
-            throw new Refusal("path '" + normalized + "' cannot be resolved on the file system: " + e);
-        }
+        return resolved;
     }
 
     /**

--- a/extensions/router/router-api/src/main/java/org/apache/unomi/router/api/EndpointValidator.java
+++ b/extensions/router/router-api/src/main/java/org/apache/unomi/router/api/EndpointValidator.java
@@ -55,7 +55,10 @@ import java.util.Set;
  * are both refusals: nothing is thrown out of this class, because one malformed endpoint must not
  * cost a deployment the routes of every other configuration.
  *
- * <p>Schemes other than {@code file} carry no local path and are left to the scheme allow-list.
+ * <p>A scheme other than {@code file} addresses a remote server, so its directory and its
+ * path-bearing options are remote and none of this applies to them — with one exception.
+ * {@code localWorkDirectory} names a <em>local</em> directory, which the remote components stage
+ * their downloads in, so it is confined whatever the scheme.
  */
 public final class EndpointValidator {
 
@@ -89,6 +92,17 @@ public final class EndpointValidator {
 
     /** Expands to the directory the file sits in, which is the endpoint directory or one below it. */
     private static final String PARENT_TOKEN = "file:parent";
+
+    /**
+     * The one option that names a local directory whatever the scheme: the remote components write the
+     * content they download into files there, under the name the remote server announces.
+     *
+     * <p>It is kept out of {@link #PATH_BEARING_OPTIONS} because it is not resolved the same way. Those
+     * options are resolved against the directory the endpoint names; this one Camel resolves on its
+     * own — {@code new File(FileUtil.normalizePath(value))} — so it is held to the permitted
+     * directories directly, and it carries no File Language expression to account for.
+     */
+    private static final String LOCAL_WORK_DIRECTORY_OPTION = "localworkdirectory";
 
     /** Stands in for a token that expands to a name: one path component, never a parent segment. */
     private static final String NAME_PLACEHOLDER = "_";
@@ -124,11 +138,11 @@ public final class EndpointValidator {
             return "endpoint scheme '" + scheme + "' is not allowed";
         }
 
-        if (!FILE_SCHEME.equalsIgnoreCase(scheme)) {
-            return null;
-        }
-
         try {
+            String refusal = validateLocalWorkDirectory(endpointUri, permittedBaseDirs);
+            if (refusal != null || !FILE_SCHEME.equalsIgnoreCase(scheme)) {
+                return refusal;
+            }
             return validateContainment(endpointUri, permittedBaseDirs);
         } catch (Refusal refusal) {
             return refusal.getMessage();
@@ -138,14 +152,45 @@ public final class EndpointValidator {
         }
     }
 
-    private static String validateContainment(String endpointUri, String permittedBaseDirs) throws Refusal {
+    /**
+     * Confines {@code localWorkDirectory}, the local directory a remote endpoint may be told to stage
+     * its downloads in. Left alone, it is a write outside the permitted directories that the scheme
+     * allow-list never sees: {@code ftp://host/x?localWorkDirectory=/opt/unomi/deploy} stages what the
+     * remote server sends, under the name the remote server chooses.
+     */
+    private static String validateLocalWorkDirectory(String endpointUri, String permittedBaseDirs) throws Refusal {
+        int querySeparator = endpointUri.indexOf('?');
+        if (querySeparator < 0) {
+            return null;
+        }
+        for (String[] parameter : parseQuery(endpointUri.substring(querySeparator + 1))) {
+            if (!LOCAL_WORK_DIRECTORY_OPTION.equals(decode(parameter[0]).toLowerCase(Locale.ROOT))) {
+                continue;
+            }
+            String value = stripRaw(decode(parameter[1]));
+            if (value.isEmpty()) {
+                continue;
+            }
+            if (!isContained(Paths.get(value), baseDirectories(permittedBaseDirs))) {
+                return "option '" + parameter[0] + "' points outside the permitted directories";
+            }
+        }
+        return null;
+    }
+
+    private static List<Path> baseDirectories(String permittedBaseDirs) throws Refusal {
         List<Path> baseDirs = new ArrayList<>();
         for (String baseDir : split(permittedBaseDirs)) {
             baseDirs.add(canonicalize(Paths.get(baseDir)));
         }
         if (baseDirs.isEmpty()) {
-            return "no permitted base directory is configured for file endpoints";
+            throw new Refusal("no permitted base directory is configured for file endpoints");
         }
+        return baseDirs;
+    }
+
+    private static String validateContainment(String endpointUri, String permittedBaseDirs) throws Refusal {
+        List<Path> baseDirs = baseDirectories(permittedBaseDirs);
 
         int querySeparator = endpointUri.indexOf('?');
         String head = querySeparator < 0 ? endpointUri : endpointUri.substring(0, querySeparator);

--- a/extensions/router/router-core/src/main/java/org/apache/unomi/router/core/route/ProfileImportFromSourceRouteBuilder.java
+++ b/extensions/router/router-core/src/main/java/org/apache/unomi/router/core/route/ProfileImportFromSourceRouteBuilder.java
@@ -94,7 +94,9 @@ public class ProfileImportFromSourceRouteBuilder extends RouterAbstractRouteBuil
 
                 String endpoint = (String) importConfiguration.getProperties().get("source");
                 if (StringUtils.isNotBlank(endpoint)) {
-                    endpoint += "&moveFailed=.error";
+                    // the separator depends on whether the source already carries a query: appending
+                    // '&' to a source that has none makes the option part of the directory name
+                    endpoint += (endpoint.indexOf('?') < 0 ? "?" : "&") + "moveFailed=.error";
                 }
 
                 String refusal = EndpointValidator.validate(endpoint, allowedEndpoints, permittedBaseDirs);

--- a/extensions/router/router-core/src/main/java/org/apache/unomi/router/core/route/RouterAbstractRouteBuilder.java
+++ b/extensions/router/router-core/src/main/java/org/apache/unomi/router/core/route/RouterAbstractRouteBuilder.java
@@ -26,6 +26,8 @@ import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.router.api.ImportExportConfiguration;
 import org.apache.unomi.router.api.RouterConstants;
 import org.apache.unomi.router.api.services.ImportExportConfigurationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -33,6 +35,8 @@ import java.util.Map;
  * Created by amidani on 13/06/2017.
  */
 public abstract class RouterAbstractRouteBuilder extends RouteBuilder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RouterAbstractRouteBuilder.class);
 
     protected JacksonDataFormat jacksonDataFormat;
 
@@ -87,10 +91,28 @@ public abstract class RouterAbstractRouteBuilder extends RouteBuilder {
             T configuration, ImportExportConfigurationService<T> service, String refusal) {
         if (refusal != null) {
             configuration.setStatus(RouterConstants.CONFIG_STATUS_INVALID_ENDPOINT);
-            service.save(configuration, false);
+            saveQuietly(configuration, service);
         } else if (RouterConstants.CONFIG_STATUS_INVALID_ENDPOINT.equals(configuration.getStatus())) {
             configuration.setStatus(null);
+            saveQuietly(configuration, service);
+        }
+    }
+
+    /**
+     * Saves the mark, and keeps a failure to itself.
+     *
+     * <p>This runs inside {@code configure()}, which builds the routes of every configuration of the
+     * batch. An exception thrown here would leave {@code addRoutes} and cost all of them their routes
+     * — the very failure this validation exists to prevent, over the report of a refusal rather than
+     * the refusal itself. The store may be unreachable at start-up; the mark is worth what it costs,
+     * and no more.
+     */
+    private <T extends ImportExportConfiguration> void saveQuietly(T configuration, ImportExportConfigurationService<T> service) {
+        try {
             service.save(configuration, false);
+        } catch (RuntimeException e) {
+            LOGGER.error("Could not record the endpoint outcome on configuration {}; its route is built "
+                    + "or skipped as decided, only the record of it is missing", configuration.getItemId(), e);
         }
     }
 

--- a/extensions/router/router-core/src/test/java/org/apache/unomi/router/core/route/FileEndpointContainmentTest.java
+++ b/extensions/router/router-core/src/test/java/org/apache/unomi/router/core/route/FileEndpointContainmentTest.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -166,12 +167,87 @@ public class FileEndpointContainmentTest {
     }
 
     @Test
+    public void moveFailedIsAppendedAsTheFirstOptionOfASourceThatCarriesNone() throws Exception {
+        addImportRoutes(recurrentImport("first-option", fileUri(permittedImportDir, "")));
+
+        assertEquals("the option must open the query, or it becomes part of the directory name",
+                fileUri(permittedImportDir, "?moveFailed=.error"), builtEndpointUri("first-option"));
+    }
+
+    @Test
+    public void moveFailedIsAppendedToASourceThatAlreadyCarriesAQuery() throws Exception {
+        addImportRoutes(recurrentImport("next-option", fileUri(permittedImportDir, "?fileName=profiles.csv")));
+
+        assertEquals("an existing query takes the option as another parameter",
+                fileUri(permittedImportDir, "?fileName=profiles.csv&moveFailed=.error"),
+                builtEndpointUri("next-option"));
+    }
+
+    @Test
     public void importRouteIsBuiltWhenSourceCarriesNoOption() throws Exception {
         // the router appends moveFailed itself; a source with no query has no separator to append to,
         // and the option would otherwise become part of the directory the endpoint names
         addImportRoutes(recurrentImport("no-option", fileUri(permittedImportDir, "")));
 
         assertRouteBuilt("no-option", "a source may name a directory and nothing else");
+    }
+
+    @Test
+    public void importRouteIsBuiltWhenSourceIsASymlinkPointingInsidePermittedBaseDir() throws Exception {
+        File target = new File(permittedImportDir, "incoming");
+        assertTrue("could not prepare the test fixture", target.mkdir());
+        File link = new File(permittedImportDir, "shortcut");
+        try {
+            Files.createSymbolicLink(link.toPath(), target.toPath());
+        } catch (IOException | UnsupportedOperationException e) {
+            Assume.assumeNoException("this file system does not support symbolic links", e);
+        }
+
+        addImportRoutes(recurrentImport("symlink-inside", fileUri(link, "?fileName=profiles.csv")));
+
+        assertRouteBuilt("symlink-inside", "resolving a link must not refuse one that stays inside the base directory");
+    }
+
+    @Test
+    public void importRouteIsBuiltWhenThePermittedBaseDirIsItselfASymlink() throws Exception {
+        File link = new File(tmp.getRoot(), "permitted-import-link");
+        try {
+            Files.createSymbolicLink(link.toPath(), permittedImportDir.toPath());
+        } catch (IOException | UnsupportedOperationException e) {
+            Assume.assumeNoException("this file system does not support symbolic links", e);
+        }
+
+        // the deployment names the link, the configuration names the directory it points at
+        addImportRoutesInto(link, recurrentImport("base-dir-link", fileUri(permittedImportDir, "?fileName=profiles.csv")));
+
+        assertRouteBuilt("base-dir-link",
+                "both sides are resolved, so naming the same directory by two paths is the same directory");
+    }
+
+    @Test
+    public void importRouteIsRefusedWhenAnOptionLeavesThroughASymlinkAndAParentSegment() throws Exception {
+        File outsideChild = new File(arbitraryDir, "child");
+        assertTrue("could not prepare the test fixture", outsideChild.mkdir());
+        File link = new File(permittedImportDir, "option-link");
+        try {
+            Files.createSymbolicLink(link.toPath(), outsideChild.toPath());
+        } catch (IOException | UnsupportedOperationException e) {
+            Assume.assumeNoException("this file system does not support symbolic links", e);
+        }
+
+        addImportRoutes(recurrentImport("option-symlink-parent",
+                fileUri(permittedImportDir, "?fileName=profiles.csv&move=option-link/..")));
+
+        assertRouteRefused("option-symlink-parent",
+                "a path-bearing option is resolved the same way the endpoint directory is");
+    }
+
+    @Test
+    public void importRouteIsRefusedWhenSourceClimbsAboveTheRoot() throws Exception {
+        addImportRoutes(recurrentImport("above-root", "file:///../../../../../../../../etc?fileName=profiles.csv"));
+
+        assertRouteRefused("above-root",
+                "more parent segments than the path has components is a refusal, not an exception");
     }
 
     @Test
@@ -495,6 +571,22 @@ public class FileEndpointContainmentTest {
     }
 
     @Test
+    public void exportRouteIsRefusedWhenDestinationStagesItsDownloadsOutsidePermittedBaseDir() throws Exception {
+        addExportRoutes(recurrentExport("remote-staging", "ftp://ftp.example.com/profiles"
+                + "?fileName=profiles.csv&localWorkDirectory=" + arbitraryDir.getAbsolutePath()));
+
+        assertRouteRefused("remote-staging", "the option names a local directory in either direction");
+    }
+
+    @Test
+    public void importRouteIsRefusedWhenTheStagingOptionIsSpeltInAnotherCase() throws Exception {
+        addImportRoutes(recurrentImport("staging-case", "ftp://ftp.example.com/profiles"
+                + "?fileName=profiles.csv&LOCALWORKDIRECTORY=" + arbitraryDir.getAbsolutePath()));
+
+        assertRouteRefused("staging-case", "the option is matched on its name, not on how it is spelt");
+    }
+
+    @Test
     public void malformedDestinationIsSkippedWithoutPreventingTheOtherRoutesFromBeingBuilt() throws Exception {
         addExportRoutes(
                 recurrentExport("blank", ""),
@@ -511,6 +603,12 @@ public class FileEndpointContainmentTest {
     private void assertRouteBuilt(String routeId, String why) {
         assertNotNull("no route was built for configuration '" + routeId + "', although " + why,
                 camelContext.getRouteDefinition(routeId));
+    }
+
+    /** The endpoint URI the route was actually built on, which is not the one that was configured. */
+    private String builtEndpointUri(String routeId) {
+        assertRouteBuilt(routeId, "there is no endpoint to look at otherwise");
+        return camelContext.getRouteDefinition(routeId).getInputs().get(0).getUri();
     }
 
     private void assertRouteRefused(String routeId, String why) {

--- a/extensions/router/router-core/src/test/java/org/apache/unomi/router/core/route/FileEndpointContainmentTest.java
+++ b/extensions/router/router-core/src/test/java/org/apache/unomi/router/core/route/FileEndpointContainmentTest.java
@@ -166,6 +166,15 @@ public class FileEndpointContainmentTest {
     }
 
     @Test
+    public void importRouteIsBuiltWhenSourceCarriesNoOption() throws Exception {
+        // the router appends moveFailed itself; a source with no query has no separator to append to,
+        // and the option would otherwise become part of the directory the endpoint names
+        addImportRoutes(recurrentImport("no-option", fileUri(permittedImportDir, "")));
+
+        assertRouteBuilt("no-option", "a source may name a directory and nothing else");
+    }
+
+    @Test
     public void importRouteIsRefusedWhenSourceIsOutsidePermittedBaseDir() throws Exception {
         addImportRoutes(recurrentImport("arbitrary-dir", fileUri(arbitraryDir, "?fileName=profiles.csv")));
 

--- a/extensions/router/router-core/src/test/java/org/apache/unomi/router/core/route/FileEndpointContainmentTest.java
+++ b/extensions/router/router-core/src/test/java/org/apache/unomi/router/core/route/FileEndpointContainmentTest.java
@@ -144,6 +144,25 @@ public class FileEndpointContainmentTest {
     }
 
     @Test
+    public void importRouteIsRefusedWhenSourceLeavesPermittedBaseDirThroughASymlinkAndAParentSegment() throws Exception {
+        File outsideChild = new File(arbitraryDir, "child");
+        assertTrue("could not prepare the test fixture", outsideChild.mkdir());
+        File link = new File(permittedImportDir, "link");
+        try {
+            Files.createSymbolicLink(link.toPath(), outsideChild.toPath());
+        } catch (IOException | UnsupportedOperationException e) {
+            Assume.assumeNoException("this file system does not support symbolic links", e);
+        }
+
+        // the file system expands the link, then applies the parent segment to its target: the source
+        // is the arbitrary directory. Collapsing the segment first would read it as the base directory.
+        addImportRoutes(recurrentImport("symlink-parent", fileUri(new File(link, ".."), "?fileName=profiles.csv")));
+
+        assertRouteRefused("symlink-parent",
+                "a parent segment applies to the target of the link that precedes it, not to the link's own parent");
+    }
+
+    @Test
     public void importRouteIsRefusedWhenSourceIsOutsidePermittedBaseDir() throws Exception {
         addImportRoutes(recurrentImport("arbitrary-dir", fileUri(arbitraryDir, "?fileName=profiles.csv")));
 

--- a/extensions/router/router-core/src/test/java/org/apache/unomi/router/core/route/FileEndpointContainmentTest.java
+++ b/extensions/router/router-core/src/test/java/org/apache/unomi/router/core/route/FileEndpointContainmentTest.java
@@ -63,8 +63,11 @@ import static org.junit.Assert.assertTrue;
  * <p>Selection options ({@code include}, {@code antInclude}) are patterns matched against the files
  * the directory already offers, not paths Camel resolves, and are not held to containment.
  *
- * <p>Remote schemes ({@code ftp}, {@code sftp}, {@code ftps}) carry no local path and are not
- * subject to directory containment; the scheme allow-list keeps governing them.
+ * <p>Remote schemes ({@code ftp}, {@code sftp}, {@code ftps}) address a remote server, so their
+ * directory and their path-bearing options are remote and are not subject to directory containment;
+ * the scheme allow-list keeps governing them. {@code localWorkDirectory} is the exception: it names a
+ * local directory, which the remote components stage their downloads in, and it is confined whatever
+ * the scheme.
  *
  * <p>These tests exercise route <em>construction</em>, which is where a configuration is turned into
  * a live route: a configuration whose endpoint is refused must leave no route behind, whether it
@@ -349,6 +352,37 @@ public class FileEndpointContainmentTest {
         addImportRoutes(recurrentImport("remote", "ftp://ftp.example.com/profiles?fileName=profiles.csv"));
 
         assertRouteBuilt("remote", "ftp is an allowed scheme and carries no local path");
+    }
+
+    @Test
+    public void importRouteIsRefusedWhenARemoteSourceStagesItsDownloadsOutsidePermittedBaseDir() throws Exception {
+        addImportRoutes(recurrentImport("remote-staging", "ftp://ftp.example.com/profiles"
+                + "?fileName=profiles.csv&localWorkDirectory=" + arbitraryDir.getAbsolutePath()));
+
+        assertRouteRefused("remote-staging",
+                "localWorkDirectory is a local directory: the remote server's content is written there, "
+                        + "under the name the remote server chooses");
+    }
+
+    @Test
+    public void importRouteIsBuiltWhenARemoteSourceStagesItsDownloadsInsidePermittedBaseDir() throws Exception {
+        addImportRoutes(recurrentImport("remote-staging-in-bounds", "ftp://ftp.example.com/profiles"
+                + "?fileName=profiles.csv&localWorkDirectory="
+                + new File(permittedImportDir, "staging").getAbsolutePath()));
+
+        assertRouteBuilt("remote-staging-in-bounds",
+                "staging downloads inside the permitted base directory is legitimate, and the directory "
+                        + "need not exist yet");
+    }
+
+    @Test
+    public void importRouteIsRefusedWhenSourceStagesItsDownloadsOutsidePermittedBaseDir() throws Exception {
+        addImportRoutes(recurrentImport("local-staging", fileUri(permittedImportDir,
+                "?fileName=profiles.csv&localWorkDirectory=" + arbitraryDir.getAbsolutePath())));
+
+        assertRouteRefused("local-staging",
+                "the option is resolved on its own, not against the endpoint directory, so a permitted "
+                        + "directory does not cover it");
     }
 
     @Test

--- a/extensions/router/router-core/src/test/java/org/apache/unomi/router/core/route/RefusedConfigurationStatusTest.java
+++ b/extensions/router/router-core/src/test/java/org/apache/unomi/router/core/route/RefusedConfigurationStatusTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -115,6 +116,18 @@ public class RefusedConfigurationStatusTest {
                 RouterConstants.CONFIG_STATUS_INVALID_ENDPOINT, configuration.getStatus());
         assertTrue("the configuration should have been saved so the failure is visible",
                 exportConfigurations.contains("out-of-bounds"));
+    }
+
+    @Test
+    public void aStoreThatCannotRecordTheRefusalDoesNotCostTheBatchItsOtherRoutes() throws Exception {
+        importConfigurations.unwritable = true;
+
+        addImportRoutes(recurrentImport(fileUri(arbitraryDir, "?fileName=profiles.csv")),
+                inBoundsImport("in-bounds"));
+
+        assertNull("the refused configuration still gets no route", camelContext.getRouteDefinition("out-of-bounds"));
+        assertNotNull("failing to record the refusal must not cost the other configurations their routes",
+                camelContext.getRouteDefinition("in-bounds"));
     }
 
     @Test
@@ -200,6 +213,12 @@ public class RefusedConfigurationStatusTest {
         return "file://" + directory.getAbsolutePath() + suffix;
     }
 
+    private ImportConfiguration inBoundsImport(String itemId) {
+        ImportConfiguration configuration = recurrentImport(fileUri(permittedImportDir, "?fileName=profiles.csv"));
+        configuration.setItemId(itemId);
+        return configuration;
+    }
+
     private ImportConfiguration recurrentImport(String source) {
         ImportConfiguration configuration = new ImportConfiguration();
         configuration.setItemId("out-of-bounds");
@@ -265,6 +284,9 @@ public class RefusedConfigurationStatusTest {
 
         private boolean lastSaveAskedForARouteRefresh;
 
+        /** Stands in for a store that cannot be written to -- Elasticsearch unreachable at start-up. */
+        private boolean unwritable;
+
         boolean contains(String configId) {
             return stored.containsKey(configId);
         }
@@ -281,6 +303,9 @@ public class RefusedConfigurationStatusTest {
 
         @Override
         public T save(T configuration, boolean updateRunningRoute) {
+            if (unwritable) {
+                throw new IllegalStateException("the store is unreachable");
+            }
             lastSaveAskedForARouteRefresh = updateRunningRoute;
             stored.put(itemIdOf(configuration), configuration);
             return configuration;

--- a/extensions/router/router-rest/src/main/java/org/apache/unomi/router/rest/AbstractConfigurationServiceEndpoint.java
+++ b/extensions/router/router-rest/src/main/java/org/apache/unomi/router/rest/AbstractConfigurationServiceEndpoint.java
@@ -44,13 +44,28 @@ public abstract class AbstractConfigurationServiceEndpoint<T> {
      * but a log line to show for it. Refusing here gives the caller the reason while it can still act
      * on it, and keeps the configuration out of the store.
      *
+     * <p>Answers {@code 503} instead while the router has yet to publish its settings, since a
+     * configuration cannot be judged against settings that are not there yet.
+     *
      * @param endpointUri              the endpoint URI the configuration names
      * @param permittedBaseDirsProperty the shared property holding the base directories for this direction
      */
     protected void refuseIfEndpointCannotBeHonoured(String endpointUri, String permittedBaseDirsProperty) {
-        String refusal = EndpointValidator.validate(endpointUri,
-                (String) configSharingService.getProperty(RouterConstants.CONFIG_ALLOWED_ENDPOINTS),
-                (String) configSharingService.getProperty(permittedBaseDirsProperty));
+        String allowedSchemes = (String) configSharingService.getProperty(RouterConstants.CONFIG_ALLOWED_ENDPOINTS);
+        String permittedBaseDirs = (String) configSharingService.getProperty(permittedBaseDirsProperty);
+        if (allowedSchemes == null || permittedBaseDirs == null) {
+            // The router's Camel context publishes both on start-up, and this endpoint answers before
+            // it has. An absent setting is not an empty allow-list: reading it as one would refuse a
+            // legitimate configuration, and blame its scheme for it. Say the truth instead -- there is
+            // nothing to validate against yet -- so the caller can retry rather than correct a
+            // configuration that is already right.
+            String unavailable = "the router is still starting up: no endpoint can be validated yet";
+            throw new ServiceUnavailableException(unavailable,
+                    Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                            .type(MediaType.TEXT_PLAIN).entity(unavailable).build());
+        }
+
+        String refusal = EndpointValidator.validate(endpointUri, allowedSchemes, permittedBaseDirs);
         if (refusal != null) {
             throw new BadRequestException(refusal, Response.status(Response.Status.BAD_REQUEST)
                     .type(MediaType.TEXT_PLAIN).entity(refusal).build());

--- a/extensions/router/router-rest/src/test/java/org/apache/unomi/router/rest/ConfigurationEndpointValidationTest.java
+++ b/extensions/router/router-rest/src/test/java/org/apache/unomi/router/rest/ConfigurationEndpointValidationTest.java
@@ -114,6 +114,42 @@ public class ConfigurationEndpointValidationTest {
     }
 
     @Test
+    public void savingARecurrentImportWhoseRemoteSourceStagesDownloadsOutsideThePermittedBaseDirsIsRefused() {
+        // ftp is an allowed scheme, but localWorkDirectory names a local directory all the same
+        ImportConfiguration configuration = recurrentImport("ftp://ftp.example.com/profiles"
+                + "?fileName=profiles.csv&localWorkDirectory=" + arbitraryDir.getAbsolutePath());
+
+        assertRefused(() -> importEndpoint.saveConfiguration(configuration));
+        assertFalse("a refused configuration must not be stored", importConfigurations.contains("in-bounds"));
+    }
+
+    @Test
+    public void savingARecurrentImportBeforeThePermittedDirectoriesArePublishedIsNotRefused() throws Exception {
+        // the scheme allow-list is there, the directories are not: still nothing to judge against
+        InMemoryConfigSharingService partial = new InMemoryConfigSharingService();
+        partial.setProperty(RouterConstants.CONFIG_ALLOWED_ENDPOINTS, "file,ftp,sftp,ftps");
+        ImportConfigurationServiceEndPoint starting = new ImportConfigurationServiceEndPoint();
+        starting.setImportConfigurationService(importConfigurations);
+        starting.setConfigSharingService(partial);
+
+        ImportConfiguration configuration = recurrentImport(fileUri(permittedImportDir, "?fileName=profiles.csv"));
+
+        assertUnavailable(() -> starting.saveConfiguration(configuration));
+    }
+
+    @Test
+    public void savingARecurrentExportBeforeTheRouterPublishedItsSettingsIsNotRefused() throws Exception {
+        ExportConfigurationServiceEndPoint starting = new ExportConfigurationServiceEndPoint();
+        starting.setExportConfigurationService(exportConfigurations);
+        starting.setConfigSharingService(new InMemoryConfigSharingService());
+
+        ExportConfiguration configuration = recurrentExport(fileUri(permittedExportDir, "?fileName=profiles.csv"));
+
+        assertUnavailable(() -> starting.saveConfiguration(configuration));
+        assertFalse("nothing is stored while the endpoint cannot be judged", exportConfigurations.contains("in-bounds"));
+    }
+
+    @Test
     public void savingARecurrentImportWhoseSourceIsOutsideThePermittedBaseDirsIsRefused() {
         ImportConfiguration configuration = recurrentImport(fileUri(arbitraryDir, "?fileName=profiles.csv"));
 

--- a/extensions/router/router-rest/src/test/java/org/apache/unomi/router/rest/ConfigurationEndpointValidationTest.java
+++ b/extensions/router/router-rest/src/test/java/org/apache/unomi/router/rest/ConfigurationEndpointValidationTest.java
@@ -101,6 +101,19 @@ public class ConfigurationEndpointValidationTest {
     }
 
     @Test
+    public void savingARecurrentImportBeforeTheRouterPublishedItsSettingsIsNotRefused() throws Exception {
+        // the router's Camel context has not started yet, so it has published nothing
+        ImportConfigurationServiceEndPoint starting = new ImportConfigurationServiceEndPoint();
+        starting.setImportConfigurationService(importConfigurations);
+        starting.setConfigSharingService(new InMemoryConfigSharingService());
+
+        ImportConfiguration configuration = recurrentImport(fileUri(permittedImportDir, "?fileName=profiles.csv"));
+
+        assertUnavailable(() -> starting.saveConfiguration(configuration));
+        assertFalse("nothing is stored while the endpoint cannot be judged", importConfigurations.contains("in-bounds"));
+    }
+
+    @Test
     public void savingARecurrentImportWhoseSourceIsOutsideThePermittedBaseDirsIsRefused() {
         ImportConfiguration configuration = recurrentImport(fileUri(arbitraryDir, "?fileName=profiles.csv"));
 
@@ -162,6 +175,16 @@ public class ConfigurationEndpointValidationTest {
      * A refused configuration answers {@code 400 Bad Request}, and says why: the caller has to be able
      * to correct the endpoint from the answer alone.
      */
+    private void assertUnavailable(Runnable save) {
+        try {
+            save.run();
+            fail("saving the configuration should not have been answered yet");
+        } catch (WebApplicationException e) {
+            assertEquals("settings that are not published yet make the service unavailable, not the "
+                    + "configuration wrong", 503, e.getResponse().getStatus());
+        }
+    }
+
     private void assertRefused(Runnable save) {
         try {
             save.run();

--- a/itests/src/test/java/org/apache/unomi/itests/BaseIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/BaseIT.java
@@ -257,6 +257,14 @@ public abstract class BaseIT extends KarafTestSupport {
                 editConfigurationFilePut("etc/custom.system.properties", "org.apache.unomi.elasticsearch.taskWaitingPollingInterval", "50"),
                 editConfigurationFilePut("etc/custom.system.properties", "org.apache.unomi.elasticsearch.rollover.maxDocs", "300"),
 
+                // The router's base directories have to be set here rather than in
+                // etc/org.apache.unomi.router.cfg: Karaf's configuration plugin overrides every
+                // configuration property whose <pid>.<key> exists as a system property, and
+                // custom.system.properties declares both of these, so a value written to the cfg
+                // never reaches the router.
+                editConfigurationFilePut("etc/custom.system.properties", "org.apache.unomi.router.config.import.baseDir", "${karaf.data}/tmp/recurrent_import"),
+                editConfigurationFilePut("etc/custom.system.properties", "org.apache.unomi.router.config.export.baseDir", "${karaf.data}/tmp/recurrent_export"),
+
                 systemProperty("org.ops4j.pax.exam.rbc.rmi.port").value("1199"),
                 systemProperty("org.apache.unomi.healthcheck.enabled").value("true"),
 

--- a/itests/src/test/java/org/apache/unomi/itests/ProfileImportExportContainmentIT.java
+++ b/itests/src/test/java/org/apache/unomi/itests/ProfileImportExportContainmentIT.java
@@ -41,7 +41,7 @@ import java.util.Map;
 /**
  * A recurrent import or export configuration using the {@code file} scheme must resolve inside the base
  * directory the deployment permits — {@code config.import.baseDir} and {@code config.export.baseDir},
- * set for these tests in {@code org.apache.unomi.router.cfg}.
+ * set for these tests in {@code etc/custom.system.properties} by {@link BaseIT}.
  *
  * <p>The unit tests decide the containment rules. What only a running Unomi can show is that the
  * settings actually reach the two places that need them: the REST layer, which refuses a configuration
@@ -55,7 +55,7 @@ public class ProfileImportExportContainmentIT extends BaseIT {
     private static final String IMPORT_CONFIGURATION_URL = "/cxs/importConfiguration";
     private static final String EXPORT_CONFIGURATION_URL = "/cxs/exportConfiguration";
 
-    /** Permitted by org.apache.unomi.router.cfg. */
+    /** Permitted by the base directories BaseIT declares. */
     private static final String PERMITTED_IMPORT_DIR = "data/tmp/recurrent_import";
     private static final String PERMITTED_EXPORT_DIR = "data/tmp/recurrent_export";
 

--- a/itests/src/test/resources/org.apache.unomi.router.cfg
+++ b/itests/src/test/resources/org.apache.unomi.router.cfg
@@ -42,6 +42,9 @@ executions.error.report.size=200
 #Allowed source endpoints
 config.allowedEndpoints=file,ftp,sftp,ftps
 
-#Base directories a file endpoint may resolve into
+#Base directories a file endpoint may resolve into. The values that reach the router are the ones
+#BaseIT writes to etc/custom.system.properties: Karaf's configuration plugin overrides a property
+#whose <pid>.<key> is a system property, and both of these are. The keys are kept here because the
+#plugin only overrides keys the configuration already carries.
 config.import.baseDir=${karaf.data}/tmp/recurrent_import
 config.export.baseDir=${karaf.data}/tmp/recurrent_export

--- a/manual/src/main/asciidoc/profile-import-export.adoc
+++ b/manual/src/main/asciidoc/profile-import-export.adoc
@@ -230,10 +230,25 @@ To change this you have to change the default values of these properties.
     #errors report size
     org.apache.unomi.router.executions.error.report.size=200
 
-Final one is about the allowed endpoints you can use when building the source or destionation path, as mentioned above
+Next one is about the allowed endpoints you can use when building the source or destionation path, as mentioned above
 we can have a path of type `file`, `ftp`, `ftps`, `sftp`. You can make it less if you want to omit some endpoints (eg.
 you don't want to permit the use of non secure FTP).
 
     #Allowed source endpoints
     org.apache.unomi.router.config.allowedEndpoints=file,ftp,sftp,ftps
+
+Final ones say where a `file` endpoint may resolve. A recurrent import source or export destination using the `file`
+scheme is refused unless it resolves inside one of these base directories, at any depth, and so is any of its options
+that names a path (`fileName`, `move`, `moveFailed`, ...). The same applies to `localWorkDirectory`, whatever the
+scheme, since that one names a local directory even on a remote endpoint. Each property accepts a comma-separated
+list.
+
+    #Base directories a file endpoint may resolve into
+    org.apache.unomi.router.config.import.baseDir=${karaf.data}/router/import/
+    org.apache.unomi.router.config.export.baseDir=${karaf.data}/router/export/
+
+Import and export are kept apart on purpose: with a single shared directory, an export writing a `.csv` could be picked
+up by an import route polling the same place. Point both properties at the same directory only if that is what you
+mean. A configuration that resolves outside them builds no route and is marked `INVALID_ENDPOINT`; restoring the
+directories clears that mark on its own at the next rebuild.
 

--- a/package/src/main/resources/etc/custom.system.properties
+++ b/package/src/main/resources/etc/custom.system.properties
@@ -396,6 +396,13 @@ org.apache.unomi.router.executions.error.report.size=${env:UNOMI_ROUTER_EXECUTIO
 #Allowed source endpoints
 org.apache.unomi.router.config.allowedEndpoints=${env:UNOMI_ROUTER_CONFIG_ALLOWEDENDPOINTS:-file,ftp,sftp,ftps}
 
+#Base directories a file endpoint may resolve into, comma-separated. A recurrent import source or
+#export destination using the file scheme is refused unless it resolves inside one of them, at any
+#depth. Import and export are kept apart so that an export cannot write into a directory an import
+#route is polling; point them at the same directory only if that is what you mean.
+org.apache.unomi.router.config.import.baseDir=${env:UNOMI_ROUTER_CONFIG_IMPORT_BASEDIR:-${karaf.data}/router/import/}
+org.apache.unomi.router.config.export.baseDir=${env:UNOMI_ROUTER_CONFIG_EXPORT_BASEDIR:-${karaf.data}/router/export/}
+
 #######################################################################################################################
 ## Salesforce connector settings                                                                                     ##
 #######################################################################################################################


### PR DESCRIPTION
This targets `UNOMI-973-file-endpoint-containment` rather than `unomi-3.0.x`, so merging it folds these changes into [unomi#849](https://github.com/apache/unomi/pull/849) and leaves that PR as the single unit of review. Take what you agree with and drop the rest — each commit stands on its own.

They come out of a careful pass over the diff of [unomi#849](https://github.com/apache/unomi/pull/849). The design there holds up; what follows are the edges it leaves open, in decreasing order of how much they matter.

## What each commit changes

**Resolving a path one component at a time.** `canonicalize` normalized the whole path before following its symbolic links. Collapsing parent segments first erases the component they cancel, symbolic link included: `/base/link/..` read as `/base`, while the file system expands the link and applies the segment to its target, landing wherever that link points. A source written that way was accepted and its route was built. The path is now walked from the root: a link is expanded where it stands, and a parent segment applies to what the walk has resolved so far. What does not exist yet is kept as written, so an export destination is still decided on before it is created, and an existing part that cannot be resolved is still a refusal.

**Confining `localWorkDirectory` whatever the scheme.** A scheme other than `file` was answered valid without its options being looked at, on the grounds that a remote endpoint carries no local path. `localWorkDirectory` is the exception. The FTP and SFTP components stage the content they download into files there: `FtpOperations.retrieveFileToFileInLocalWorkDirectory` writes `new File(localWorkDirectory, <the name the remote server announces>)` and creates the directories on the way. So `ftp://host/x?localWorkDirectory=<karaf.home>/deploy` was accepted, and `ftp` is in the shipped allow-list. The option now answers to the permitted base directories whatever the scheme. It stays out of `PATH_BEARING_OPTIONS` because Camel resolves it on its own rather than against the directory the endpoint names, and it carries no File Language expression to account for.

**Appending `moveFailed` as an option rather than to the directory name.** The router appends its own `moveFailed` to the configured source with an unconditional `&`. A source that carries no query has no separator to append to, so the option became part of the directory the endpoint names: `file:///base` turned into `file:///base&moveFailed=.error`, a directory called `base&moveFailed=.error`. That was a malformed endpoint before this validation existed; with it, the two layers disagree — `saveConfiguration` validates the source as configured and answers 200, then the route builder validates the source with the option appended, refuses it and marks the configuration `INVALID_ENDPOINT`. Stored, answered 200, never run, which is what refusing at save time exists to prevent.

**A system property and a manual entry for the two new settings.** `org.apache.unomi.router.cfg` reads `config.import.baseDir` and `config.export.baseDir` from system properties, but neither was declared in `custom.system.properties`, so unlike every other router setting they had no env-var override. A deployment that has to relocate its import directory — which this change forces on anyone whose configurations resolve elsewhere — could only do it by editing `etc/org.apache.unomi.router.cfg` inside the image. The manual's list of router properties now names them too.

**Not reading a setting the router has not published yet as a refusal.** The REST endpoint validates against the settings the router's Camel context publishes on start-up, but it answers as soon as its own component is satisfied, which can be first. `getProperty` then returns `null`, an empty scheme allow-list follows from it, and a good configuration is answered `400 endpoint scheme 'file' is not allowed` — pointing its author at a scheme that was never the problem. An absent setting now answers 503 with what is actually the matter.

**Keeping a failure to record the refusal from costing the batch its routes.** `recordEndpointOutcome` writes to the store from inside `configure()`, which builds the routes of every configuration of the batch. With the store unreachable — Elasticsearch not up yet at start-up, say — the exception leaves `addRoutes` and every other configuration loses its route, silently. That is the failure mode this validation exists to remove, reached through the report of a refusal rather than the refusal itself. The write is now logged and swallowed; the route is built or skipped exactly as decided, and only the record of it can go missing.

## On the `localWorkDirectory` one, since the claim it contradicts is explicit

It was measured rather than argued. A harness — a minimal FTP server plus a Camel route built from the URI, no running Unomi — samples the target directory every 2 ms, because Camel deletes its local work file when the exchange completes (`GenericFileProcessStrategySupport.deleteLocalWorkFile`, called from `commit`, `rollback` and `abort`). Three runs, before the fix:

- nominal transfer with a trivial route: `evil.jar.inprogress` then `evil.jar` appear and are cleaned up within about 7 ms;
- the same with the exchange lasting 3 s, which is what a real CSV split and profile import costs: `evil.jar` — the attacker's name, the attacker's bytes — stands in the target directory from 501 ms to 3513 ms, the whole duration of the exchange, which the deploy watcher polls;
- the remote server dropping the data connection mid-transfer: `evil.jar.inprogress`, 100 012 bytes of remote content, **is still there when the route stops**. `deleteLocalWorkFile` removes the final path, never the `.inprogress` temp file.

So the deterministic part is a permanent write of remote content at an arbitrary absolute path, with a `.inprogress` suffix and therefore not directly deployable; the racy part is the exact chosen name standing for the duration of the exchange. Either way the invariant this PR establishes — that a recurrent import touches nothing outside the declared base directories — does not hold. Happy to attach the harness if it is useful.

## Tests

Each of the five behavioural commits carries a test that fails without it, checked by reverting the fix and watching exactly the expected tests go red. The seventh commit covers what those changes touched and nothing yet observed: a path-bearing option leaving through a link and a parent segment; a link that stays inside the base directory still building its route; a base directory that is itself a link still matching the directory it points at; more parent segments than a path has components being a refusal rather than an exception; the export direction and the REST layer for `localWorkDirectory`, and the option matched on its name rather than on how it is spelt; the endpoint URI the route is actually built on; and the export endpoint and a partly published configuration for the 503.

71 tests over `router-api`, `router-core` and `router-rest`, all green. No integration test was added — `ProfileImportExportContainmentIT` already covers the shape of this, and none of these changes alters what it asserts.

## Two things for you to decide

The 503 was a judgement call. Answering "not ready" rather than deferring validation is the conservative reading — nothing is stored, the caller retries — but deferring is defensible too, and it is your call.

The tests are in a seventh commit rather than folded into the six, because hunks from several of them share the same test files and splitting that cleanly is worth less than it costs. Say the word and I will rebase them into their commits.
